### PR TITLE
Remove if-guards for delivered feature flags (where-filter, db-combo)

### DIFF
--- a/src/opensak/gui/dialogs/filter_dialog.py
+++ b/src/opensak/gui/dialogs/filter_dialog.py
@@ -26,7 +26,6 @@ from opensak.gui.icon import OpenSAKMessageBox as QMessageBox
 from PySide6.QtCore import QDate
 
 from opensak.lang import tr
-from opensak.utils import flags
 from opensak.filters.engine import (
     FilterSet, SortSpec,
     CacheTypeFilter, ContainerFilter,
@@ -260,16 +259,14 @@ class FilterDialog(QDialog):
 
         # ── Faneblade ─────────────────────────────────────────────────────────
         self._tabs = QTabWidget()
-        self._where_tab = None
         self._general_tab = self._build_general_tab()
         self._dates_tab = self._build_dates_tab()
         self._attributes_tab = self._build_attributes_tab()
+        self._where_tab = self._build_where_tab()
         self._tabs.addTab(self._general_tab, tr("settings_tab_general"))
         self._tabs.addTab(self._dates_tab, tr("filter_tab_dates"))
         self._tabs.addTab(self._attributes_tab, tr("filter_tab_attributes"))
-        if flags.where_filter:
-            self._where_tab = self._build_where_tab()
-            self._tabs.addTab(self._where_tab, tr("filter_tab_where"))
+        self._tabs.addTab(self._where_tab, tr("filter_tab_where"))
         layout.addWidget(self._tabs)
 
         # ── Knapper ───────────────────────────────────────────────────────────

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -160,9 +160,7 @@ class MainWindow(QMainWindow):
         self._restore_state()
         self._update_title()
         self._reload_home_combo()
-        from opensak.utils import flags
-        if flags.db_combo:
-            self._reload_db_combo()
+        self._reload_db_combo()
         # Load caches after UI is ready
         QTimer.singleShot(100, self._refresh_cache_list)
         # Tjek for opdateringer i baggrunden (5 sek forsinkelse — GUI er klar)
@@ -423,16 +421,14 @@ class MainWindow(QMainWindow):
         self._act_db_manager.setToolTip(tr("action_db_manager") + " (Ctrl+D)")
         tb.addAction(self._act_db_manager)
 
-        from opensak.utils import flags
-        if flags.db_combo:
-            self._db_combo = QComboBox()
-            self._db_combo.setMinimumWidth(140)
-            self._db_combo.setMaximumWidth(220)
-            self._db_combo.setToolTip(tr("toolbar_db_combo_tooltip"))
-            self._db_combo.currentIndexChanged.connect(self._on_db_combo_changed)
-            db_combo_action = QWidgetAction(self)
-            db_combo_action.setDefaultWidget(self._db_combo)
-            tb.addAction(db_combo_action)
+        self._db_combo = QComboBox()
+        self._db_combo.setMinimumWidth(140)
+        self._db_combo.setMaximumWidth(220)
+        self._db_combo.setToolTip(tr("toolbar_db_combo_tooltip"))
+        self._db_combo.currentIndexChanged.connect(self._on_db_combo_changed)
+        db_combo_action = QWidgetAction(self)
+        db_combo_action.setDefaultWidget(self._db_combo)
+        tb.addAction(db_combo_action)
 
         # Importer
         self._act_import.setText(tr("action_import"))
@@ -619,9 +615,7 @@ class MainWindow(QMainWindow):
     def _on_database_switched(self, db_info) -> None:
         """Kaldes når brugeren skifter aktiv database."""
         self._update_title()
-        from opensak.utils import flags
-        if flags.db_combo:
-            self._reload_db_combo()
+        self._reload_db_combo()
         self._detail_panel.clear()
         self._load_sort_for_active_db()
         self._refresh_cache_list()

--- a/tests/e2e-tests/test_e2e_db_combo.py
+++ b/tests/e2e-tests/test_e2e_db_combo.py
@@ -2,8 +2,7 @@
 tests/e2e-tests/test_e2e_db_combo.py — Database dropdown toolbar tests.
 
 Covers:
-- Combo is absent when flags.db_combo is False
-- Combo is present and populated when flags.db_combo is True
+- Combo is present and populated on startup
 - Active database is pre-selected in the combo
 - Selecting a different entry calls manager.switch_to and refreshes the combo
 - _on_database_switched (e.g. triggered by the dialog) also refreshes the combo
@@ -54,45 +53,14 @@ def _make_two_db_manager(db_path_a, db_path_b):
 
 
 @pytest.fixture
-def no_combo_window(qtbot, tmp_path, monkeypatch):
-    """MainWindow with flags.db_combo=False — combo widget must be absent."""
-    import opensak.db.manager as mgr_module
-    from opensak.db.database import init_db
-    from opensak.lang import load_language
-    from opensak.utils import flags
-    from tests.data import make_fake_manager
-
-    load_language("en")
-    monkeypatch.setattr(flags, "db_combo", False)
-
-    db_path = tmp_path / "no_combo.db"
-    init_db(db_path=db_path)
-    monkeypatch.setattr(mgr_module, "_manager", make_fake_manager(db_path))
-
-    from opensak.gui.mainwindow import MainWindow
-
-    window = MainWindow()
-    qtbot.addWidget(window)
-    window.show()
-    qtbot.waitExposed(window)
-    qtbot.wait(200)
-
-    yield window
-
-    mgr_module._manager = None
-
-
-@pytest.fixture
 def combo_window(qtbot, tmp_path, monkeypatch):
-    """MainWindow with flags.db_combo=True and a single-database manager."""
+    """MainWindow with a single-database manager."""
     import opensak.db.manager as mgr_module
     from opensak.db.database import init_db
     from opensak.lang import load_language
-    from opensak.utils import flags
     from tests.data import make_fake_manager
 
     load_language("en")
-    monkeypatch.setattr(flags, "db_combo", True)
 
     db_path = tmp_path / "combo.db"
     init_db(db_path=db_path)
@@ -113,14 +81,12 @@ def combo_window(qtbot, tmp_path, monkeypatch):
 
 @pytest.fixture
 def two_db_combo_window(qtbot, tmp_path, monkeypatch):
-    """MainWindow with flags.db_combo=True and a two-database manager."""
+    """MainWindow with a two-database manager."""
     import opensak.db.manager as mgr_module
     from opensak.db.database import init_db
     from opensak.lang import load_language
-    from opensak.utils import flags
 
     load_language("en")
-    monkeypatch.setattr(flags, "db_combo", True)
 
     db_path_a = tmp_path / "alpha.db"
     db_path_b = tmp_path / "beta.db"
@@ -142,19 +108,11 @@ def two_db_combo_window(qtbot, tmp_path, monkeypatch):
     mgr_module._manager = None
 
 
-# ── Flag off ───────────────────────────────────────────────────────────────────
+# ── Presence and population ───────────────────────────────────────────────────
 
 
-def test_db_combo_absent_when_flag_disabled(no_combo_window, qtbot):
-    """When flags.db_combo is False the toolbar combo is never created."""
-    assert not hasattr(no_combo_window, "_db_combo")
-
-
-# ── Flag on — presence and population ─────────────────────────────────────────
-
-
-def test_db_combo_present_when_flag_enabled(combo_window, qtbot):
-    """When flags.db_combo is True the combo widget exists."""
+def test_db_combo_present(combo_window, qtbot):
+    """The toolbar combo widget is always created."""
     assert hasattr(combo_window, "_db_combo")
     assert combo_window._db_combo is not None
 

--- a/tests/e2e-tests/test_e2e_filter.py
+++ b/tests/e2e-tests/test_e2e_filter.py
@@ -221,29 +221,12 @@ def test_where_clause_clear_restores_full_count(seeded_window, qtbot):
     assert window._cache_table.row_count() == TOTAL
 
 
-# ── FilterDialog WHERE tab (requires where_filter flag) ───────────────────────
+# ── FilterDialog WHERE tab ────────────────────────────────────────────────────
 
 
-def test_where_tab_absent_when_flag_disabled(seeded_window, qtbot, monkeypatch):
-    """FilterDialog has no WHERE tab when flags.where_filter is False."""
-    from opensak.utils import flags
+def test_where_tab_present(seeded_window, qtbot):
+    """FilterDialog always shows a WHERE tab."""
     from opensak.gui.dialogs.filter_dialog import FilterDialog
-
-    monkeypatch.setattr(flags, "where_filter", False)
-
-    dialog = FilterDialog(parent=seeded_window)
-    qtbot.addWidget(dialog)
-
-    assert dialog._where_tab is None
-    dialog.close()
-
-
-def test_where_tab_present_when_flag_enabled(seeded_window, qtbot, monkeypatch):
-    """FilterDialog shows a WHERE tab when flags.where_filter is True."""
-    from opensak.utils import flags
-    from opensak.gui.dialogs.filter_dialog import FilterDialog
-
-    monkeypatch.setattr(flags, "where_filter", True)
 
     dialog = FilterDialog(parent=seeded_window)
     qtbot.addWidget(dialog)
@@ -254,13 +237,10 @@ def test_where_tab_present_when_flag_enabled(seeded_window, qtbot, monkeypatch):
     dialog.close()
 
 
-def test_where_tab_builds_where_clause_filter(seeded_window, qtbot, monkeypatch):
+def test_where_tab_builds_where_clause_filter(seeded_window, qtbot):
     """Entering SQL in the WHERE tab produces a WhereClauseFilter in the FilterSet."""
-    from opensak.utils import flags
     from opensak.gui.dialogs.filter_dialog import FilterDialog
     from opensak.filters.engine import WhereClauseFilter, _iter_filters
-
-    monkeypatch.setattr(flags, "where_filter", True)
 
     dialog = FilterDialog(parent=seeded_window)
     qtbot.addWidget(dialog)
@@ -274,13 +254,10 @@ def test_where_tab_builds_where_clause_filter(seeded_window, qtbot, monkeypatch)
     dialog.close()
 
 
-def test_where_tab_empty_sql_adds_no_filter(seeded_window, qtbot, monkeypatch):
+def test_where_tab_empty_sql_adds_no_filter(seeded_window, qtbot):
     """An empty WHERE text field does not add a WhereClauseFilter to the set."""
-    from opensak.utils import flags
     from opensak.gui.dialogs.filter_dialog import FilterDialog
     from opensak.filters.engine import WhereClauseFilter, _iter_filters
-
-    monkeypatch.setattr(flags, "where_filter", True)
 
     dialog = FilterDialog(parent=seeded_window)
     qtbot.addWidget(dialog)
@@ -293,12 +270,9 @@ def test_where_tab_empty_sql_adds_no_filter(seeded_window, qtbot, monkeypatch):
     dialog.close()
 
 
-def test_where_tab_reset_clears_sql(seeded_window, qtbot, monkeypatch):
+def test_where_tab_reset_clears_sql(seeded_window, qtbot):
     """_reset_all() empties the WHERE SQL field and hides the error label."""
-    from opensak.utils import flags
     from opensak.gui.dialogs.filter_dialog import FilterDialog
-
-    monkeypatch.setattr(flags, "where_filter", True)
 
     dialog = FilterDialog(parent=seeded_window)
     qtbot.addWidget(dialog)
@@ -311,12 +285,9 @@ def test_where_tab_reset_clears_sql(seeded_window, qtbot, monkeypatch):
     dialog.close()
 
 
-def test_where_tab_validate_valid_sql_returns_none(seeded_window, qtbot, monkeypatch):
+def test_where_tab_validate_valid_sql_returns_none(seeded_window, qtbot):
     """_validate_where_sql returns None for syntactically valid SQL."""
-    from opensak.utils import flags
     from opensak.gui.dialogs.filter_dialog import FilterDialog
-
-    monkeypatch.setattr(flags, "where_filter", True)
 
     dialog = FilterDialog(parent=seeded_window)
     qtbot.addWidget(dialog)
@@ -326,12 +297,9 @@ def test_where_tab_validate_valid_sql_returns_none(seeded_window, qtbot, monkeyp
     dialog.close()
 
 
-def test_where_tab_validate_invalid_sql_returns_error(seeded_window, qtbot, monkeypatch):
+def test_where_tab_validate_invalid_sql_returns_error(seeded_window, qtbot):
     """_validate_where_sql returns a non-empty error string for bad SQL."""
-    from opensak.utils import flags
     from opensak.gui.dialogs.filter_dialog import FilterDialog
-
-    monkeypatch.setattr(flags, "where_filter", True)
 
     dialog = FilterDialog(parent=seeded_window)
     qtbot.addWidget(dialog)


### PR DESCRIPTION
# Remove if-guards for delivered feature flags (`where-filter`, `db-combo`)

## Context

OpenSAK uses a feature flag system (`src/opensak/utils/flags.py`) to gate in-development functionality behind runtime toggles. Flags are resolved from `features.json`, CLI overrides, and hardcoded release defaults. When a feature ships, its `_RELEASE_DEFAULTS` entry is set to `True` — meaning the flag is permanently on in every build, and the conditional branches it guards are dead code.

Both `where-filter` and `db-combo` reached this state: their defaults were set to `True` at delivery and have never been reverted. Every user, on every install, always sees both features. The `if flags.x:` guards remained in place only as cleanup debt.

## What changed

### Source code

- **`filter_dialog.py`** — Removed the `if flags.where_filter:` guard. The WHERE tab is now unconditionally built and added to the dialog. Removed the stale `self._where_tab = None` initialisation that was immediately overwritten. Removed the unused `flags` import.
- **`mainwindow.py`** — Removed three `if flags.db_combo:` guards (widget creation in `_setup_toolbar`, reload on startup in `__init__`, reload on database switch in `_on_database_switched`). The db combo is now always wired up. Removed the three inline `from opensak.utils import flags` imports.

### Tests

- **`test_e2e_filter.py`** — Removed `test_where_tab_absent_when_flag_disabled` (the scenario no longer exists). Removed `monkeypatch.setattr(flags, "where_filter", True)` boilerplate from all remaining WHERE tab tests, since no override is needed.
- **`test_e2e_db_combo.py`** — Removed `no_combo_window` fixture and `test_db_combo_absent_when_flag_disabled` test. Removed flag patching from `combo_window` and `two_db_combo_window` fixtures.

### What was intentionally kept

The flags module (`flags.py`), `features.json`, `docs/feature-flags.md`, and `tests/unit-tests/test_flags.py` are **unchanged**. The infrastructure remains available for future flags.

## Why this matters

- **Removes dead branches** that could mislead contributors into thinking the features are optional.
- **Simplifies tests** — tests no longer need to fabricate a specific flag state to exercise normal behavior.
- **Reduces coupling** — mainwindow no longer imports `flags` at all; filter_dialog drops it too.
- **No behavior change** — both features were unconditionally active before this PR. This only removes the indirection.
