### PR TITLE
Home Location Bugs (new DB, edit persistence, map centering)

### DIFF
--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -595,8 +595,11 @@ class SettingsDialog(QDialog):
                 s.set_active_home(point)
 
         s.add_or_update_home_point(point)
+        s.sync()
 
-        if len(s.home_points) == 1 or not s.active_home_name:
+        is_active = (s.active_home_name == name
+                     or s.active_home_name == self._editing_original_name)
+        if len(s.home_points) == 1 or not s.active_home_name or is_active:
             s.set_active_home(point)
 
         self._editing_original_name = None
@@ -625,6 +628,12 @@ class SettingsDialog(QDialog):
         self._refresh_gc_status_on_open()
 
     def _save(self) -> None:
+        # Auto-commit any in-progress home-point edit when the user clicks OK
+        if self._editing_original_name is not None:
+            self._add_point()
+            if self._editing_original_name is not None:
+                return  # validation failed — keep dialog open
+
         s = get_settings()
         s.gc_username   = self._gc_username.text()
         s.use_miles     = self._miles_cb.isChecked()

--- a/src/opensak/gui/map_widget.py
+++ b/src/opensak/gui/map_widget.py
@@ -366,10 +366,11 @@ class MapWidget(QWidget):
             return
         self._ready = True
 
-        # Sæt hjemkoordinat
+        # Sæt hjemkoordinat og centrér kortet der
         from opensak.gui.settings import get_settings
         s = get_settings()
         self._run_js(f"setHomeLocation({s.home_lat}, {s.home_lon}, {json.dumps(tr('map_home_label'))})")
+        self._run_js("panToHome()")
 
         # Indlæs ventende caches hvis der er nogen
         if self._pending_caches is not None:

--- a/src/opensak/gui/settings.py
+++ b/src/opensak/gui/settings.py
@@ -56,19 +56,29 @@ class AppSettings:
 
     @property
     def home_lat(self) -> float:
-        return float(self._s.value(self._db_key("home_lat"), 55.6761))
+        per_db_key = self._db_key("home_lat")
+        val = self._s.value(per_db_key, None)
+        if val is not None:
+            return float(val)
+        return float(self._s.value("location/home_lat", 55.6761))
 
     @home_lat.setter
     def home_lat(self, value: float) -> None:
         self._s.setValue(self._db_key("home_lat"), value)
+        self._s.setValue("location/home_lat", value)
 
     @property
     def home_lon(self) -> float:
-        return float(self._s.value(self._db_key("home_lon"), 12.5683))
+        per_db_key = self._db_key("home_lon")
+        val = self._s.value(per_db_key, None)
+        if val is not None:
+            return float(val)
+        return float(self._s.value("location/home_lon", 12.5683))
 
     @home_lon.setter
     def home_lon(self, value: float) -> None:
         self._s.setValue(self._db_key("home_lon"), value)
+        self._s.setValue("location/home_lon", value)
 
     # ── Globale hjemmepunkter (liste) ─────────────────────────────────────────
 


### PR DESCRIPTION
# Home location bugs (new DB, edit persistence, map centering)

## Summary

Three related bugs around the home waypoint system, all fixed in this branch.

Fix #183 

---

### 1. New database shows home location in wrong place

**Bug:** Creating a new database always placed the home marker in Copenhagen (Denmark), regardless of any home waypoint the user had previously set.

**Root cause:** `home_lat` / `home_lon` are stored per-database in QSettings. A brand-new database has no entry for those keys, so the hardcoded fallback `55.6761 / 12.5683` (Copenhagen) was used.

**Fix (`settings.py`):** Getters now use a two-level fallback:
1. Per-database key — used when set.
2. Global key (`location/home_lat` / `location/home_lon`) — populated whenever the user sets a home on any database.
3. Copenhagen constant — only if the user has never configured a home at all.

Setters now write to both the per-database key and the global key, so the next new database always inherits the last known home location.

---

### 2. Editing a home waypoint does not persist the new coordinates

**Bug:** Editing a home point in Settings and clicking Save did not update the coordinate shown in the list, and changes were lost on dialog close.

**Root cause (three issues):**

- `add_or_update_home_point` wrote to the in-memory QSettings cache but never called `sync()`, so the data could be lost before the dialog flushed on OK.
- Editing the **active** home point updated the `homepoints/list` JSON blob but never refreshed the separate `home_lat` / `home_lon` keys that the map reads. `set_active_home` (which writes those keys) was only called for new or first-ever points.
- Clicking the dialog **OK** button while an edit was in-progress (form populated, Save not yet clicked) silently discarded the pending changes because `_save()` never inspected the edit state.

**Fix (`settings_dialog.py`):**
- `s.sync()` added immediately after `add_or_update_home_point`.
- `set_active_home` is now also called when saving an edit of the currently active point, keeping `home_lat` / `home_lon` in sync with the list.
- `_save()` (OK handler) auto-commits any in-progress edit before saving the rest of the settings; if coordinate validation fails the dialog stays open instead of closing with unsaved data.

---

### 3. Map does not center on home when the application loads

**Bug:** On startup the map was always centered on the hardcoded coordinates `[56.0, 10.5]` (Denmark), even when a home waypoint was configured.

**Root cause:** `_on_load_finished` called `setHomeLocation` (which places the marker) but never moved the viewport.

**Fix (`map_widget.py`):** After placing the home marker, `panToHome()` is now called. The JS function already existed; it was simply not being invoked on load. When caches are present, `fitAllMarkers` runs afterwards and takes over the viewport as usual.

---

## Main concerns

- **Copenhagen default still exists** as the last-resort fallback in `settings.py`. First-time users (no home ever set) will still see Denmark on the first launch. A future improvement could prompt for home location on first run.
- **`panToHome()` on every load** — if the user had manually panned the map to a different area before closing, the view resets to home on reopen. This is intentional per the feature request, but worth noting as a potential UX trade-off.
- **Auto-commit on OK** — clicking OK while an edit form is open now commits it silently. If the user intended to cancel the edit (not just cancel the dialog), they must use the Cancel button instead. This matches standard dialog conventions but is a behaviour change.
- **No test coverage** — these are QSettings / Qt widget interactions with no automated tests. Manual testing of each scenario (new DB, edit active point, edit inactive point, press OK mid-edit, open app) is required before merging.
