### PR TITLE
Add "Owner name" filter field (separate from "Placed by")

### DIFF
--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -283,6 +283,20 @@ def _run_migrations(engine: Engine) -> None:
             conn.commit()
             print("Migration: tilføjede caches.parent_gc_code")
 
+        # ── Migration 9: owner_name (issue #158) ─────────────────────────────
+        # Stores the gs:owner display name separately from placed_by, which may
+        # differ when a cache is adopted or placed under a pseudonym.
+        existing_caches = [
+            row[1]
+            for row in conn.execute(text("PRAGMA table_info(caches)")).fetchall()
+        ]
+        if "owner_name" not in existing_caches:
+            conn.execute(text(
+                "ALTER TABLE caches ADD COLUMN owner_name VARCHAR(128)"
+            ))
+            conn.commit()
+            print("Migration: tilføjede caches.owner_name")
+
 
 def dispose_engine(db_path: Path | None = None) -> None:
     """

--- a/src/opensak/db/models.py
+++ b/src/opensak/db/models.py
@@ -67,6 +67,7 @@ class Cache(Base):
 
     # Owner
     placed_by: Mapped[Optional[str]] = mapped_column(String(128))
+    owner_name: Mapped[Optional[str]] = mapped_column(String(128))
     owner_id: Mapped[Optional[str]] = mapped_column(String(64))
 
     # Dates

--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -359,6 +359,24 @@ class PlacedByFilter(BaseFilter):
         return cls(data["text"])
 
 
+class OwnerFilter(BaseFilter):
+    """Keep caches whose owner name contains *text* (case-insensitive)."""
+    filter_type = "owner_name"
+
+    def __init__(self, text: str):
+        self.text = text.lower()
+
+    def matches(self, cache: Cache) -> bool:
+        return self.text in (cache.owner_name or "").lower()
+
+    def to_dict(self) -> dict:
+        return {"filter_type": self.filter_type, "text": self.text}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OwnerFilter":
+        return cls(data["text"])
+
+
 class DistanceFilter(BaseFilter):
     """
     Keep caches within *max_km* kilometres of a reference coordinate.
@@ -502,6 +520,7 @@ FILTER_REGISTRY: dict[str, type[BaseFilter]] = {
     "name":          NameFilter,
     "gc_code":       GcCodeFilter,
     "placed_by":     PlacedByFilter,
+    "owner_name":    OwnerFilter,
     "distance":      DistanceFilter,
     "attribute":     AttributeFilter,
     "has_trackable": HasTrackableFilter,

--- a/src/opensak/gui/dialogs/filter_dialog.py
+++ b/src/opensak/gui/dialogs/filter_dialog.py
@@ -329,6 +329,10 @@ class FilterDialog(QDialog):
         self._owner_filter.setPlaceholderText(tr("filter_contains_placeholder"))
         layout.addRow(tr("filter_owner_name_label"), self._owner_filter)
 
+        spacer = QWidget()
+        spacer.setFixedHeight(6)
+        layout.addRow(spacer)
+
         # Cache type
         type_group = QGroupBox(tr("filter_cache_type_group"))
         type_layout = QGridLayout(type_group)

--- a/src/opensak/gui/dialogs/filter_dialog.py
+++ b/src/opensak/gui/dialogs/filter_dialog.py
@@ -34,7 +34,7 @@ from opensak.filters.engine import (
     FoundFilter, NotFoundFilter,
     AvailableFilter, ArchivedFilter, AvailabilityFilter,
     CountryFilter, NameFilter, GcCodeFilter,
-    PlacedByFilter, DistanceFilter,
+    PlacedByFilter, OwnerFilter, DistanceFilter,
     AttributeFilter, HasTrackableFilter,
     PremiumFilter, NonPremiumFilter,
     WhereClauseFilter,
@@ -323,6 +323,11 @@ class FilterDialog(QDialog):
         self._placed_filter = QLineEdit()
         self._placed_filter.setPlaceholderText(tr("filter_contains_placeholder"))
         layout.addRow(tr("filter_placed_by_label"), self._placed_filter)
+
+        # Owner name
+        self._owner_filter = QLineEdit()
+        self._owner_filter.setPlaceholderText(tr("filter_contains_placeholder"))
+        layout.addRow(tr("filter_owner_name_label"), self._owner_filter)
 
         # Cache type
         type_group = QGroupBox(tr("filter_cache_type_group"))
@@ -786,6 +791,10 @@ class FilterDialog(QDialog):
         if self._placed_filter.text().strip():
             fs.add(PlacedByFilter(self._placed_filter.text().strip()))
 
+        # Owner name
+        if self._owner_filter.text().strip():
+            fs.add(OwnerFilter(self._owner_filter.text().strip()))
+
         # Cache type — byg OR gruppe af valgte typer
         selected_types = [t for t, cb in self._type_checks.items() if cb.isChecked()]
         if selected_types and len(selected_types) < len(CACHE_TYPES):
@@ -1006,6 +1015,8 @@ class FilterDialog(QDialog):
                 self._gc_filter.setText(getattr(f, "text", ""))
             elif ftype == "placed_by":
                 self._placed_filter.setText(getattr(f, "text", ""))
+            elif ftype == "owner_name":
+                self._owner_filter.setText(getattr(f, "text", ""))
             elif ftype == "cache_type":
                 types = getattr(f, "types", [])
                 for ct, cb in self._type_checks.items():

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -297,6 +297,7 @@ def _parse_wpt(wpt_el) -> Optional[dict]:
         "difficulty":        difficulty,
         "terrain":           terrain,
         "placed_by":         placed_by,
+        "owner_name":        owner,
         "owner_id":          owner_id,
         "hidden_date":       _parse_datetime(hidden_raw),
         "available":         available,
@@ -495,6 +496,7 @@ def _parse_loc_waypoint(wpt_el) -> Optional[dict]:
         "difficulty":        None,
         "terrain":           None,
         "placed_by":         None,
+        "owner_name":        None,
         "owner_id":          None,
         "hidden_date":       None,
         "available":         True,
@@ -540,7 +542,7 @@ def _upsert_cache(session: Session, data: dict, source_file: str) -> tuple[Cache
     # Scalar fields
     for field in (
         "name", "cache_type", "container", "latitude", "longitude",
-        "difficulty", "terrain", "placed_by", "owner_id",
+        "difficulty", "terrain", "placed_by", "owner_name", "owner_id",
         "hidden_date", "available", "archived",
         "country", "state", "county",
         "short_description", "short_desc_html",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -345,6 +345,7 @@ STRINGS: dict[str, str] = {
     "filter_contains_placeholder":  "Obsahuje text…",
     "filter_gc_label":              "GC kód:",
     "filter_placed_by_label":       "Umístil:",
+    "filter_owner_name_label":      "Jméno vlastníka:",
     "filter_cache_type_group":      "Typ keše",
     "filter_container_group":       "Velikost schránky",
     "filter_dt_group":              "Obtížnost / Terén",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -345,6 +345,7 @@ STRINGS: dict[str, str] = {
     "filter_contains_placeholder":  "Indeholder tekst…",
     "filter_gc_label":              "GC Kode:",
     "filter_placed_by_label":       "Udlagt af:",
+    "filter_owner_name_label":      "Ejernavn:",
     "filter_cache_type_group":      "Cache type",
     "filter_container_group":       "Container størrelse",
     "filter_dt_group":              "Sværhedsgrad / Terræn",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -345,6 +345,7 @@ STRINGS: dict[str, str] = {
     "filter_contains_placeholder":  "Enthält Text…",
     "filter_gc_label":              "GC-Code:",
     "filter_placed_by_label":       "Versteckt von:",
+    "filter_owner_name_label":      "Eigenname:",
     "filter_cache_type_group":      "Cache-Type",
     "filter_container_group":       "Container-Größe",
     "filter_dt_group":              "Schwierigkeit / Terrain (D/T)",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -345,6 +345,7 @@ STRINGS: dict[str, str] = {
     "filter_contains_placeholder":  "Contains text…",
     "filter_gc_label":              "GC Code:",
     "filter_placed_by_label":       "Placed by:",
+    "filter_owner_name_label":      "Owner name:",
     "filter_cache_type_group":      "Cache type",
     "filter_container_group":       "Container size",
     "filter_dt_group":              "Difficulty / Terrain",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -345,6 +345,7 @@ STRINGS: dict[str, str] = {
     "filter_contains_placeholder":  "Texte contenant…",
     "filter_gc_label":              "Code GC:",
     "filter_placed_by_label":       "Placé par:",
+    "filter_owner_name_label":      "Nom du propriétaire:",
     "filter_cache_type_group":      "Type de cache",
     "filter_container_group":       "Taille du conteneur",
     "filter_dt_group":              "Difficulté / Terrain",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -345,6 +345,7 @@ STRINGS: dict[str, str] = {
     "filter_contains_placeholder":  "Contém o texto…",
     "filter_gc_label":              "Código GC:",
     "filter_placed_by_label":       "Colocada por:",
+    "filter_owner_name_label":      "Nome do dono:",
     "filter_cache_type_group":      "Tipo de cache",
     "filter_container_group":       "Tamanho do contentor",
     "filter_dt_group":              "Dificuldade / Terreno",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -345,6 +345,7 @@ STRINGS: dict[str, str] = {
     "filter_contains_placeholder":  "Innehåller text…",
     "filter_gc_label":              "GC Kod:",
     "filter_placed_by_label":       "Utlagd av:",
+    "filter_owner_name_label":      "Ägarnamn:",
     "filter_cache_type_group":      "Cache typ",
     "filter_container_group":       "Storlek",
     "filter_dt_group":              "Svårighet / Terräng",


### PR DESCRIPTION
Closes #158

A geocache's Placed by (the pseudonym used at hide time) and its Owner name (the account holder) are distinct — caches can be adopted or hidden under a pseudonym. GSAK stores both separately. OpenSAK was importing the gs:owner value but silently discarding it.