### PR TITLE
Fix Issue 186 - Latest Log column always blank

### DIFF
--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -297,6 +297,29 @@ def _run_migrations(engine: Engine) -> None:
             conn.commit()
             print("Migration: tilføjede caches.owner_name")
 
+        # ── Migration 10: last_log_date (issue #186) ─────────────────────────
+        # Caches the date of the most recent log so the "Latest Log" column can
+        # display it without loading the noload'ed logs relationship.
+        # Populated from existing log data so users don't need to re-import.
+        existing_caches = [
+            row[1]
+            for row in conn.execute(text("PRAGMA table_info(caches)")).fetchall()
+        ]
+        if "last_log_date" not in existing_caches:
+            conn.execute(text(
+                "ALTER TABLE caches ADD COLUMN last_log_date DATETIME"
+            ))
+            result = conn.execute(text("""
+                UPDATE caches
+                SET last_log_date = (
+                    SELECT MAX(log_date)
+                    FROM logs
+                    WHERE logs.cache_id = caches.id
+                )
+            """))
+            conn.commit()
+            print(f"Migration: tilføjede caches.last_log_date og opdaterede {result.rowcount} caches")
+
 
 def dispose_engine(db_path: Path | None = None) -> None:
     """

--- a/src/opensak/db/models.py
+++ b/src/opensak/db/models.py
@@ -127,6 +127,11 @@ class Cache(Base):
     # for performance). Updated automatically on import in _upsert_cache().
     log_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
+    # ── Issue #186: Cached latest log date ───────────────────────────────────
+    # Date of the most recent log entry, cached so the UI can display it
+    # without loading the noload'ed logs relationship. Updated on import.
+    last_log_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
     # Custom waypoint link (issue #141)
     # For CW... entries: optionally links to a parent geocache's gc_code.
     # NULL for all real geocaches imported from GPX/PQ.

--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -659,7 +659,7 @@ SORT_FIELDS: dict[str, Any] = {
     "distance":        lambda c: c.distance or 99999.0,
     "bearing":         lambda c: c.bearing or 0.0,
     "log_count":       lambda c: 0,   # placeholder — model.sort() håndterer det
-    "last_log":        lambda c: 0,
+    "last_log":        lambda c: 0,   # placeholder — model.sort() håndterer det
     "found_date":      lambda c: c.found_date or 0,
     "dnf":             lambda c: int(c.dnf),
     "dnf_date":        lambda c: c.dnf_date or 0,

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -559,15 +559,7 @@ class CacheTableModel(QAbstractTableModel):
         if col == "hidden_date":
             return cache.hidden_date.strftime("%d.%m.%Y") if cache.hidden_date else ""
         if col == "last_log":
-            if cache.logs:
-                latest = max(
-                    (l for l in cache.logs if l.log_date),
-                    key=lambda l: l.log_date,
-                    default=None
-                )
-                if latest:
-                    return latest.log_date.strftime("%d.%m.%Y")
-            return ""
+            return cache.last_log_date.strftime("%d.%m.%Y") if cache.last_log_date else ""
         if col == "log_count":
             # Issue #87: use cached log_count column instead of len(cache.logs)
             # because logs are noload'ed for performance and would always be
@@ -651,6 +643,11 @@ class CacheTableModel(QAbstractTableModel):
             # Issue #87: sort on cached log_count column (logs are noload'ed)
             self._caches.sort(
                 key=lambda c: c.log_count or 0, reverse=reverse
+            )
+        elif col == "last_log":
+            # Issue #186: sort on cached last_log_date column (logs are noload'ed)
+            self._caches.sort(
+                key=lambda c: c.last_log_date or datetime.min, reverse=reverse
             )
         elif col == "hidden_date":
             self._caches.sort(

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -644,6 +644,10 @@ def _upsert_cache(session: Session, data: dict, source_file: str) -> tuple[Cache
     # its length equals the new total count of logs for this cache.
     cache.log_count = len(seen_log_ids)
 
+    # ── Issue #186: Cache latest log date for fast UI display ────────────────
+    log_dates = [lg["log_date"] for lg in data.get("logs", []) if lg.get("log_date")]
+    cache.last_log_date = max(log_dates) if log_dates else None
+
     # Trackables
     for tb in data.get("trackables", []):
         session.add(Trackable(cache=cache, ref=tb["ref"], name=tb["name"]))


### PR DESCRIPTION
## Latest Log column always blank

Fix #186 

### Root cause

`cache.logs` is `noload`'ed by SQLAlchemy for performance — loading all
log rows for every visible cache would be far too slow. This meant the
table-view code that iterated `cache.logs` to find the latest date always
got an empty list and returned `""`.

This is the same root cause that was fixed for the **Log Count** column
in issue #87, which introduced the `log_count` cached column.

### Solution

Follow the same pattern as #87: add a `last_log_date` column to the
`Cache` table that is maintained on import and read directly by the UI.

**Commits:**

1. **Schema + migration** — add `last_log_date DATETIME` to `caches`.
   Migration 10 backfills the value from the existing `logs` table with
   a single `UPDATE … SET last_log_date = (SELECT MAX(log_date) …)`, so
   users don't need to re-import their databases.

2. **Importer** — set `cache.last_log_date` to `max(log_dates)` during
   import, alongside the existing `log_count` update.

3. **UI** — replace the `cache.logs` iteration in the table display with
   a direct read of `cache.last_log_date`. Add a proper `datetime` sort
   case in `model.sort()` so clicking the column header orders by date
   instead of falling through to a string sort.

### Testing

- Import a Pocket Query GPX; the Latest Log column now shows the date of
  the most recent log entry.
- Existing databases are automatically upgraded on first open — no
  re-import required.
- Clicking the Latest Log column header sorts by date ascending/descending.
- All unit tests pass.