### PR TITLE
Add Continuous Integration workflow with automated tests for OpenSAK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds a GitHub Actions CI workflow to automatically run all tests in the tests/ folder using pytest on multiple Python versions 3.10 to 3.12 for retrocompatibility. It also ensures that dependencies are installed and the environment is correctly set up.

### Motivation:

OpenSAK is an open-source project that may evolve in different directions. As a new contributor, I noticed that:

- Running the app for the first time sometimes fails due to Python version issues or missing dependencies.
- Without CI, changes could introduce runtime errors that are hard to debug.

### This workflow helps:

- Catch errors early before merging PRs.
- Verify Python 3.10+ compatibility.
- Ensure required dependencies are installed.
- Provide a smoother experience for new contributors.
