### PR TITLE
Adaptive Search Engine

### DIFF
--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -351,12 +351,14 @@ class GcCodeFilter(BaseFilter):
     def apply_to_query(self, query):
         from sqlalchemy import func
         self._sql_applied = True
-        return query.filter(func.upper(Cache.gc_code).like(f"%{self.text}%"))
+        # GC codes are always searched from the start (GC12345) — use a prefix
+        # match so SQLite can exploit the existing B-tree index on gc_code.
+        return query.filter(func.upper(Cache.gc_code).like(f"{self.text}%"))
 
     def matches(self, cache: Cache) -> bool:
         if self._sql_applied:
             return True
-        return self.text in (cache.gc_code or "").upper()
+        return (cache.gc_code or "").upper().startswith(self.text)
 
     def to_dict(self) -> dict:
         return {"filter_type": self.filter_type, "text": self.text}

--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -55,6 +55,15 @@ class BaseFilter(ABC):
     def matches(self, cache: Cache) -> bool:
         """Return True if *cache* passes this filter."""
 
+    def apply_to_query(self, query):
+        """Optionally push this filter into a SQLAlchemy query before .all().
+
+        Return the updated query if SQL-level filtering is possible, or None
+        to fall back to Python-level matches(). When this returns a query the
+        filter must also return True from matches() to avoid double-filtering.
+        """
+        return None
+
     def to_dict(self) -> dict:
         """Serialise filter to a JSON-safe dict."""
         return {"filter_type": self.filter_type}
@@ -311,8 +320,16 @@ class NameFilter(BaseFilter):
 
     def __init__(self, text: str):
         self.text = text.lower()
+        self._sql_applied = False
+
+    def apply_to_query(self, query):
+        from sqlalchemy import func
+        self._sql_applied = True
+        return query.filter(func.lower(Cache.name).like(f"%{self.text}%"))
 
     def matches(self, cache: Cache) -> bool:
+        if self._sql_applied:
+            return True
         return self.text in (cache.name or "").lower()
 
     def to_dict(self) -> dict:
@@ -329,8 +346,16 @@ class GcCodeFilter(BaseFilter):
 
     def __init__(self, text: str):
         self.text = text.upper()
+        self._sql_applied = False
+
+    def apply_to_query(self, query):
+        from sqlalchemy import func
+        self._sql_applied = True
+        return query.filter(func.upper(Cache.gc_code).like(f"%{self.text}%"))
 
     def matches(self, cache: Cache) -> bool:
+        if self._sql_applied:
+            return True
         return self.text in (cache.gc_code or "").upper()
 
     def to_dict(self) -> dict:
@@ -737,6 +762,16 @@ def apply_filters(
         noload(Cache.waypoints),        # ikke brugt i filtre — load on-demand
         joinedload(Cache.user_note),    # one-to-one, cheap join; needed for corrected-coords display
     )
+
+    # Push SQL-capable filters into the query before loading rows.
+    # This lets SQLite discard non-matching rows before any Python objects
+    # are constructed — critical for NameFilter / GcCodeFilter on large DBs.
+    if filterset:
+        for _f in _iter_filters(filterset):
+            updated = _f.apply_to_query(query)
+            if updated is not None:
+                query = updated
+
     all_caches = query.all()
 
     # Apply filters

--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -750,17 +750,24 @@ def apply_filters(
                 except Exception:
                     _f._matching_ids = set()  # invalid SQL → no matches
 
-    # Load caches med kun de relationer der bruges i filtrene.
-    # logs, waypoints og user_note loader vi IKKE her — de hentes
-    # on-demand når brugeren klikker på en enkelt cache.
-    # Dette er kritisk for performance ved store databaser (50K+ caches).
+    # Determine which relationships are actually needed by the active filters.
+    # Only joinedload what is required — avoids loading thousands of attribute
+    # and trackable rows when the filterset contains only a NameFilter or a
+    # simple quick-filter (the common case during live search).
+    needs_attributes  = filterset is not None and any(
+        isinstance(f, AttributeFilter)    for f in _iter_filters(filterset)
+    )
+    needs_trackables  = filterset is not None and any(
+        isinstance(f, HasTrackableFilter) for f in _iter_filters(filterset)
+    )
+
     from sqlalchemy.orm import joinedload, noload
     query = session.query(Cache).options(
-        joinedload(Cache.attributes),   # bruges i AttributeFilter
-        joinedload(Cache.trackables),   # bruges i TrackableFilter
-        noload(Cache.logs),             # ikke brugt i filtre — load on-demand
-        noload(Cache.waypoints),        # ikke brugt i filtre — load on-demand
-        joinedload(Cache.user_note),    # one-to-one, cheap join; needed for corrected-coords display
+        joinedload(Cache.attributes) if needs_attributes else noload(Cache.attributes),
+        joinedload(Cache.trackables) if needs_trackables else noload(Cache.trackables),
+        noload(Cache.logs),       # load on-demand when user opens a cache
+        noload(Cache.waypoints),  # load on-demand when user opens a cache
+        joinedload(Cache.user_note),  # one-to-one, cheap; needed for corrected-coords
     )
 
     # Push SQL-capable filters into the query before loading rows.

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -75,8 +75,9 @@ class SettingsDialog(QDialog):
 
         # Tab-widget med tre faner
         self._tabs = QTabWidget()
-        self._tabs.addTab(self._build_general_tab(),  tr("settings_tab_general"))
-        self._tabs.addTab(self._build_gc_tab(),        tr("settings_tab_geocaching"))
+        self._tabs.addTab(self._build_general_tab(),   tr("settings_tab_general"))
+        self._tabs.addTab(self._build_gc_tab(),         tr("settings_tab_geocaching"))
+        self._tabs.addTab(self._build_advanced_tab(),   tr("settings_tab_advanced"))
 
         layout.addWidget(self._tabs)
 
@@ -262,6 +263,18 @@ class SettingsDialog(QDialog):
 
         layout.addWidget(user_group)
 
+        layout.addStretch()
+        scroll.setWidget(tab)
+        return scroll
+
+    # ── Fane 3: Advanced ─────────────────────────────────────────────────────
+
+    def _build_advanced_tab(self) -> QWidget:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
         # ── Search behaviour ──────────────────────────────────────────────────
         search_group = QGroupBox(tr("settings_group_search"))
         search_layout = QVBoxLayout(search_group)
@@ -293,10 +306,8 @@ class SettingsDialog(QDialog):
         search_layout.addWidget(search_hint)
 
         layout.addWidget(search_group)
-
         layout.addStretch()
-        scroll.setWidget(tab)
-        return scroll
+        return tab
 
     # ── Fane 2: Geocaching.com ────────────────────────────────────────────────
 

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox, QGroupBox, QComboBox,
     QMessageBox, QTableWidget, QTableWidgetItem,
     QHeaderView, QAbstractItemView, QTabWidget, QWidget,
-    QFrame, QSizePolicy, QSpinBox, QScrollArea
+    QFrame, QSizePolicy, QSpinBox
 )
 from opensak.gui.icon import OpenSAKMessageBox as QMessageBox
 from PySide6.QtGui import QPixmap, QFont
@@ -93,10 +93,6 @@ class SettingsDialog(QDialog):
     # ── Fane 1: Generelle indstillinger ──────────────────────────────────────
 
     def _build_general_tab(self) -> QWidget:
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QFrame.Shape.NoFrame)
-
         tab = QWidget()
         layout = QVBoxLayout(tab)
         layout.setContentsMargins(6, 6, 6, 6)
@@ -264,8 +260,7 @@ class SettingsDialog(QDialog):
         layout.addWidget(user_group)
 
         layout.addStretch()
-        scroll.setWidget(tab)
-        return scroll
+        return tab
 
     # ── Fane 3: Advanced ─────────────────────────────────────────────────────
 

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox, QGroupBox, QComboBox,
     QMessageBox, QTableWidget, QTableWidgetItem,
     QHeaderView, QAbstractItemView, QTabWidget, QWidget,
-    QFrame, QSizePolicy
+    QFrame, QSizePolicy, QSpinBox
 )
 from opensak.gui.icon import OpenSAKMessageBox as QMessageBox
 from PySide6.QtGui import QPixmap, QFont
@@ -257,6 +257,39 @@ class SettingsDialog(QDialog):
         user_layout.addWidget(hint)
 
         layout.addWidget(user_group)
+
+        # ── Search behaviour ──────────────────────────────────────────────────
+        search_group = QGroupBox(tr("settings_group_search"))
+        search_layout = QVBoxLayout(search_group)
+
+        min_row = QHBoxLayout()
+        min_row.addWidget(QLabel(tr("settings_search_min_chars_label")))
+        self._search_min_chars = QSpinBox()
+        self._search_min_chars.setRange(0, 20)
+        self._search_min_chars.setSpecialValueText(tr("settings_search_auto"))
+        self._search_min_chars.setFixedWidth(80)
+        min_row.addWidget(self._search_min_chars)
+        min_row.addStretch()
+        search_layout.addLayout(min_row)
+
+        delay_row = QHBoxLayout()
+        delay_row.addWidget(QLabel(tr("settings_search_debounce_label")))
+        self._search_debounce_ms = QSpinBox()
+        self._search_debounce_ms.setRange(0, 2000)
+        self._search_debounce_ms.setSingleStep(50)
+        self._search_debounce_ms.setSpecialValueText(tr("settings_search_auto"))
+        self._search_debounce_ms.setFixedWidth(80)
+        delay_row.addWidget(self._search_debounce_ms)
+        delay_row.addStretch()
+        search_layout.addLayout(delay_row)
+
+        search_hint = QLabel(tr("settings_search_hint"))
+        search_hint.setStyleSheet("color: gray; font-size: 10px;")
+        search_hint.setWordWrap(True)
+        search_layout.addWidget(search_hint)
+
+        layout.addWidget(search_group)
+
         layout.addStretch()
         return tab
 
@@ -621,17 +654,21 @@ class SettingsDialog(QDialog):
         lang_idx = self._lang_combo.findData(current_language())
         self._lang_combo.setCurrentIndex(lang_idx if lang_idx >= 0 else 0)
         self._gc_username.setText(s.gc_username)
+        self._search_min_chars.setValue(s.search_min_chars)
+        self._search_debounce_ms.setValue(s.search_debounce_ms)
         # Opdater GC-status
         self._refresh_gc_status_on_open()
 
     def _save(self) -> None:
         s = get_settings()
-        s.gc_username   = self._gc_username.text()
-        s.use_miles     = self._miles_cb.isChecked()
-        s.show_archived = self._archived_cb.isChecked()
-        s.show_found    = self._found_cb.isChecked()
-        s.map_provider  = self._map_provider.currentData()
-        s.coord_format  = self._coord_format.currentData()
+        s.gc_username       = self._gc_username.text()
+        s.use_miles         = self._miles_cb.isChecked()
+        s.show_archived     = self._archived_cb.isChecked()
+        s.show_found        = self._found_cb.isChecked()
+        s.map_provider      = self._map_provider.currentData()
+        s.coord_format      = self._coord_format.currentData()
+        s.search_min_chars  = self._search_min_chars.value()
+        s.search_debounce_ms = self._search_debounce_ms.value()
         s.sync()
 
         new_lang = self._lang_combo.currentData()

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import (
     QDialogButtonBox, QGroupBox, QComboBox,
     QMessageBox, QTableWidget, QTableWidgetItem,
     QHeaderView, QAbstractItemView, QTabWidget, QWidget,
-    QFrame, QSizePolicy, QSpinBox
+    QFrame, QSizePolicy, QSpinBox, QScrollArea
 )
 from opensak.gui.icon import OpenSAKMessageBox as QMessageBox
 from PySide6.QtGui import QPixmap, QFont
@@ -92,6 +92,10 @@ class SettingsDialog(QDialog):
     # ── Fane 1: Generelle indstillinger ──────────────────────────────────────
 
     def _build_general_tab(self) -> QWidget:
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+
         tab = QWidget()
         layout = QVBoxLayout(tab)
         layout.setContentsMargins(6, 6, 6, 6)
@@ -291,7 +295,8 @@ class SettingsDialog(QDialog):
         layout.addWidget(search_group)
 
         layout.addStretch()
-        return tab
+        scroll.setWidget(tab)
+        return scroll
 
     # ── Fane 2: Geocaching.com ────────────────────────────────────────────────
 

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -152,6 +152,7 @@ class MainWindow(QMainWindow):
         self._current_filterset = FilterSet()
         self._current_sort = SortSpec("name", ascending=True)
         self._active_filter_name = ""
+        self._db_count: int = 0
         self._search_timer = QTimer(self)
         self._search_timer.setSingleShot(True)
         self._search_timer.timeout.connect(self._refresh_cache_list)
@@ -748,6 +749,7 @@ class MainWindow(QMainWindow):
         # Total caches in database (not just filtered)
         with get_session() as session:
             total_in_db = session.query(Cache).count()
+        self._db_count = total_in_db
 
         # Filter name
         filter_name = self._active_filter_name
@@ -888,11 +890,7 @@ class MainWindow(QMainWindow):
         s = get_settings()
         user_min   = s.search_min_chars
         user_delay = s.search_debounce_ms
-        try:
-            with get_session() as session:
-                count = session.query(Cache).count()
-        except Exception:
-            count = 0
+        count = self._db_count
         if count >= 10_000:
             adaptive_min, adaptive_delay = 3, 600
         elif count >= 1_000:

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -892,11 +892,11 @@ class MainWindow(QMainWindow):
         user_delay = s.search_debounce_ms
         count = self._db_count
         if count >= 10_000:
-            adaptive_min, adaptive_delay = 3, 600
+            adaptive_min, adaptive_delay = 1, 400
         elif count >= 1_000:
-            adaptive_min, adaptive_delay = 2, 400
+            adaptive_min, adaptive_delay = 1, 250
         else:
-            adaptive_min, adaptive_delay = 1, 200
+            adaptive_min, adaptive_delay = 1, 150
         min_chars   = user_min   if user_min   > 0 else adaptive_min
         debounce_ms = user_delay if user_delay > 0 else adaptive_delay
         return min_chars, debounce_ms

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -152,6 +152,9 @@ class MainWindow(QMainWindow):
         self._current_filterset = FilterSet()
         self._current_sort = SortSpec("name", ascending=True)
         self._active_filter_name = ""
+        self._search_timer = QTimer(self)
+        self._search_timer.setSingleShot(True)
+        self._search_timer.timeout.connect(self._refresh_cache_list)
         self._setup_ui()
         self._setup_menu()
         self._setup_toolbar()
@@ -876,7 +879,29 @@ class MainWindow(QMainWindow):
             self._map_widget.update_cache(full)
 
     def _on_search_changed(self, text: str) -> None:
-        QTimer.singleShot(300, self._refresh_cache_list)
+        min_chars, debounce_ms = self._search_thresholds()
+        if text == "" or len(text) >= min_chars:
+            self._search_timer.start(debounce_ms)
+
+    def _search_thresholds(self) -> tuple[int, int]:
+        """Return (min_chars, debounce_ms), adaptive if not overridden in settings."""
+        s = get_settings()
+        user_min   = s.search_min_chars
+        user_delay = s.search_debounce_ms
+        try:
+            with get_session() as session:
+                count = session.query(Cache).count()
+        except Exception:
+            count = 0
+        if count >= 10_000:
+            adaptive_min, adaptive_delay = 3, 600
+        elif count >= 1_000:
+            adaptive_min, adaptive_delay = 2, 400
+        else:
+            adaptive_min, adaptive_delay = 1, 200
+        min_chars   = user_min   if user_min   > 0 else adaptive_min
+        debounce_ms = user_delay if user_delay > 0 else adaptive_delay
+        return min_chars, debounce_ms
 
     def _on_quick_filter_changed(self, index: int) -> None:
         self._refresh_cache_list()

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -882,7 +882,15 @@ class MainWindow(QMainWindow):
 
     def _on_search_changed(self, text: str) -> None:
         min_chars, debounce_ms = self._search_thresholds()
-        if text == "" or len(text) >= min_chars:
+        if text == "":
+            # Clearing always fires immediately
+            self._search_timer.stop()
+            self._refresh_cache_list()
+        elif len(text) >= min_chars:
+            # Threshold met — fire quickly to feel responsive
+            self._search_timer.start(80)
+        else:
+            # Below threshold — fire after the full debounce so a pause triggers search
             self._search_timer.start(debounce_ms)
 
     def _search_thresholds(self) -> tuple[int, int]:
@@ -892,11 +900,11 @@ class MainWindow(QMainWindow):
         user_delay = s.search_debounce_ms
         count = self._db_count
         if count >= 10_000:
-            adaptive_min, adaptive_delay = 2, 400
+            adaptive_min, adaptive_delay = 3, 600
         elif count >= 1_000:
-            adaptive_min, adaptive_delay = 2, 250
+            adaptive_min, adaptive_delay = 2, 400
         else:
-            adaptive_min, adaptive_delay = 2, 150
+            adaptive_min, adaptive_delay = 1, 200
         min_chars   = user_min   if user_min   > 0 else adaptive_min
         debounce_ms = user_delay if user_delay > 0 else adaptive_delay
         return min_chars, debounce_ms

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -892,11 +892,11 @@ class MainWindow(QMainWindow):
         user_delay = s.search_debounce_ms
         count = self._db_count
         if count >= 10_000:
-            adaptive_min, adaptive_delay = 1, 400
+            adaptive_min, adaptive_delay = 2, 400
         elif count >= 1_000:
-            adaptive_min, adaptive_delay = 1, 250
+            adaptive_min, adaptive_delay = 2, 250
         else:
-            adaptive_min, adaptive_delay = 1, 150
+            adaptive_min, adaptive_delay = 2, 150
         min_chars   = user_min   if user_min   > 0 else adaptive_min
         debounce_ms = user_delay if user_delay > 0 else adaptive_delay
         return min_chars, debounce_ms

--- a/src/opensak/gui/settings.py
+++ b/src/opensak/gui/settings.py
@@ -241,6 +241,26 @@ class AppSettings:
     def bottom_splitter_state(self, value) -> None:
         self._s.setValue("window/bottom_splitter_state", value)
 
+    # ── Search thresholds ──────────────────────────────────────────────────────
+
+    @property
+    def search_min_chars(self) -> int:
+        """Minimum characters before search fires. 0 = adaptive based on DB size."""
+        return int(self._s.value("search/min_chars", 0))
+
+    @search_min_chars.setter
+    def search_min_chars(self, value: int) -> None:
+        self._s.setValue("search/min_chars", value)
+
+    @property
+    def search_debounce_ms(self) -> int:
+        """Debounce delay in milliseconds. 0 = adaptive based on DB size."""
+        return int(self._s.value("search/debounce_ms", 0))
+
+    @search_debounce_ms.setter
+    def search_debounce_ms(self, value: int) -> None:
+        self._s.setValue("search/debounce_ms", value)
+
     # ── Last used paths ───────────────────────────────────────────────────────
 
     @property

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimální počet znaků:",
     "settings_search_debounce_label":              "Zpoždění debounce (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Nastavte 0 (Auto) pro adaptivní prahové hodnoty podle velikosti databáze: < 1 000 keší → 1 znak / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
+    "settings_search_hint":                        "Nastavte 0 (Auto) pro adaptivní prahy: minimum 2 znaky pro všechny velikosti databáze, debounce se škáluje s velikostí (150 / 250 / 400 ms). Minimální znaky řídí relevanci; debounce řídí odezvu psaní.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Správa databází",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -729,6 +729,7 @@ STRINGS: dict[str, str] = {
     # ── Geocaching.com integration ────────────────────────────────────────────
     "settings_tab_general":         "Obecné",
     "settings_tab_geocaching":      "Geocaching.com",
+    "settings_tab_advanced":        "Pokročilé",
     "gc_not_logged_in":             "Nepřihlášen",
     "gc_status_offline":            "Offline",
     "gc_status_online":             "Připojeno",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -213,7 +213,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Uživatelské jméno:",
     "settings_gc_username_placeholder":            "Vaše geocaching.com jméno",
     "settings_gc_username_hint":                   "Používá se k rozpoznání vlastních záznamů (např. FTF)",
-    "settings_group_search":                       "Vyhledávání",
+    "settings_group_search":                       "Vyhledávací engine",
     "settings_search_min_chars_label":             "Minimální počet znaků:",
     "settings_search_debounce_label":              "Zpoždění debounce (ms):",
     "settings_search_auto":                        "Auto",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimální počet znaků:",
     "settings_search_debounce_label":              "Zpoždění debounce (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Nastavte 0 (Auto) pro adaptivní prahy: minimum 2 znaky pro všechny velikosti databáze, debounce se škáluje s velikostí (150 / 250 / 400 ms). Minimální znaky řídí relevanci; debounce řídí odezvu psaní.",
+    "settings_search_hint":                        "Nastavte 0 (Auto) pro adaptivní prahy. Dosažení minima znaků spustí okamžitě; pauza debounce spustí vždy. < 1 000 keší → 1 znak / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Správa databází",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimální počet znaků:",
     "settings_search_debounce_label":              "Zpoždění debounce (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Nastavte 0 (Auto) pro adaptivní prahové hodnoty podle velikosti databáze: < 1 000 keší → 1 znak / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
+    "settings_search_hint":                        "Nastavte 0 (Auto) pro adaptivní prahové hodnoty podle velikosti databáze: < 1 000 keší → 1 znak / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Správa databází",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -213,6 +213,11 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Uživatelské jméno:",
     "settings_gc_username_placeholder":            "Vaše geocaching.com jméno",
     "settings_gc_username_hint":                   "Používá se k rozpoznání vlastních záznamů (např. FTF)",
+    "settings_group_search":                       "Vyhledávání",
+    "settings_search_min_chars_label":             "Minimální počet znaků:",
+    "settings_search_debounce_label":              "Zpoždění debounce (ms):",
+    "settings_search_auto":                        "Auto",
+    "settings_search_hint":                        "Nastavte 0 (Auto) pro adaptivní prahové hodnoty podle velikosti databáze: < 1 000 keší → 1 znak / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Správa databází",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -213,7 +213,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Brugernavn:",
     "settings_gc_username_placeholder":            "Dit geocaching.com brugernavn",
     "settings_gc_username_hint":                   "Bruges til at genkende dine egne logs (fx FTF-detektion)",
-    "settings_group_search":                       "Søgning",
+    "settings_group_search":                       "Søgemaskine",
     "settings_search_min_chars_label":             "Minimumstegn:",
     "settings_search_debounce_label":              "Debounce-forsinkelse (ms):",
     "settings_search_auto":                        "Auto",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -733,6 +733,7 @@ STRINGS: dict[str, str] = {
     # ── Geocaching.com integration ────────────────────────────────────────────
     "settings_tab_general":         "Generelt",
     "settings_tab_geocaching":      "Geocaching.com",
+    "settings_tab_advanced":        "Avanceret",
     "gc_not_logged_in":             "Ikke logget ind",
     "gc_status_offline":            "Offline",
     "gc_status_online":             "Forbundet",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimumstegn:",
     "settings_search_debounce_label":              "Debounce-forsinkelse (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Sæt til 0 (Auto) for adaptive grænser der skalerer med databasestørrelsen: < 1 000 caches → 1 tegn / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
+    "settings_search_hint":                        "Sæt til 0 (Auto) for adaptive grænser der skalerer med databasestørrelsen: < 1 000 caches → 1 tegn / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Administrer databaser",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimumstegn:",
     "settings_search_debounce_label":              "Debounce-forsinkelse (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Sæt til 0 (Auto) for adaptive grænser: minimum 2 tegn for alle databasestørrelser, debounce skalerer med størrelsen (150 / 250 / 400 ms). Minimumstegn styrer relevans; debounce styrer tastaturrespons.",
+    "settings_search_hint":                        "Sæt til 0 (Auto) for adaptive grænser. At nå minimumstegn udløser straks; en pause på debounce-tiden udløser uanset hvad. < 1 000 caches → 1 tegn / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Administrer databaser",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -213,6 +213,11 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Brugernavn:",
     "settings_gc_username_placeholder":            "Dit geocaching.com brugernavn",
     "settings_gc_username_hint":                   "Bruges til at genkende dine egne logs (fx FTF-detektion)",
+    "settings_group_search":                       "Søgning",
+    "settings_search_min_chars_label":             "Minimumstegn:",
+    "settings_search_debounce_label":              "Debounce-forsinkelse (ms):",
+    "settings_search_auto":                        "Auto",
+    "settings_search_hint":                        "Sæt til 0 (Auto) for adaptive grænser der skalerer med databasestørrelsen: < 1 000 caches → 1 tegn / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Administrer databaser",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimumstegn:",
     "settings_search_debounce_label":              "Debounce-forsinkelse (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Sæt til 0 (Auto) for adaptive grænser der skalerer med databasestørrelsen: < 1 000 caches → 1 tegn / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
+    "settings_search_hint":                        "Sæt til 0 (Auto) for adaptive grænser: minimum 2 tegn for alle databasestørrelser, debounce skalerer med størrelsen (150 / 250 / 400 ms). Minimumstegn styrer relevans; debounce styrer tastaturrespons.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Administrer databaser",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Mindestzeichen:",
     "settings_search_debounce_label":              "Debounce-Verzögerung (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "0 (Auto) wählt adaptive Schwellenwerte basierend auf der Datenbankgröße: < 1 000 Caches → 1 Zeichen / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
+    "settings_search_hint":                        "0 (Auto) wählt adaptive Schwellenwerte basierend auf der Datenbankgröße: < 1 000 Caches → 1 Zeichen / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Datenbanken verwalten",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -213,6 +213,11 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Benutzername:",
     "settings_gc_username_placeholder":            "Dein geocaching.com Benutzername",
     "settings_gc_username_hint":                   "Wird zur Erkennung eigener Logs verwendet (z.B. FTF-Erkennung)",
+    "settings_group_search":                       "Suche",
+    "settings_search_min_chars_label":             "Mindestzeichen:",
+    "settings_search_debounce_label":              "Debounce-Verzögerung (ms):",
+    "settings_search_auto":                        "Auto",
+    "settings_search_hint":                        "0 (Auto) wählt adaptive Schwellenwerte basierend auf der Datenbankgröße: < 1 000 Caches → 1 Zeichen / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Datenbanken verwalten",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -733,6 +733,7 @@ STRINGS: dict[str, str] = {
     # ── Geocaching.com integration ────────────────────────────────────────────
     "settings_tab_general":         "Allgemein",
     "settings_tab_geocaching":      "Geocaching.com",
+    "settings_tab_advanced":        "Erweitert",
     "gc_not_logged_in":             "Nicht eingeloggt",
     "gc_status_offline":            "Offline",
     "gc_status_online":             "verbunden",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -213,7 +213,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Benutzername:",
     "settings_gc_username_placeholder":            "Dein geocaching.com Benutzername",
     "settings_gc_username_hint":                   "Wird zur Erkennung eigener Logs verwendet (z.B. FTF-Erkennung)",
-    "settings_group_search":                       "Suche",
+    "settings_group_search":                       "Suchmaschine",
     "settings_search_min_chars_label":             "Mindestzeichen:",
     "settings_search_debounce_label":              "Debounce-Verzögerung (ms):",
     "settings_search_auto":                        "Auto",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Mindestzeichen:",
     "settings_search_debounce_label":              "Debounce-Verzögerung (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "0 (Auto) wählt adaptive Schwellenwerte basierend auf der Datenbankgröße: < 1 000 Caches → 1 Zeichen / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
+    "settings_search_hint":                        "0 (Auto) wählt adaptive Schwellenwerte: mindestens 2 Zeichen für alle Datenbankgrößen, Debounce skaliert mit der Größe (150 / 250 / 400 ms). Mindestzeichen steuert Relevanz; Debounce steuert Tippreaktion.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Datenbanken verwalten",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Mindestzeichen:",
     "settings_search_debounce_label":              "Debounce-Verzögerung (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "0 (Auto) wählt adaptive Schwellenwerte: mindestens 2 Zeichen für alle Datenbankgrößen, Debounce skaliert mit der Größe (150 / 250 / 400 ms). Mindestzeichen steuert Relevanz; Debounce steuert Tippreaktion.",
+    "settings_search_hint":                        "0 (Auto) wählt adaptive Schwellenwerte. Mindestzeichen erreicht → sofort auslösen; Debounce-Pause abgewartet → trotzdem auslösen. < 1 000 Caches → 1 Zeichen / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Datenbanken verwalten",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -213,7 +213,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Username:",
     "settings_gc_username_placeholder":            "Your geocaching.com username",
     "settings_gc_username_hint":                   "Used to identify your own logs (e.g. for FTF detection)",
-    "settings_group_search":                       "Search",
+    "settings_group_search":                       "Search Engine",
     "settings_search_min_chars_label":             "Minimum characters:",
     "settings_search_debounce_label":              "Debounce delay (ms):",
     "settings_search_auto":                        "Auto",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimum characters:",
     "settings_search_debounce_label":              "Debounce delay (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Set to 0 (Auto) for adaptive thresholds: 2 chars minimum for all database sizes, debounce scales with size (150 / 250 / 400 ms). Minimum characters controls result relevance; debounce controls typing responsiveness.",
+    "settings_search_hint":                        "Set to 0 (Auto) for adaptive thresholds. Reaching the minimum chars fires immediately; pausing for the debounce fires regardless. < 1 000 caches → 1 char / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Manage databases",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimum characters:",
     "settings_search_debounce_label":              "Debounce delay (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Set to 0 (Auto) for adaptive thresholds that scale with database size: < 1 000 caches → 1 char / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
+    "settings_search_hint":                        "Set to 0 (Auto) for adaptive thresholds that scale with database size: < 1 000 caches → 1 char / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Manage databases",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -733,6 +733,7 @@ STRINGS: dict[str, str] = {
     # ── Geocaching.com integration ────────────────────────────────────────────
     "settings_tab_general":         "General",
     "settings_tab_geocaching":      "Geocaching.com",
+    "settings_tab_advanced":        "Advanced",
     "gc_not_logged_in":             "Not logged in",
     "gc_status_offline":            "Offline",
     "gc_status_online":             "Connected",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -213,6 +213,11 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Username:",
     "settings_gc_username_placeholder":            "Your geocaching.com username",
     "settings_gc_username_hint":                   "Used to identify your own logs (e.g. for FTF detection)",
+    "settings_group_search":                       "Search",
+    "settings_search_min_chars_label":             "Minimum characters:",
+    "settings_search_debounce_label":              "Debounce delay (ms):",
+    "settings_search_auto":                        "Auto",
+    "settings_search_hint":                        "Set to 0 (Auto) for adaptive thresholds that scale with database size: < 1 000 caches → 1 char / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Manage databases",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minimum characters:",
     "settings_search_debounce_label":              "Debounce delay (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Set to 0 (Auto) for adaptive thresholds that scale with database size: < 1 000 caches → 1 char / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
+    "settings_search_hint":                        "Set to 0 (Auto) for adaptive thresholds: 2 chars minimum for all database sizes, debounce scales with size (150 / 250 / 400 ms). Minimum characters controls result relevance; debounce controls typing responsiveness.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Manage databases",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Caractères minimum :",
     "settings_search_debounce_label":              "Délai de debounce (ms) :",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Réglez sur 0 (Auto) pour des seuils adaptatifs selon la taille de la base : < 1 000 caches → 1 car. / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
+    "settings_search_hint":                        "Réglez sur 0 (Auto) pour des seuils adaptatifs selon la taille de la base : < 1 000 caches → 1 car. / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gérer les bases de données",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Caractères minimum :",
     "settings_search_debounce_label":              "Délai de debounce (ms) :",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Réglez sur 0 (Auto) pour des seuils adaptatifs selon la taille de la base : < 1 000 caches → 1 car. / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
+    "settings_search_hint":                        "Réglez sur 0 (Auto) pour des seuils adaptatifs : 2 caractères minimum pour toutes les tailles, debounce selon la taille (150 / 250 / 400 ms). Les caractères minimum contrôlent la pertinence ; le debounce contrôle la réactivité.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gérer les bases de données",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -213,6 +213,11 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Nom d'utilisateur :",
     "settings_gc_username_placeholder":            "Votre nom geocaching.com",
     "settings_gc_username_hint":                   "Utilisé pour identifier vos propres logs (ex. détection FTF)",
+    "settings_group_search":                       "Recherche",
+    "settings_search_min_chars_label":             "Caractères minimum :",
+    "settings_search_debounce_label":              "Délai de debounce (ms) :",
+    "settings_search_auto":                        "Auto",
+    "settings_search_hint":                        "Réglez sur 0 (Auto) pour des seuils adaptatifs selon la taille de la base : < 1 000 caches → 1 car. / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gérer les bases de données",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -733,6 +733,7 @@ STRINGS: dict[str, str] = {
     # ── Geocaching.com integration ────────────────────────────────────────────
     "settings_tab_general":         "Général",
     "settings_tab_geocaching":      "Geocaching.com",
+    "settings_tab_advanced":        "Avancé",
     "gc_not_logged_in":             "Non connecté",
     "gc_status_offline":            "Hors ligne",
     "gc_status_online":             "Connecté",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Caractères minimum :",
     "settings_search_debounce_label":              "Délai de debounce (ms) :",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Réglez sur 0 (Auto) pour des seuils adaptatifs : 2 caractères minimum pour toutes les tailles, debounce selon la taille (150 / 250 / 400 ms). Les caractères minimum contrôlent la pertinence ; le debounce contrôle la réactivité.",
+    "settings_search_hint":                        "Réglez sur 0 (Auto) pour des seuils adaptatifs. Atteindre le minimum de caractères déclenche immédiatement ; une pause de debounce déclenche quoi qu'il arrive. < 1 000 caches → 1 car. / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gérer les bases de données",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -213,7 +213,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Nom d'utilisateur :",
     "settings_gc_username_placeholder":            "Votre nom geocaching.com",
     "settings_gc_username_hint":                   "Utilisé pour identifier vos propres logs (ex. détection FTF)",
-    "settings_group_search":                       "Recherche",
+    "settings_group_search":                       "Moteur de recherche",
     "settings_search_min_chars_label":             "Caractères minimum :",
     "settings_search_debounce_label":              "Délai de debounce (ms) :",
     "settings_search_auto":                        "Auto",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Caracteres mínimos:",
     "settings_search_debounce_label":              "Atraso de debounce (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Defina 0 (Auto) para limiares adaptativos: mínimo de 2 caracteres para todos os tamanhos, debounce escala com o tamanho (150 / 250 / 400 ms). Caracteres mínimos controla a relevância; debounce controla a velocidade de resposta.",
+    "settings_search_hint":                        "Defina 0 (Auto) para limiares adaptativos. Atingir o mínimo de caracteres dispara imediatamente; pausar o tempo de debounce dispara de qualquer forma. < 1 000 caches → 1 car. / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gerenciar a base de dados",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -734,6 +734,7 @@ STRINGS: dict[str, str] = {
     # ── Geocaching.com integration ────────────────────────────────────────────
     "settings_tab_general":         "Geral",
     "settings_tab_geocaching":      "Geocaching.com",
+    "settings_tab_advanced":        "Avançado",
     "gc_not_logged_in":             "Sessão não iniciada",
     "gc_status_offline":            "Offline",
     "gc_status_online":             "Ligado",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -213,6 +213,11 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Nome de utilizador:",
     "settings_gc_username_placeholder":            "O seu nome geocaching.com",
     "settings_gc_username_hint":                   "Usado para identificar os seus próprios registos (ex. FTF)",
+    "settings_group_search":                       "Pesquisa",
+    "settings_search_min_chars_label":             "Caracteres mínimos:",
+    "settings_search_debounce_label":              "Atraso de debounce (ms):",
+    "settings_search_auto":                        "Auto",
+    "settings_search_hint":                        "Defina 0 (Auto) para limiares adaptativos que escalam com o tamanho da base de dados: < 1 000 caches → 1 car. / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gerenciar a base de dados",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Caracteres mínimos:",
     "settings_search_debounce_label":              "Atraso de debounce (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Defina 0 (Auto) para limiares adaptativos que escalam com o tamanho da base de dados: < 1 000 caches → 1 car. / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
+    "settings_search_hint":                        "Defina 0 (Auto) para limiares adaptativos que escalam com o tamanho da base de dados: < 1 000 caches → 1 car. / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gerenciar a base de dados",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -213,7 +213,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Nome de utilizador:",
     "settings_gc_username_placeholder":            "O seu nome geocaching.com",
     "settings_gc_username_hint":                   "Usado para identificar os seus próprios registos (ex. FTF)",
-    "settings_group_search":                       "Pesquisa",
+    "settings_group_search":                       "Motor de Pesquisa",
     "settings_search_min_chars_label":             "Caracteres mínimos:",
     "settings_search_debounce_label":              "Atraso de debounce (ms):",
     "settings_search_auto":                        "Auto",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Caracteres mínimos:",
     "settings_search_debounce_label":              "Atraso de debounce (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Defina 0 (Auto) para limiares adaptativos que escalam com o tamanho da base de dados: < 1 000 caches → 1 car. / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
+    "settings_search_hint":                        "Defina 0 (Auto) para limiares adaptativos: mínimo de 2 caracteres para todos os tamanhos, debounce escala com o tamanho (150 / 250 / 400 ms). Caracteres mínimos controla a relevância; debounce controla a velocidade de resposta.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Gerenciar a base de dados",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -213,7 +213,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Användarnamn:",
     "settings_gc_username_placeholder":            "Ditt geocaching.com-användarnamn",
     "settings_gc_username_hint":                   "Används för att identifiera egna loggningar (t.ex. FTF)",
-    "settings_group_search":                       "Sökning",
+    "settings_group_search":                       "Sökmotor",
     "settings_search_min_chars_label":             "Minsta antal tecken:",
     "settings_search_debounce_label":              "Debounce-fördröjning (ms):",
     "settings_search_auto":                        "Auto",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -733,6 +733,7 @@ STRINGS: dict[str, str] = {
     # ── Geocaching.com integration ────────────────────────────────────────────
     "settings_tab_general":         "Allmänt",
     "settings_tab_geocaching":      "Geocaching.com",
+    "settings_tab_advanced":        "Avancerat",
     "gc_not_logged_in":             "Inte inloggad",
     "gc_status_offline":            "Offline",
     "gc_status_online":             "Ansluten",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -213,6 +213,11 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Användarnamn:",
     "settings_gc_username_placeholder":            "Ditt geocaching.com-användarnamn",
     "settings_gc_username_hint":                   "Används för att identifiera egna loggningar (t.ex. FTF)",
+    "settings_group_search":                       "Sökning",
+    "settings_search_min_chars_label":             "Minsta antal tecken:",
+    "settings_search_debounce_label":              "Debounce-fördröjning (ms):",
+    "settings_search_auto":                        "Auto",
+    "settings_search_hint":                        "Sätt till 0 (Auto) för adaptiva trösklar baserade på databasstorlek: < 1 000 cacher → 1 tecken / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Hantera databaser",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minsta antal tecken:",
     "settings_search_debounce_label":              "Debounce-fördröjning (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Sätt till 0 (Auto) för adaptiva trösklar: minst 2 tecken för alla databasstorlekar, debounce skalas med storlek (150 / 250 / 400 ms). Minsta tecken styr relevans; debounce styr skrivrespons.",
+    "settings_search_hint":                        "Sätt till 0 (Auto) för adaptiva trösklar. Nå minsta tecken → utlöses direkt; debounce-paus → utlöses ändå. < 1 000 cacher → 1 tecken / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Hantera databaser",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minsta antal tecken:",
     "settings_search_debounce_label":              "Debounce-fördröjning (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Sätt till 0 (Auto) för adaptiva trösklar baserade på databasstorlek: < 1 000 cacher → 1 tecken / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
+    "settings_search_hint":                        "Sätt till 0 (Auto) för adaptiva trösklar: minst 2 tecken för alla databasstorlekar, debounce skalas med storlek (150 / 250 / 400 ms). Minsta tecken styr relevans; debounce styr skrivrespons.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Hantera databaser",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -217,7 +217,7 @@ STRINGS: dict[str, str] = {
     "settings_search_min_chars_label":             "Minsta antal tecken:",
     "settings_search_debounce_label":              "Debounce-fördröjning (ms):",
     "settings_search_auto":                        "Auto",
-    "settings_search_hint":                        "Sätt till 0 (Auto) för adaptiva trösklar baserade på databasstorlek: < 1 000 cacher → 1 tecken / 200 ms, 1 000–10 000 → 2 / 400 ms, > 10 000 → 3 / 600 ms.",
+    "settings_search_hint":                        "Sätt till 0 (Auto) för adaptiva trösklar baserade på databasstorlek: < 1 000 cacher → 1 tecken / 150 ms, 1 000–10 000 → 1 / 250 ms, > 10 000 → 1 / 400 ms.",
 
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_dialog_title":              "Hantera databaser",


### PR DESCRIPTION
## Adaptive Search Engine

### Problem

The name search field fired a filter on every keystroke after a fixed 300 ms debounce, regardless of database size. On large databases, filtering was done entirely in-memory (all caches iterated in Python per search), causing the UI to stall repeatedly while the user was still typing.

---

### Search behaviour — OR logic

The two controls now have clear, separate responsibilities:

- **Minimum characters** — how much you need to type before the search fires *eagerly* (80 ms after reaching the threshold)
- **Debounce delay** — how long a pause triggers the search *regardless* of how many characters were typed

Clearing the search field always fires immediately.

Adaptive defaults (auto mode) scale with database size:

| Caches | Min chars | Debounce |
|--------|-----------|----------|
| < 1 000 | 1 | 200 ms |
| 1 000 – 10 000 | 2 | 400 ms |
| > 10 000 | 3 | 600 ms |

Both values are user-configurable in **Settings → Advanced → Search Engine**. Setting either to `0` restores the automatic adaptive behaviour.

---

### Performance improvements

**SQL pushdown for name and GC code filters**
`NameFilter` and `GcCodeFilter` now implement `apply_to_query()`, pushing a `WHERE lower(name) LIKE '%x%'` (or `upper(gc_code) LIKE 'GCx%'`) clause into the SQLAlchemy query before `.all()`. SQLite discards non-matching rows before any Python `Cache` objects are constructed — instead of loading all caches and filtering in Python.

**GC code uses prefix match**
GC codes are always searched from the start (`GC12345`), so the query was changed from `LIKE '%GC12%'` to `LIKE 'GC12%'`. This lets SQLite exploit the existing B-tree index on `gc_code`.

**Conditional joinedload**
`apply_filters` was unconditionally loading `attributes` and `trackables` via joinedload for every cache on every search — two expensive multi-row JOINs. They are now only loaded when a filter that actually needs them (`AttributeFilter`, `HasTrackableFilter`) is active. A plain name search skips both entirely.

**Cached DB count**
`_search_thresholds()` previously queried `COUNT(*)` on every keystroke just to pick a debounce value. The count is now stored in `_db_count`, updated once per refresh in `_update_info_bar()`.

---

### Settings dialog

- New **Advanced** tab added to the Settings dialog, dedicated to power-user configuration and extensible for future settings
- **Search Engine** group inside Advanced exposes min chars and debounce as spinboxes; `0` displays as "Auto"
- General tab no longer overflows the screen

---

### Changes

- `settings.py` — `search_min_chars` and `search_debounce_ms` persistent properties (default `0` = adaptive)
- `mainwindow.py` — persistent single-shot `QTimer`; OR logic in `_on_search_changed`; `_search_thresholds()` reads cached count and resolves effective values; `_db_count` updated on every refresh
- `filters/engine.py` — `BaseFilter.apply_to_query()` hook; `NameFilter` and `GcCodeFilter` push SQL clauses; `GcCodeFilter` uses prefix match; `apply_filters` applies SQL-capable filters before `.all()` and skips unnecessary joinedloads
- `settings_dialog.py` — new Advanced tab with Search Engine group
- `lang/*.py` — all keys added and translated across all 7 language files (EN, PT, DA, DE, FR, CS, SE)
