### PR TITLE
Update County / State / Country - Phase 2 - online refinement (#60)

### DIFF
--- a/docs/update-location.md
+++ b/docs/update-location.md
@@ -68,4 +68,6 @@ The online checkbox is **unchecked by default**. To have it checked by default f
 
 ## Auto-geocode on import
 
-When importing a GPX or PQ zip file, OpenSAK automatically runs Phase 1 for any waypoints that are missing location data immediately after a successful import — no extra step needed. If **Enable online lookup for higher accuracy** is enabled in Advanced Settings, Phase 2 runs as well.
+When importing a GPX or PQ zip file, OpenSAK automatically runs Phase 1 for any waypoints that are missing location data immediately after a successful import — no extra step needed.
+
+Phase 2 (online lookup) is **never triggered automatically on import**, even if **Enable online lookup for higher accuracy** is turned on in Advanced Settings. To run Phase 2, open the dialog manually via **Waypoint → Update Waypoint Locations…** after the import.

--- a/docs/update-location.md
+++ b/docs/update-location.md
@@ -1,6 +1,6 @@
 # Update Waypoint Locations
 
-OpenSAK can automatically fill in the county, state, and country fields for your waypoints using reverse geocoding. The process runs in two phases — a fast offline pass, followed by an optional online refinement step.
+OpenSAK can automatically fill in the county, state, and country fields for your waypoints using reverse geocoding. It always starts with a fast offline lookup, and optionally follows up with an online refinement for higher accuracy.
 
 ---
 
@@ -33,15 +33,15 @@ Controls how the lookup behaves:
 
 **Use corrected coordinates when available** — when checked (the default), waypoints with a corrected final location are looked up using those coordinates instead of the original listing coordinates. This is the correct behaviour for mystery and multi-caches where the final location differs from the published coordinates.
 
-**Also use online lookup for higher accuracy** — when checked, a second online pass runs after the offline lookup (see Phase 2 below). The initial state of this checkbox is controlled by **Settings → Advanced → Location refinement**; you can always override it per-run.
+**Also use online lookup for higher accuracy** — when checked, an online refinement pass runs after the offline lookup. The initial state of this checkbox is controlled by **Settings → Advanced → Location refinement**; you can always override it per-run.
 
 ---
 
-## Phase 1 — offline lookup (always runs)
+## Offline lookup
 
-Location data comes from [GeoNames](https://www.geonames.org/), a curated global geographic database bundled with the `reverse_geocoder` library. Lookups use a K-D tree that loads once in about one second and then resolves any number of coordinates instantly — no network connection required, no rate limits.
+The offline lookup always runs first. Location data comes from [GeoNames](https://www.geonames.org/), a curated global geographic database bundled with the app. It resolves any number of coordinates instantly — no network connection required, no rate limits.
 
-**Known limitations of Phase 1:**
+**Known limitations:**
 
 - The lookup is point-based (nearest known locality), not polygon-based. Waypoints on or very close to an administrative boundary may resolve to the wrong side.
 - GeoNames data is periodically updated but may not reflect very recent political changes (e.g. county redefinitions).
@@ -49,15 +49,15 @@ Location data comes from [GeoNames](https://www.geonames.org/), a curated global
 
 ---
 
-## Phase 2 — online lookup (opt-in)
+## Online refinement (opt-in)
 
-When **Also use online lookup for higher accuracy** is checked in the Lookup options section, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
+When **Also use online lookup for higher accuracy** is checked, an additional pass runs after the offline lookup using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
 
 **Important notes:**
 
 - Requires an internet connection.
 - Rate-limited to **1 request per second** per Nominatim's usage policy. For large databases this can take a long time (e.g. ~3 hours for 10 000 waypoints).
-- Phase 1 results are always written first. The online pass only overwrites a field if it returns a non-empty value — Phase 1 data is never erased by a failed or empty response.
+- Offline results are always written first. The online pass only overwrites a field if it returns a non-empty value — offline data is never erased by a failed or empty response.
 - Progress and estimated time remaining are shown in the dialog. You can cancel at any time and keep whatever has been refined so far.
 
 ### Setting the default
@@ -68,6 +68,6 @@ The online checkbox is **unchecked by default**. To have it checked by default f
 
 ## Auto-geocode on import
 
-When importing a GPX or PQ zip file, OpenSAK automatically runs Phase 1 for any waypoints that are missing location data immediately after a successful import — no extra step needed.
+When importing a GPX or PQ zip file, OpenSAK automatically runs the offline lookup for any waypoints that are missing location data immediately after a successful import — no extra step needed.
 
-Phase 2 (online lookup) is **never triggered automatically on import**, even if **Enable online lookup for higher accuracy** is turned on in Advanced Settings. To run Phase 2, open the dialog manually via **Waypoint → Update Waypoint Locations…** after the import.
+The online refinement is **never triggered automatically on import**. To run it, open the dialog manually via **Waypoint → Update Waypoint Locations…** after the import.

--- a/docs/update-location.md
+++ b/docs/update-location.md
@@ -39,27 +39,29 @@ Location data comes from [GeoNames](https://www.geonames.org/), a curated global
 
 ---
 
-## Phase 2 — Nominatim refinement (optional, online)
+## Phase 2 — online lookup (opt-in)
 
-Phase 2 is **disabled by default**. To enable it, go to **Settings → Advanced → Location refinement** and tick **Enable Nominatim online refinement**.
-
-Once enabled, an **Also refine with Nominatim** checkbox appears in the update dialog. When ticked, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
+An **Also use online lookup for higher accuracy** checkbox appears in the update dialog. When ticked, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
 
 **Important notes:**
 
 - Requires an internet connection.
 - Rate-limited to **1 request per second** per Nominatim's usage policy. For large databases this can take a long time (e.g. ~3 hours for 10 000 caches).
-- Phase 1 results are always written first. Nominatim only overwrites a field if it returns a non-empty value — Phase 1 data is never erased by a failed or empty Nominatim response.
+- Phase 1 results are always written first. The online pass only overwrites a field if it returns a non-empty value — Phase 1 data is never erased by a failed or empty response.
 - Progress and estimated time remaining are shown in the dialog. You can cancel at any time and keep whatever has been refined so far.
+
+### Setting the default
+
+The checkbox is **unchecked by default**. To have it checked by default for every run, go to **Settings → Advanced → Location refinement** and tick **Enable online lookup for higher accuracy**. You can still toggle it per-run in the dialog regardless of this setting.
 
 ---
 
 ## Updating a single cache
 
-Right-click any cache in the cache list and choose **Update location data…** to run the lookup for that cache only. The same corrected-coordinates logic applies, and the Nominatim checkbox is available here as well.
+Right-click any cache in the cache list and choose **Update location data…** to run the lookup for that cache only. The same corrected-coordinates logic applies, and the online lookup checkbox is available here as well.
 
 ---
 
 ## Auto-geocode on import
 
-When importing a GPX or PQ zip file, the import dialog shows a **Geocode missing location data after import** checkbox. When checked, OpenSAK automatically runs the offline lookup (Phase 1) for any newly imported caches that are missing location fields. This runs as part of the import flow without opening a separate dialog.
+When importing a GPX or PQ zip file, OpenSAK automatically runs Phase 1 for any caches that are missing location data immediately after a successful import — no extra step needed. If **Enable online lookup for higher accuracy** is enabled in Advanced Settings, Phase 2 runs as well.

--- a/docs/update-location.md
+++ b/docs/update-location.md
@@ -1,6 +1,6 @@
 # Update County / State / Country
 
-OpenSAK can automatically fill in the county, state, and country fields for your caches using an offline reverse geocoding lookup. The process is instant for any database size — no network connection required.
+OpenSAK can automatically fill in the county, state, and country fields for your caches using reverse geocoding. The process runs in two phases — a fast offline pass, followed by an optional online refinement step.
 
 ---
 
@@ -27,11 +27,11 @@ When **Use corrected coordinates when available** is checked (the default), cach
 
 ---
 
-## Data source and accuracy
+## Phase 1 — offline lookup (always runs)
 
-Location data comes from [GeoNames](https://www.geonames.org/), a curated global geographic database bundled with the `reverse_geocoder` library. Lookups use a K-D tree that loads once in about one second and then resolves any number of coordinates instantly.
+Location data comes from [GeoNames](https://www.geonames.org/), a curated global geographic database bundled with the `reverse_geocoder` library. Lookups use a K-D tree that loads once in about one second and then resolves any number of coordinates instantly — no network connection required, no rate limits.
 
-**Known limitations:**
+**Known limitations of Phase 1:**
 
 - The lookup is point-based (nearest known locality), not polygon-based. Caches on or very close to an administrative boundary may resolve to the wrong side.
 - GeoNames data is periodically updated but may not reflect very recent political changes (e.g. county redefinitions).
@@ -39,12 +39,25 @@ Location data comes from [GeoNames](https://www.geonames.org/), a curated global
 
 ---
 
+## Phase 2 — Nominatim refinement (optional, online)
+
+When **Also refine with Nominatim** is checked, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
+
+**Important notes:**
+
+- Requires an internet connection.
+- Rate-limited to **1 request per second** per Nominatim's usage policy. For large databases this can take a long time (e.g. ~3 hours for 10 000 caches).
+- Phase 1 results are always written first. Nominatim only overwrites a field if it returns a non-empty value — Phase 1 data is never erased by a failed or empty Nominatim response.
+- Progress and estimated time remaining are shown in the dialog. You can cancel at any time and keep whatever has been refined so far.
+
+---
+
 ## Updating a single cache
 
-Right-click any cache in the cache list and choose **Update County / State / Country** to run the lookup for that cache only. The same scope and corrected-coordinates logic applies.
+Right-click any cache in the cache list and choose **Update location data…** to run the lookup for that cache only. The same corrected-coordinates logic applies, and the Nominatim checkbox is available here as well.
 
 ---
 
 ## Auto-geocode on import
 
-When importing a GPX or PQ zip file, the import dialog shows a **Geocode missing location data after import** checkbox. When checked, OpenSAK automatically runs the offline lookup for any newly imported caches that are missing location fields. This runs as part of the import flow without opening a separate dialog.
+When importing a GPX or PQ zip file, the import dialog shows a **Geocode missing location data after import** checkbox. When checked, OpenSAK automatically runs the offline lookup (Phase 1) for any newly imported caches that are missing location fields. This runs as part of the import flow without opening a separate dialog.

--- a/docs/update-location.md
+++ b/docs/update-location.md
@@ -41,7 +41,9 @@ Location data comes from [GeoNames](https://www.geonames.org/), a curated global
 
 ## Phase 2 — Nominatim refinement (optional, online)
 
-When **Also refine with Nominatim** is checked, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
+Phase 2 is **disabled by default**. To enable it, go to **Settings → Advanced → Location refinement** and tick **Enable Nominatim online refinement**.
+
+Once enabled, an **Also refine with Nominatim** checkbox appears in the update dialog. When ticked, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
 
 **Important notes:**
 

--- a/docs/update-location.md
+++ b/docs/update-location.md
@@ -1,29 +1,39 @@
-# Update County / State / Country
+# Update Waypoint Locations
 
-OpenSAK can automatically fill in the county, state, and country fields for your caches using reverse geocoding. The process runs in two phases — a fast offline pass, followed by an optional online refinement step.
+OpenSAK can automatically fill in the county, state, and country fields for your waypoints using reverse geocoding. The process runs in two phases — a fast offline pass, followed by an optional online refinement step.
 
 ---
 
 ## Opening the dialog
 
-Click **Waypoint → Update County / State / Country**.
+There are two ways to open the dialog, and both open the same window. The difference is the default scope selection:
+
+- **Waypoint menu → Update Waypoint Locations…** — opens with *Only waypoints with missing location data* selected by default.
+- **Right-click a waypoint → Update location data…** — opens with *Only this waypoint* selected by default.
 
 This option is only visible when the `update-location` feature flag is enabled. See [Feature Flags](feature-flags.md) for details.
 
 ---
 
-## Scope options
+## Scope section
+
+Controls which waypoints are processed:
 
 | Option | Behaviour |
 |---|---|
-| **Only caches with missing location data** | Skips caches that already have all three fields filled in. Recommended for most runs. |
-| **Update all caches** | Overwrites existing values for every cache in the database. |
+| **Only this waypoint** | Processes the single waypoint that was right-clicked. Available only when opened via the context menu. |
+| **Only waypoints with missing location data** | Skips waypoints that already have all three fields filled in. Recommended for bulk runs. |
+| **Update all waypoints** | Overwrites existing values for every waypoint in the database. |
 
 ---
 
-## Corrected coordinates
+## Lookup options section
 
-When **Use corrected coordinates when available** is checked (the default), caches with a corrected final waypoint are looked up using those coordinates instead of the original listing coordinates. This is the correct behaviour for mystery and multi-caches where the final location differs from the published coordinates.
+Controls how the lookup behaves:
+
+**Use corrected coordinates when available** — when checked (the default), waypoints with a corrected final location are looked up using those coordinates instead of the original listing coordinates. This is the correct behaviour for mystery and multi-caches where the final location differs from the published coordinates.
+
+**Also use online lookup for higher accuracy** — when checked, a second online pass runs after the offline lookup (see Phase 2 below). The initial state of this checkbox is controlled by **Settings → Advanced → Location refinement**; you can always override it per-run.
 
 ---
 
@@ -33,7 +43,7 @@ Location data comes from [GeoNames](https://www.geonames.org/), a curated global
 
 **Known limitations of Phase 1:**
 
-- The lookup is point-based (nearest known locality), not polygon-based. Caches on or very close to an administrative boundary may resolve to the wrong side.
+- The lookup is point-based (nearest known locality), not polygon-based. Waypoints on or very close to an administrative boundary may resolve to the wrong side.
 - GeoNames data is periodically updated but may not reflect very recent political changes (e.g. county redefinitions).
 - Virginia (USA) has independent cities that are legally separate from the surrounding county. The offline lookup may assign the surrounding county instead of the correct independent city.
 
@@ -41,27 +51,21 @@ Location data comes from [GeoNames](https://www.geonames.org/), a curated global
 
 ## Phase 2 — online lookup (opt-in)
 
-An **Also use online lookup for higher accuracy** checkbox appears in the update dialog. When ticked, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
+When **Also use online lookup for higher accuracy** is checked in the Lookup options section, a second pass runs after Phase 1 using the [Nominatim](https://nominatim.org/) reverse geocoding API (OpenStreetMap polygon data). This provides higher-accuracy results — especially for county — because it uses actual administrative boundary polygons rather than nearest-point matching.
 
 **Important notes:**
 
 - Requires an internet connection.
-- Rate-limited to **1 request per second** per Nominatim's usage policy. For large databases this can take a long time (e.g. ~3 hours for 10 000 caches).
+- Rate-limited to **1 request per second** per Nominatim's usage policy. For large databases this can take a long time (e.g. ~3 hours for 10 000 waypoints).
 - Phase 1 results are always written first. The online pass only overwrites a field if it returns a non-empty value — Phase 1 data is never erased by a failed or empty response.
 - Progress and estimated time remaining are shown in the dialog. You can cancel at any time and keep whatever has been refined so far.
 
 ### Setting the default
 
-The checkbox is **unchecked by default**. To have it checked by default for every run, go to **Settings → Advanced → Location refinement** and tick **Enable online lookup for higher accuracy**. You can still toggle it per-run in the dialog regardless of this setting.
-
----
-
-## Updating a single cache
-
-Right-click any cache in the cache list and choose **Update location data…** to run the lookup for that cache only. The same corrected-coordinates logic applies, and the online lookup checkbox is available here as well.
+The online checkbox is **unchecked by default**. To have it checked by default for every run, go to **Settings → Advanced → Location refinement** and tick **Enable online lookup for higher accuracy**.
 
 ---
 
 ## Auto-geocode on import
 
-When importing a GPX or PQ zip file, OpenSAK automatically runs Phase 1 for any caches that are missing location data immediately after a successful import — no extra step needed. If **Enable online lookup for higher accuracy** is enabled in Advanced Settings, Phase 2 runs as well.
+When importing a GPX or PQ zip file, OpenSAK automatically runs Phase 1 for any waypoints that are missing location data immediately after a successful import — no extra step needed. If **Enable online lookup for higher accuracy** is enabled in Advanced Settings, Phase 2 runs as well.

--- a/src/opensak/geocoder.py
+++ b/src/opensak/geocoder.py
@@ -1,9 +1,12 @@
 """
-src/opensak/geocoder.py — Offline reverse geocoding for OpenSAK.
+src/opensak/geocoder.py — Reverse geocoding for OpenSAK.
 
-Uses the bundled reverse_geocoder KD-tree (GeoNames data).
-Processes tens of thousands of points in under a second with no
-network dependency, no API key, and no rate limits.
+Phase 1 — fast_batch_geocode(): offline, KD-tree (GeoNames), no network,
+processes tens of thousands of points in under a second.
+
+Phase 2 — nominatim_reverse(): single-point lookup via Nominatim/OSM,
+higher accuracy (polygon-based), requires internet, 1 request/second limit.
+Caller is responsible for enforcing the rate limit.
 """
 
 from __future__ import annotations
@@ -46,3 +49,57 @@ def fast_batch_geocode(coords: list[tuple[float, float]]) -> list[GeoLocation]:
         out.append(GeoLocation(country=country, state=state, county=county))
 
     return out
+
+
+def nominatim_reverse(lat: float, lon: float, *, timeout: int = 10) -> GeoLocation:
+    """
+    Query Nominatim reverse geocoding API for a single (lat, lon) coordinate.
+
+    Caller must enforce the 1 request/second rate limit (Nominatim usage policy).
+    Returns whatever fields Nominatim provides; missing fields become None.
+    Falls back to GeoLocation(None, None, None) on any network or parse error.
+    """
+    import json
+    import urllib.parse
+    import urllib.request
+    import pycountry
+
+    params = urllib.parse.urlencode({
+        "lat": lat,
+        "lon": lon,
+        "format": "json",
+        "addressdetails": 1,
+        "zoom": 10,
+    })
+    url = f"https://nominatim.openstreetmap.org/reverse?{params}"
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "OpenSAK/1.0 (https://github.com/AgreeDK/opensak)"},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return GeoLocation(None, None, None)
+
+    address = data.get("address", {})
+
+    cc = address.get("country_code", "").upper()
+    try:
+        country = pycountry.countries.get(alpha_2=cc).name if cc else None
+    except AttributeError:
+        country = address.get("country") or None
+
+    state = address.get("state") or None
+
+    # OSM uses several fields for sub-state regions depending on the country
+    county = (
+        address.get("county")
+        or address.get("district")
+        or address.get("municipality")
+        or address.get("city_district")
+        or None
+    )
+
+    return GeoLocation(country=country, state=state, county=county)

--- a/src/opensak/geocoder.py
+++ b/src/opensak/geocoder.py
@@ -62,7 +62,6 @@ def nominatim_reverse(lat: float, lon: float, *, timeout: int = 10) -> GeoLocati
     import json
     import urllib.parse
     import urllib.request
-    import pycountry
 
     params = urllib.parse.urlencode({
         "lat": lat,
@@ -85,6 +84,7 @@ def nominatim_reverse(lat: float, lon: float, *, timeout: int = 10) -> GeoLocati
 
     address = data.get("address", {})
 
+    import pycountry
     cc = address.get("country_code", "").upper()
     try:
         country = pycountry.countries.get(alpha_2=cc).name if cc else None

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -713,6 +713,7 @@ class CacheTableView(QTableView):
     cache_selected = Signal(object)
     flags_changed = Signal()          # videresendes fra model
     sort_changed = Signal(str, bool)  # (col_id, ascending) videresendes fra model
+    location_updated = Signal()       # emitted after right-click location update
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -993,10 +994,7 @@ class CacheTableView(QTableView):
         """Open UpdateLocationDialog targeted at a single cache."""
         from opensak.gui.dialogs.update_location_dialog import UpdateLocationDialog
         dlg = UpdateLocationDialog(self, gc_codes=[gc_code])
-        dlg.location_updated.connect(lambda: (
-            self._model.beginResetModel(),
-            self._model.endResetModel(),
-        ))
+        dlg.location_updated.connect(self.location_updated)
         dlg.exec()
 
     def selected_cache(self) -> Optional[Cache]:

--- a/src/opensak/gui/dialogs/import_dialog.py
+++ b/src/opensak/gui/dialogs/import_dialog.py
@@ -77,7 +77,6 @@ class ImportDialog(QDialog):
         self.setMinimumHeight(420)
         self._worker: ImportWorker | None = None
         self._geo_worker = None
-        self._online_worker = None
         self._selected_paths: list[Path] = []
         self._any_success = False
         self._setup_ui()
@@ -306,41 +305,9 @@ class ImportDialog(QDialog):
         self._geo_worker.start()
 
     def _on_geocode_done(self, result) -> None:
-        self._append_log(tr(
-            "update_loc_done",
-            updated=result.updated,
-            skipped=result.skipped,
-            errors=result.errors,
-        ))
-        if result.updated > 0:
-            self.import_completed.emit()
-
-        if get_settings().nominatim_enabled:
-            self._start_online_geocoding(self._geocode_rows)
-        else:
-            self._progress.setVisible(False)
-            self._finish_geocoding()
-
-    def _start_online_geocoding(self, rows: list) -> None:
-        from opensak.gui.dialogs.update_location_dialog import OnlineLookupWorker
-
-        self._append_log(tr("import_geocode_online_running"))
-        self._progress.setRange(0, len(rows))
-        self._progress.setValue(0)
-
-        self._online_worker = OnlineLookupWorker(rows)
-        self._online_worker.progress.connect(
-            lambda cur, tot: self._progress.setValue(cur)
-        )
-        self._online_worker.all_done.connect(self._on_online_geocode_done)
-        self._online_worker.cancelled.connect(self._on_online_geocode_done)
-        self._online_worker.finished.connect(self._online_worker.deleteLater)
-        self._online_worker.start()
-
-    def _on_online_geocode_done(self, result) -> None:
         self._progress.setVisible(False)
         self._append_log(tr(
-            "update_loc_online_done",
+            "update_loc_done",
             updated=result.updated,
             skipped=result.skipped,
             errors=result.errors,
@@ -361,15 +328,13 @@ class ImportDialog(QDialog):
         except RuntimeError:
             pass
         self._worker = None
-        for worker in (self._geo_worker, self._online_worker):
-            try:
-                if worker and worker.isRunning():
-                    worker.request_cancel()
-                    worker.wait(3000)
-            except RuntimeError:
-                pass
+        try:
+            if self._geo_worker and self._geo_worker.isRunning():
+                self._geo_worker.request_cancel()
+                self._geo_worker.wait(3000)
+        except RuntimeError:
+            pass
         self._geo_worker = None
-        self._online_worker = None
         super().closeEvent(event)
 
     # ── Log helpers ───────────────────────────────────────────────────────────

--- a/src/opensak/gui/dialogs/import_dialog.py
+++ b/src/opensak/gui/dialogs/import_dialog.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QFileDialog, QProgressBar,
     QTextEdit, QListWidget, QListWidgetItem,
-    QAbstractItemView, QCheckBox
+    QAbstractItemView,
 )
 
 from opensak.gui.settings import get_settings
@@ -76,7 +76,8 @@ class ImportDialog(QDialog):
         self.setMinimumWidth(540)
         self.setMinimumHeight(420)
         self._worker: ImportWorker | None = None
-        self._geo_worker = None   # ReverseGeocodeWorker, set after import if needed
+        self._geo_worker = None
+        self._online_worker = None
         self._selected_paths: list[Path] = []
         self._any_success = False
         self._setup_ui()
@@ -120,13 +121,6 @@ class ImportDialog(QDialog):
         btn_row.addWidget(self._close_btn)
 
         layout.addLayout(btn_row)
-
-        # ── Geocode option ────────────────────────────────────────────────────
-        from opensak.utils import flags
-        self._cb_geocode = QCheckBox(tr("import_geocode_checkbox"))
-        self._cb_geocode.setChecked(True)
-        self._cb_geocode.setVisible(flags.update_location)
-        layout.addWidget(self._cb_geocode)
 
         # ── Progress ──────────────────────────────────────────────────────────
         self._progress = QProgressBar()
@@ -192,7 +186,6 @@ class ImportDialog(QDialog):
         self._import_btn.setEnabled(False)
         self._browse_btn.setEnabled(False)
         self._remove_btn.setEnabled(False)
-        self._cb_geocode.setEnabled(False)
         self._progress.setVisible(True)
         self._any_success = False
         self._log.clear()
@@ -264,13 +257,12 @@ class ImportDialog(QDialog):
             self.import_completed.emit()
 
         from opensak.utils import flags
-        if flags.update_location and self._any_success and self._cb_geocode.isChecked():
+        if flags.update_location and self._any_success:
             self._start_geocoding()
         else:
             self._browse_btn.setEnabled(True)
             self._import_btn.setText(tr("import_again"))
             self._import_btn.setEnabled(True)
-            self._cb_geocode.setEnabled(True)
 
     def _start_geocoding(self) -> None:
         from opensak.gui.dialogs.update_location_dialog import (
@@ -300,39 +292,67 @@ class ImportDialog(QDialog):
                     rows.append(_CacheRow(gc_code=cache.gc_code, lat=lat, lon=lon))
 
         if not rows:
-            self._browse_btn.setEnabled(True)
-            self._import_btn.setText(tr("import_again"))
-            self._import_btn.setEnabled(True)
-            self._cb_geocode.setEnabled(True)
+            self._finish_geocoding()
             return
 
-        self._progress.setRange(0, len(rows))
-        self._progress.setValue(0)
+        self._progress.setRange(0, 0)  # indeterminate — batch runs instantly
         self._progress.setVisible(True)
+        self._geocode_rows = rows
 
         self._geo_worker = ReverseGeocodeWorker(rows)
-        self._geo_worker.progress.connect(lambda cur, tot: self._progress.setValue(cur))
-        self._geo_worker.row_done.connect(lambda _gc, line: self._append_log(line))
         self._geo_worker.all_done.connect(self._on_geocode_done)
         self._geo_worker.cancelled.connect(self._on_geocode_done)
         self._geo_worker.finished.connect(self._geo_worker.deleteLater)
         self._geo_worker.start()
 
     def _on_geocode_done(self, result) -> None:
-        self._progress.setVisible(False)
-        summary = tr(
+        self._append_log(tr(
             "update_loc_done",
             updated=result.updated,
             skipped=result.skipped,
             errors=result.errors,
-        )
-        self._append_log(summary)
+        ))
         if result.updated > 0:
             self.import_completed.emit()
+
+        if get_settings().nominatim_enabled:
+            self._start_online_geocoding(self._geocode_rows)
+        else:
+            self._progress.setVisible(False)
+            self._finish_geocoding()
+
+    def _start_online_geocoding(self, rows: list) -> None:
+        from opensak.gui.dialogs.update_location_dialog import OnlineLookupWorker
+
+        self._append_log(tr("import_geocode_online_running"))
+        self._progress.setRange(0, len(rows))
+        self._progress.setValue(0)
+
+        self._online_worker = OnlineLookupWorker(rows)
+        self._online_worker.progress.connect(
+            lambda cur, tot: self._progress.setValue(cur)
+        )
+        self._online_worker.all_done.connect(self._on_online_geocode_done)
+        self._online_worker.cancelled.connect(self._on_online_geocode_done)
+        self._online_worker.finished.connect(self._online_worker.deleteLater)
+        self._online_worker.start()
+
+    def _on_online_geocode_done(self, result) -> None:
+        self._progress.setVisible(False)
+        self._append_log(tr(
+            "update_loc_online_done",
+            updated=result.updated,
+            skipped=result.skipped,
+            errors=result.errors,
+        ))
+        if result.updated > 0:
+            self.import_completed.emit()
+        self._finish_geocoding()
+
+    def _finish_geocoding(self) -> None:
         self._browse_btn.setEnabled(True)
         self._import_btn.setText(tr("import_again"))
         self._import_btn.setEnabled(True)
-        self._cb_geocode.setEnabled(True)
 
     def closeEvent(self, event) -> None:
         try:
@@ -341,13 +361,15 @@ class ImportDialog(QDialog):
         except RuntimeError:
             pass
         self._worker = None
-        try:
-            if self._geo_worker and self._geo_worker.isRunning():
-                self._geo_worker.request_cancel()
-                self._geo_worker.wait(3000)
-        except RuntimeError:
-            pass
+        for worker in (self._geo_worker, self._online_worker):
+            try:
+                if worker and worker.isRunning():
+                    worker.request_cancel()
+                    worker.wait(3000)
+            except RuntimeError:
+                pass
         self._geo_worker = None
+        self._online_worker = None
         super().closeEvent(event)
 
     # ── Log helpers ───────────────────────────────────────────────────────────

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -301,6 +301,25 @@ class SettingsDialog(QDialog):
         search_layout.addWidget(search_hint)
 
         layout.addWidget(search_group)
+
+        # ── Location refinement (only shown when update-location flag is on) ──
+        from opensak.utils import flags
+        if flags.update_location:
+            loc_ref_group = QGroupBox(tr("settings_group_nominatim"))
+            loc_ref_layout = QVBoxLayout(loc_ref_group)
+
+            self._nominatim_cb = QCheckBox(tr("settings_nominatim_cb"))
+            loc_ref_layout.addWidget(self._nominatim_cb)
+
+            nominatim_hint = QLabel(tr("settings_nominatim_hint"))
+            nominatim_hint.setWordWrap(True)
+            nominatim_hint.setStyleSheet("color: gray; font-size: 10px;")
+            loc_ref_layout.addWidget(nominatim_hint)
+
+            layout.addWidget(loc_ref_group)
+        else:
+            self._nominatim_cb = None
+
         layout.addStretch()
         return tab
 
@@ -670,6 +689,8 @@ class SettingsDialog(QDialog):
         self._gc_username.setText(s.gc_username)
         self._search_min_chars.setValue(s.search_min_chars)
         self._search_debounce_ms.setValue(s.search_debounce_ms)
+        if self._nominatim_cb is not None:
+            self._nominatim_cb.setChecked(s.nominatim_enabled)
         # Opdater GC-status
         self._refresh_gc_status_on_open()
 
@@ -689,6 +710,8 @@ class SettingsDialog(QDialog):
         s.coord_format      = self._coord_format.currentData()
         s.search_min_chars  = self._search_min_chars.value()
         s.search_debounce_ms = self._search_debounce_ms.value()
+        if self._nominatim_cb is not None:
+            s.nominatim_enabled = self._nominatim_cb.isChecked()
         s.sync()
 
         new_lang = self._lang_combo.currentData()

--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -241,7 +241,7 @@ class UpdateLocationDialog(QDialog):
     # ── UI ────────────────────────────────────────────────────────────────────
 
     def _setup_ui(self) -> None:
-        from opensak.utils import flags
+        from opensak.gui.settings import get_settings
 
         layout = QVBoxLayout(self)
         layout.setSpacing(10)
@@ -269,8 +269,8 @@ class UpdateLocationDialog(QDialog):
         self._cb_corrected.setChecked(True)
         layout.addWidget(self._cb_corrected)
 
-        # Nominatim checkbox — shown whenever the update-location flag is active
-        if flags.update_location:
+        # Nominatim checkbox — shown only when the user has enabled it in Advanced Settings
+        if get_settings().nominatim_enabled:
             self._cb_nominatim = QCheckBox(tr("update_loc_nominatim_cb"))
             self._cb_nominatim.setChecked(False)
             self._cb_nominatim.setToolTip(tr("update_loc_nominatim_tooltip"))

--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -1,13 +1,13 @@
 """
-src/opensak/gui/dialogs/update_location_dialog.py — Update county/state/country dialog.
+src/opensak/gui/dialogs/update_location_dialog.py — Update cache locations dialog.
 
 Two-phase reverse geocoding:
   Phase 1 (always): offline KD-tree (GeoNames), instant, no network.
   Phase 2 (opt-in): online OpenStreetMap lookup, 1 req/sec.
 
-Can be opened two ways:
-  - Bulk (no gc_codes): shows scope options, user picks all vs. missing-only.
-  - Single/selection (gc_codes list): compact mode, scope group hidden.
+Always opened as the same dialog; entry point controls the default scope:
+  - Via menu (gc_codes=None): "Only caches with missing location data" is default.
+  - Via right-click (gc_codes list): "Only this cache" is default.
 """
 
 from __future__ import annotations
@@ -212,13 +212,14 @@ class OnlineLookupWorker(QThread):
 
 class UpdateLocationDialog(QDialog):
     """
-    Dialog to update county/state/country via reverse geocoding.
+    Dialog to update cache locations via reverse geocoding.
 
     Phase 1 (always active): offline GeoNames KD-tree — instant.
     Phase 2 (opt-in): online OpenStreetMap lookup — 1 req/sec.
 
-    Bulk mode (gc_codes=None): full dialog with scope options and log.
-    Single/selection mode (gc_codes list): compact dialog, no log.
+    The same dialog is used from the menu and from the right-click context menu.
+    When gc_codes is None (menu): "Only caches with missing location data" is default.
+    When gc_codes is a list (right-click): "Only this cache" is default.
     """
 
     location_updated = Signal()
@@ -226,9 +227,10 @@ class UpdateLocationDialog(QDialog):
     def __init__(self, parent=None, *, gc_codes: list[str] | None = None):
         super().__init__(parent)
         self._gc_codes = gc_codes
-        self._is_single = gc_codes is not None
+        self._from_context_menu = gc_codes is not None
         self.setWindowTitle(tr("update_loc_title"))
         self.setMinimumWidth(460)
+        self.setMinimumHeight(420)
         self._worker: ReverseGeocodeWorker | OnlineLookupWorker | None = None
         self._pending_rows: list[_CacheRow] = []
         self._setup_ui()
@@ -248,23 +250,34 @@ class UpdateLocationDialog(QDialog):
         self._info_label.setStyleSheet("color: palette(mid);")
         layout.addWidget(self._info_label)
 
-        # ── Scope (bulk mode only) ────────────────────────────────────────────
+        # ── Section 1: Scope ──────────────────────────────────────────────────
         self._scope_box = QGroupBox(tr("update_loc_scope_group"))
         scope_layout = QVBoxLayout(self._scope_box)
-        self._rb_all = QRadioButton(tr("update_loc_scope_all"))
+
+        self._rb_this = QRadioButton(tr("update_loc_scope_this"))
         self._rb_missing = QRadioButton(tr("update_loc_scope_missing"))
-        self._rb_missing.setChecked(True)
-        scope_layout.addWidget(self._rb_all)
+        self._rb_all = QRadioButton(tr("update_loc_scope_all"))
+
+        scope_layout.addWidget(self._rb_this)
         scope_layout.addWidget(self._rb_missing)
+        scope_layout.addWidget(self._rb_all)
         layout.addWidget(self._scope_box)
 
-        if self._is_single:
-            self._scope_box.setVisible(False)
+        if self._from_context_menu:
+            # Right-click: default to "Only this cache"
+            self._rb_this.setChecked(True)
+        else:
+            # Menu: "Only this cache" is irrelevant — disable and default to missing
+            self._rb_this.setEnabled(False)
+            self._rb_missing.setChecked(True)
 
-        # ── Options ───────────────────────────────────────────────────────────
+        # ── Section 2: Lookup options ─────────────────────────────────────────
+        self._lookup_box = QGroupBox(tr("update_loc_lookup_group"))
+        lookup_layout = QVBoxLayout(self._lookup_box)
+
         self._cb_corrected = QCheckBox(tr("update_loc_use_corrected"))
         self._cb_corrected.setChecked(True)
-        layout.addWidget(self._cb_corrected)
+        lookup_layout.addWidget(self._cb_corrected)
 
         # Online lookup checkbox — always visible when flag is on;
         # initial state comes from the Advanced Settings default.
@@ -273,11 +286,12 @@ class UpdateLocationDialog(QDialog):
             self._cb_online.setChecked(get_settings().nominatim_enabled)
             self._cb_online.setToolTip(tr("update_loc_online_tooltip"))
             self._cb_online.stateChanged.connect(self._on_online_toggled)
-            layout.addWidget(self._cb_online)
-            # Sync info text with initial checkbox state
+            lookup_layout.addWidget(self._cb_online)
             self._on_online_toggled()
         else:
             self._cb_online = None
+
+        layout.addWidget(self._lookup_box)
 
         # ── Progress ──────────────────────────────────────────────────────────
         self._progress_label = QLabel("")
@@ -289,15 +303,11 @@ class UpdateLocationDialog(QDialog):
         self._progress.setVisible(False)
         layout.addWidget(self._progress)
 
-        # ── Log (bulk mode only — hidden for single-cache to reduce verbosity) ─
-        if not self._is_single:
-            self._log = QTextEdit()
-            self._log.setReadOnly(True)
-            self._log.setPlaceholderText(tr("update_loc_log_placeholder"))
-            layout.addWidget(self._log)
-            self.setMinimumHeight(420)
-        else:
-            self._log = None
+        # ── Log ───────────────────────────────────────────────────────────────
+        self._log = QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setPlaceholderText(tr("update_loc_log_placeholder"))
+        layout.addWidget(self._log)
 
         # ── Buttons ───────────────────────────────────────────────────────────
         btn_row = QHBoxLayout()
@@ -335,7 +345,6 @@ class UpdateLocationDialog(QDialog):
         from sqlalchemy.orm import joinedload
 
         use_corrected = self._cb_corrected.isChecked()
-        only_missing  = self._rb_missing.isChecked()
 
         rows: list[_CacheRow] = []
         with get_session() as session:
@@ -343,14 +352,15 @@ class UpdateLocationDialog(QDialog):
             if use_corrected:
                 query = query.options(joinedload(Cache.user_note))
 
-            if self._gc_codes is not None:
+            if self._rb_this.isChecked() and self._gc_codes is not None:
                 query = query.filter(Cache.gc_code.in_(self._gc_codes))
-            elif only_missing:
+            elif self._rb_missing.isChecked():
                 query = query.filter(
                     (Cache.country == None) | (Cache.country == "") |
                     (Cache.state   == None) | (Cache.state   == "") |
                     (Cache.county  == None) | (Cache.county  == "")
                 )
+            # _rb_all: no filter
 
             for cache in query.all():
                 lat, lon = cache.latitude, cache.longitude
@@ -378,8 +388,7 @@ class UpdateLocationDialog(QDialog):
 
         self._progress.setRange(0, 0)
         self._progress.setVisible(True)
-        if self._log:
-            self._log.clear()
+        self._log.clear()
         self._progress_label.setText(tr("update_loc_running", total=len(rows)))
 
         self._worker = ReverseGeocodeWorker(rows)
@@ -408,8 +417,7 @@ class UpdateLocationDialog(QDialog):
     # ── Worker signals — Phase 1 ──────────────────────────────────────────────
 
     def _on_row_done(self, _gc_code: str, line: str) -> None:
-        if self._log:
-            self._log.append(line)
+        self._log.append(line)
 
     def _on_phase1_done(self, result: UpdateLocationResult) -> None:
         self.location_updated.emit()
@@ -472,15 +480,16 @@ class UpdateLocationDialog(QDialog):
     def _set_controls_enabled(self, enabled: bool) -> None:
         self._start_btn.setEnabled(enabled)
         self._scope_box.setEnabled(enabled)
-        self._cb_corrected.setEnabled(enabled)
-        if self._cb_online is not None:
-            self._cb_online.setEnabled(enabled)
+        self._lookup_box.setEnabled(enabled)
         self._cancel_btn.setEnabled(not enabled)
         self._close_btn.setEnabled(enabled)
 
     def _finalize(self) -> None:
         self._progress.setVisible(False)
         self._set_controls_enabled(True)
+        # Re-disable "Only this cache" if opened from menu
+        if not self._from_context_menu:
+            self._rb_this.setEnabled(False)
 
     def closeEvent(self, event) -> None:
         if self._worker and self._worker.isRunning():

--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -1,8 +1,9 @@
 """
 src/opensak/gui/dialogs/update_location_dialog.py — Update county/state/country dialog.
 
-Runs a fully offline background reverse-geocode pass over caches using a
-KD-tree (GeoNames data). Instant for any number of caches, no network required.
+Two-phase reverse geocoding:
+  Phase 1 (always): offline KD-tree (GeoNames), instant, no network.
+  Phase 2 (optional, flag-gated): Nominatim OSM API, 1 req/sec, online.
 
 Can be opened two ways:
   - Bulk (no gc_codes): shows scope options, user picks all vs. missing-only.
@@ -11,6 +12,7 @@ Can be opened two ways:
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 
 from PySide6.QtCore import Qt, QThread, Signal
@@ -42,11 +44,25 @@ class UpdateLocationResult:
     error_msgs: list[str] = field(default_factory=list)
 
 
-# ── Worker ────────────────────────────────────────────────────────────────────
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _format_eta(remaining_seconds: int) -> str:
+    if remaining_seconds < 60:
+        return tr("update_loc_eta_sec", n=remaining_seconds)
+    elif remaining_seconds < 3600:
+        m, s = divmod(remaining_seconds, 60)
+        return tr("update_loc_eta_min", m=m, s=s)
+    else:
+        h, rem = divmod(remaining_seconds, 3600)
+        m = rem // 60
+        return tr("update_loc_eta_hr", h=h, m=m)
+
+
+# ── Workers ───────────────────────────────────────────────────────────────────
 
 class ReverseGeocodeWorker(QThread):
     """
-    Offline geocoding worker using the reverse_geocoder KD-tree (GeoNames).
+    Phase 1: offline geocoding using the reverse_geocoder KD-tree (GeoNames).
 
     Fills country + state + county for all rows in a single batch call.
     No network, no rate limit — runs in under a second for any database size.
@@ -106,11 +122,100 @@ class ReverseGeocodeWorker(QThread):
         self.all_done.emit(result)
 
 
+class NominatimWorker(QThread):
+    """
+    Phase 2: Nominatim reverse geocoding at 1 request/second (Nominatim ToS).
+
+    Refines county/state/country for each cache using OSM polygon boundaries.
+    Requires internet. Only non-None fields returned by Nominatim are written
+    back, so Phase 1 data is never erased by a failed/empty Nominatim response.
+    """
+
+    row_done  = Signal(str, str)   # (gc_code, log_line)
+    progress  = Signal(int, int)   # (done, total)
+    all_done  = Signal(object)     # UpdateLocationResult
+    cancelled = Signal(object)     # UpdateLocationResult
+
+    def __init__(self, rows: list[_CacheRow], *, parent=None):
+        super().__init__(parent)
+        self._rows = rows
+        self._cancel = False
+
+    def request_cancel(self) -> None:
+        self._cancel = True
+
+    def run(self) -> None:
+        from opensak.geocoder import nominatim_reverse
+        from opensak.db.database import get_session
+        from opensak.db.models import Cache
+
+        result = UpdateLocationResult()
+        total = len(self._rows)
+
+        for i, row in enumerate(self._rows):
+            if self._cancel:
+                self.cancelled.emit(result)
+                return
+
+            t0 = time.monotonic()
+            loc = nominatim_reverse(row.lat, row.lon)
+            elapsed = time.monotonic() - t0
+
+            if loc.country is None and loc.state is None and loc.county is None:
+                result.skipped += 1
+                self.row_done.emit(
+                    row.gc_code,
+                    tr("update_loc_nominatim_skip", gc_code=row.gc_code),
+                )
+            else:
+                try:
+                    with get_session() as session:
+                        cache = session.query(Cache).filter_by(gc_code=row.gc_code).first()
+                        if cache:
+                            if loc.country is not None:
+                                cache.country = loc.country
+                            if loc.state is not None:
+                                cache.state = loc.state
+                            if loc.county is not None:
+                                cache.county = loc.county
+                            result.updated += 1
+                            self.row_done.emit(
+                                row.gc_code,
+                                tr(
+                                    "update_loc_nominatim_row",
+                                    gc_code=row.gc_code,
+                                    county=loc.county or "–",
+                                ),
+                            )
+                except Exception as exc:
+                    result.errors += 1
+                    self.row_done.emit(
+                        "",
+                        tr("update_loc_row_error", gc_code=row.gc_code, msg=str(exc)),
+                    )
+
+            self.progress.emit(i + 1, total)
+
+            # Maintain 1 req/sec; sleep in small steps to allow cancellation
+            if i < total - 1:
+                deadline = t0 + 1.0
+                while time.monotonic() < deadline:
+                    if self._cancel:
+                        self.cancelled.emit(result)
+                        return
+                    time.sleep(0.05)
+
+        self.all_done.emit(result)
+
+
 # ── Dialog ────────────────────────────────────────────────────────────────────
 
 class UpdateLocationDialog(QDialog):
     """
-    Dialog to update county/state/country via offline reverse geocoding.
+    Dialog to update county/state/country via reverse geocoding.
+
+    Phase 1 (always active): offline GeoNames KD-tree — instant.
+    Phase 2 (opt-in, flag-gated): Nominatim OSM API — 1 req/sec, online.
 
     When gc_codes is None: full bulk mode — scope options are shown.
     When gc_codes is a list: targeted mode — scope group is hidden and only
@@ -125,7 +230,8 @@ class UpdateLocationDialog(QDialog):
         self.setWindowTitle(tr("update_loc_title"))
         self.setMinimumWidth(520)
         self.setMinimumHeight(480)
-        self._worker: ReverseGeocodeWorker | None = None
+        self._worker: ReverseGeocodeWorker | NominatimWorker | None = None
+        self._pending_rows: list[_CacheRow] = []
         self._setup_ui()
 
         # In targeted mode, hide the scope controls — they don't apply.
@@ -135,6 +241,8 @@ class UpdateLocationDialog(QDialog):
     # ── UI ────────────────────────────────────────────────────────────────────
 
     def _setup_ui(self) -> None:
+        from opensak.utils import flags
+
         layout = QVBoxLayout(self)
         layout.setSpacing(10)
 
@@ -161,13 +269,22 @@ class UpdateLocationDialog(QDialog):
         self._cb_corrected.setChecked(True)
         layout.addWidget(self._cb_corrected)
 
+        # Nominatim checkbox — shown whenever the update-location flag is active
+        if flags.update_location:
+            self._cb_nominatim = QCheckBox(tr("update_loc_nominatim_cb"))
+            self._cb_nominatim.setChecked(False)
+            self._cb_nominatim.setToolTip(tr("update_loc_nominatim_tooltip"))
+            layout.addWidget(self._cb_nominatim)
+        else:
+            self._cb_nominatim = None
+
         # ── Progress ──────────────────────────────────────────────────────────
         self._progress_label = QLabel("")
         self._progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._progress_label)
 
         self._progress = QProgressBar()
-        self._progress.setRange(0, 0)  # indeterminate — batch runs instantly
+        self._progress.setRange(0, 0)  # indeterminate during Phase 1
         self._progress.setVisible(False)
         layout.addWidget(self._progress)
 
@@ -246,20 +363,37 @@ class UpdateLocationDialog(QDialog):
             self._log.setPlainText(tr("update_loc_nothing_to_do"))
             return
 
+        self._pending_rows = rows
+
         self._start_btn.setEnabled(False)
         self._scope_box.setEnabled(False)
         self._cb_corrected.setEnabled(False)
+        if self._cb_nominatim is not None:
+            self._cb_nominatim.setEnabled(False)
         self._cancel_btn.setEnabled(True)
         self._close_btn.setEnabled(False)
 
+        self._progress.setRange(0, 0)  # indeterminate for Phase 1
         self._progress.setVisible(True)
         self._log.clear()
         self._progress_label.setText(tr("update_loc_running", total=len(rows)))
 
         self._worker = ReverseGeocodeWorker(rows)
         self._worker.row_done.connect(self._on_row_done)
-        self._worker.all_done.connect(self._on_done)
-        self._worker.cancelled.connect(self._on_cancelled)
+        self._worker.all_done.connect(self._on_phase1_done)
+        self._worker.cancelled.connect(self._on_phase1_cancelled)
+        self._worker.start()
+
+    def _start_phase2(self, rows: list[_CacheRow]) -> None:
+        self._progress.setRange(0, len(rows))
+        self._progress.setValue(0)
+        self._cancel_btn.setEnabled(True)
+
+        self._worker = NominatimWorker(rows)
+        self._worker.row_done.connect(self._on_row_done)
+        self._worker.progress.connect(self._on_nominatim_progress)
+        self._worker.all_done.connect(self._on_nominatim_done)
+        self._worker.cancelled.connect(self._on_nominatim_cancelled)
         self._worker.start()
 
     def _request_cancel(self) -> None:
@@ -267,32 +401,78 @@ class UpdateLocationDialog(QDialog):
             self._worker.request_cancel()
         self._cancel_btn.setEnabled(False)
 
-    # ── Worker signals ────────────────────────────────────────────────────────
+    # ── Worker signals — Phase 1 ──────────────────────────────────────────────
 
     def _on_row_done(self, _gc_code: str, line: str) -> None:
         self._log.append(line)
 
-    def _on_done(self, result: UpdateLocationResult) -> None:
+    def _on_phase1_done(self, result: UpdateLocationResult) -> None:
+        self.location_updated.emit()
+
+        nominatim_requested = (
+            self._cb_nominatim is not None and self._cb_nominatim.isChecked()
+        )
+        if nominatim_requested and self._pending_rows:
+            self._progress_label.setText(tr(
+                "update_loc_phase1_done",
+                updated=result.updated,
+            ))
+            self._start_phase2(self._pending_rows)
+        else:
+            self._finalize()
+            self._progress_label.setText(tr(
+                "update_loc_done",
+                updated=result.updated,
+                skipped=result.skipped,
+                errors=result.errors,
+            ))
+
+    def _on_phase1_cancelled(self, result: UpdateLocationResult) -> None:
+        self._finalize()
+        self._progress_label.setText(tr("update_loc_cancelled", updated=result.updated))
+        if result.updated > 0:
+            self.location_updated.emit()
+
+    # ── Worker signals — Phase 2 ──────────────────────────────────────────────
+
+    def _on_nominatim_progress(self, done: int, total: int) -> None:
+        self._progress.setValue(done)
+        eta = _format_eta(total - done)
+        self._progress_label.setText(tr(
+            "update_loc_nominatim_running",
+            done=done,
+            total=total,
+            eta=eta,
+        ))
+
+    def _on_nominatim_done(self, result: UpdateLocationResult) -> None:
         self._finalize()
         self._progress_label.setText(tr(
-            "update_loc_done",
+            "update_loc_nominatim_done",
             updated=result.updated,
             skipped=result.skipped,
             errors=result.errors,
         ))
         self.location_updated.emit()
 
-    def _on_cancelled(self, result: UpdateLocationResult) -> None:
+    def _on_nominatim_cancelled(self, result: UpdateLocationResult) -> None:
         self._finalize()
-        self._progress_label.setText(tr("update_loc_cancelled", updated=result.updated))
+        self._progress_label.setText(tr(
+            "update_loc_nominatim_cancelled",
+            updated=result.updated,
+        ))
         if result.updated > 0:
             self.location_updated.emit()
+
+    # ── Shared finalization ───────────────────────────────────────────────────
 
     def _finalize(self) -> None:
         self._progress.setVisible(False)
         self._start_btn.setEnabled(True)
         self._scope_box.setEnabled(True)
         self._cb_corrected.setEnabled(True)
+        if self._cb_nominatim is not None:
+            self._cb_nominatim.setEnabled(True)
         self._cancel_btn.setEnabled(False)
         self._close_btn.setEnabled(True)
 

--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -3,11 +3,11 @@ src/opensak/gui/dialogs/update_location_dialog.py — Update county/state/countr
 
 Two-phase reverse geocoding:
   Phase 1 (always): offline KD-tree (GeoNames), instant, no network.
-  Phase 2 (optional, flag-gated): Nominatim OSM API, 1 req/sec, online.
+  Phase 2 (opt-in): online OpenStreetMap lookup, 1 req/sec.
 
 Can be opened two ways:
   - Bulk (no gc_codes): shows scope options, user picks all vs. missing-only.
-  - Single/selection (gc_codes list): hides scope group, targets only those caches.
+  - Single/selection (gc_codes list): compact mode, scope group hidden.
 """
 
 from __future__ import annotations
@@ -122,13 +122,13 @@ class ReverseGeocodeWorker(QThread):
         self.all_done.emit(result)
 
 
-class NominatimWorker(QThread):
+class OnlineLookupWorker(QThread):
     """
-    Phase 2: Nominatim reverse geocoding at 1 request/second (Nominatim ToS).
+    Phase 2: online lookup via OpenStreetMap at 1 request/second.
 
     Refines county/state/country for each cache using OSM polygon boundaries.
-    Requires internet. Only non-None fields returned by Nominatim are written
-    back, so Phase 1 data is never erased by a failed/empty Nominatim response.
+    Requires internet. Only non-None fields are written back, so Phase 1 data
+    is never erased by a failed or empty online response.
     """
 
     row_done  = Signal(str, str)   # (gc_code, log_line)
@@ -165,7 +165,7 @@ class NominatimWorker(QThread):
                 result.skipped += 1
                 self.row_done.emit(
                     row.gc_code,
-                    tr("update_loc_nominatim_skip", gc_code=row.gc_code),
+                    tr("update_loc_online_skip", gc_code=row.gc_code),
                 )
             else:
                 try:
@@ -182,7 +182,7 @@ class NominatimWorker(QThread):
                             self.row_done.emit(
                                 row.gc_code,
                                 tr(
-                                    "update_loc_nominatim_row",
+                                    "update_loc_online_row",
                                     gc_code=row.gc_code,
                                     county=loc.county or "–",
                                 ),
@@ -215,11 +215,10 @@ class UpdateLocationDialog(QDialog):
     Dialog to update county/state/country via reverse geocoding.
 
     Phase 1 (always active): offline GeoNames KD-tree — instant.
-    Phase 2 (opt-in, flag-gated): Nominatim OSM API — 1 req/sec, online.
+    Phase 2 (opt-in): online OpenStreetMap lookup — 1 req/sec.
 
-    When gc_codes is None: full bulk mode — scope options are shown.
-    When gc_codes is a list: targeted mode — scope group is hidden and only
-    those specific caches are processed.
+    Bulk mode (gc_codes=None): full dialog with scope options and log.
+    Single/selection mode (gc_codes list): compact dialog, no log.
     """
 
     location_updated = Signal()
@@ -227,56 +226,58 @@ class UpdateLocationDialog(QDialog):
     def __init__(self, parent=None, *, gc_codes: list[str] | None = None):
         super().__init__(parent)
         self._gc_codes = gc_codes
+        self._is_single = gc_codes is not None
         self.setWindowTitle(tr("update_loc_title"))
-        self.setMinimumWidth(520)
-        self.setMinimumHeight(480)
-        self._worker: ReverseGeocodeWorker | NominatimWorker | None = None
+        self.setMinimumWidth(460)
+        self._worker: ReverseGeocodeWorker | OnlineLookupWorker | None = None
         self._pending_rows: list[_CacheRow] = []
         self._setup_ui()
-
-        # In targeted mode, hide the scope controls — they don't apply.
-        if gc_codes is not None:
-            self._scope_box.setVisible(False)
 
     # ── UI ────────────────────────────────────────────────────────────────────
 
     def _setup_ui(self) -> None:
+        from opensak.utils import flags
         from opensak.gui.settings import get_settings
 
         layout = QVBoxLayout(self)
         layout.setSpacing(10)
 
-        # Info label
-        info = QLabel(tr("update_loc_info"))
-        info.setWordWrap(True)
-        info.setStyleSheet("color: palette(mid);")
-        layout.addWidget(info)
+        # Info label — text changes when the online checkbox is toggled
+        self._info_label = QLabel(tr("update_loc_info"))
+        self._info_label.setWordWrap(True)
+        self._info_label.setStyleSheet("color: palette(mid);")
+        layout.addWidget(self._info_label)
 
         # ── Scope (bulk mode only) ────────────────────────────────────────────
         self._scope_box = QGroupBox(tr("update_loc_scope_group"))
         scope_layout = QVBoxLayout(self._scope_box)
-
         self._rb_all = QRadioButton(tr("update_loc_scope_all"))
         self._rb_missing = QRadioButton(tr("update_loc_scope_missing"))
         self._rb_missing.setChecked(True)
         scope_layout.addWidget(self._rb_all)
         scope_layout.addWidget(self._rb_missing)
-
         layout.addWidget(self._scope_box)
+
+        if self._is_single:
+            self._scope_box.setVisible(False)
 
         # ── Options ───────────────────────────────────────────────────────────
         self._cb_corrected = QCheckBox(tr("update_loc_use_corrected"))
         self._cb_corrected.setChecked(True)
         layout.addWidget(self._cb_corrected)
 
-        # Nominatim checkbox — shown only when the user has enabled it in Advanced Settings
-        if get_settings().nominatim_enabled:
-            self._cb_nominatim = QCheckBox(tr("update_loc_nominatim_cb"))
-            self._cb_nominatim.setChecked(False)
-            self._cb_nominatim.setToolTip(tr("update_loc_nominatim_tooltip"))
-            layout.addWidget(self._cb_nominatim)
+        # Online lookup checkbox — always visible when flag is on;
+        # initial state comes from the Advanced Settings default.
+        if flags.update_location:
+            self._cb_online = QCheckBox(tr("update_loc_online_cb"))
+            self._cb_online.setChecked(get_settings().nominatim_enabled)
+            self._cb_online.setToolTip(tr("update_loc_online_tooltip"))
+            self._cb_online.stateChanged.connect(self._on_online_toggled)
+            layout.addWidget(self._cb_online)
+            # Sync info text with initial checkbox state
+            self._on_online_toggled()
         else:
-            self._cb_nominatim = None
+            self._cb_online = None
 
         # ── Progress ──────────────────────────────────────────────────────────
         self._progress_label = QLabel("")
@@ -284,15 +285,19 @@ class UpdateLocationDialog(QDialog):
         layout.addWidget(self._progress_label)
 
         self._progress = QProgressBar()
-        self._progress.setRange(0, 0)  # indeterminate during Phase 1
+        self._progress.setRange(0, 0)
         self._progress.setVisible(False)
         layout.addWidget(self._progress)
 
-        # ── Log ───────────────────────────────────────────────────────────────
-        self._log = QTextEdit()
-        self._log.setReadOnly(True)
-        self._log.setPlaceholderText(tr("update_loc_log_placeholder"))
-        layout.addWidget(self._log)
+        # ── Log (bulk mode only — hidden for single-cache to reduce verbosity) ─
+        if not self._is_single:
+            self._log = QTextEdit()
+            self._log.setReadOnly(True)
+            self._log.setPlaceholderText(tr("update_loc_log_placeholder"))
+            layout.addWidget(self._log)
+            self.setMinimumHeight(420)
+        else:
+            self._log = None
 
         # ── Buttons ───────────────────────────────────────────────────────────
         btn_row = QHBoxLayout()
@@ -314,10 +319,17 @@ class UpdateLocationDialog(QDialog):
 
         layout.addLayout(btn_row)
 
+    # ── Dynamic info text ─────────────────────────────────────────────────────
+
+    def _on_online_toggled(self) -> None:
+        if self._cb_online and self._cb_online.isChecked():
+            self._info_label.setText(tr("update_loc_info_online"))
+        else:
+            self._info_label.setText(tr("update_loc_info"))
+
     # ── Row building ──────────────────────────────────────────────────────────
 
     def _build_rows(self) -> list[_CacheRow]:
-        """Load cache rows from the active DB, applying scope and coord options."""
         from opensak.db.database import get_session
         from opensak.db.models import Cache
         from sqlalchemy.orm import joinedload
@@ -332,7 +344,6 @@ class UpdateLocationDialog(QDialog):
                 query = query.options(joinedload(Cache.user_note))
 
             if self._gc_codes is not None:
-                # Targeted mode: restrict to the given gc_codes.
                 query = query.filter(Cache.gc_code.in_(self._gc_codes))
             elif only_missing:
                 query = query.filter(
@@ -348,7 +359,6 @@ class UpdateLocationDialog(QDialog):
                     clon = cache.user_note.corrected_lon
                     if clat is not None and clon is not None:
                         lat, lon = clat, clon
-
                 if lat is None or lon is None:
                     continue
                 rows.append(_CacheRow(gc_code=cache.gc_code, lat=lat, lon=lon))
@@ -360,22 +370,16 @@ class UpdateLocationDialog(QDialog):
     def _start(self) -> None:
         rows = self._build_rows()
         if not rows:
-            self._log.setPlainText(tr("update_loc_nothing_to_do"))
+            self._progress_label.setText(tr("update_loc_nothing_to_do"))
             return
 
         self._pending_rows = rows
+        self._set_controls_enabled(False)
 
-        self._start_btn.setEnabled(False)
-        self._scope_box.setEnabled(False)
-        self._cb_corrected.setEnabled(False)
-        if self._cb_nominatim is not None:
-            self._cb_nominatim.setEnabled(False)
-        self._cancel_btn.setEnabled(True)
-        self._close_btn.setEnabled(False)
-
-        self._progress.setRange(0, 0)  # indeterminate for Phase 1
+        self._progress.setRange(0, 0)
         self._progress.setVisible(True)
-        self._log.clear()
+        if self._log:
+            self._log.clear()
         self._progress_label.setText(tr("update_loc_running", total=len(rows)))
 
         self._worker = ReverseGeocodeWorker(rows)
@@ -384,16 +388,16 @@ class UpdateLocationDialog(QDialog):
         self._worker.cancelled.connect(self._on_phase1_cancelled)
         self._worker.start()
 
-    def _start_phase2(self, rows: list[_CacheRow]) -> None:
+    def _start_online_phase(self, rows: list[_CacheRow]) -> None:
         self._progress.setRange(0, len(rows))
         self._progress.setValue(0)
         self._cancel_btn.setEnabled(True)
 
-        self._worker = NominatimWorker(rows)
+        self._worker = OnlineLookupWorker(rows)
         self._worker.row_done.connect(self._on_row_done)
-        self._worker.progress.connect(self._on_nominatim_progress)
-        self._worker.all_done.connect(self._on_nominatim_done)
-        self._worker.cancelled.connect(self._on_nominatim_cancelled)
+        self._worker.progress.connect(self._on_online_progress)
+        self._worker.all_done.connect(self._on_online_done)
+        self._worker.cancelled.connect(self._on_online_cancelled)
         self._worker.start()
 
     def _request_cancel(self) -> None:
@@ -404,20 +408,19 @@ class UpdateLocationDialog(QDialog):
     # ── Worker signals — Phase 1 ──────────────────────────────────────────────
 
     def _on_row_done(self, _gc_code: str, line: str) -> None:
-        self._log.append(line)
+        if self._log:
+            self._log.append(line)
 
     def _on_phase1_done(self, result: UpdateLocationResult) -> None:
         self.location_updated.emit()
 
-        nominatim_requested = (
-            self._cb_nominatim is not None and self._cb_nominatim.isChecked()
-        )
-        if nominatim_requested and self._pending_rows:
+        online_requested = self._cb_online is not None and self._cb_online.isChecked()
+        if online_requested and self._pending_rows:
             self._progress_label.setText(tr(
-                "update_loc_phase1_done",
+                "update_loc_offline_done",
                 updated=result.updated,
             ))
-            self._start_phase2(self._pending_rows)
+            self._start_online_phase(self._pending_rows)
         else:
             self._finalize()
             self._progress_label.setText(tr(
@@ -435,46 +438,49 @@ class UpdateLocationDialog(QDialog):
 
     # ── Worker signals — Phase 2 ──────────────────────────────────────────────
 
-    def _on_nominatim_progress(self, done: int, total: int) -> None:
+    def _on_online_progress(self, done: int, total: int) -> None:
         self._progress.setValue(done)
         eta = _format_eta(total - done)
         self._progress_label.setText(tr(
-            "update_loc_nominatim_running",
+            "update_loc_online_running",
             done=done,
             total=total,
             eta=eta,
         ))
 
-    def _on_nominatim_done(self, result: UpdateLocationResult) -> None:
+    def _on_online_done(self, result: UpdateLocationResult) -> None:
         self._finalize()
         self._progress_label.setText(tr(
-            "update_loc_nominatim_done",
+            "update_loc_online_done",
             updated=result.updated,
             skipped=result.skipped,
             errors=result.errors,
         ))
         self.location_updated.emit()
 
-    def _on_nominatim_cancelled(self, result: UpdateLocationResult) -> None:
+    def _on_online_cancelled(self, result: UpdateLocationResult) -> None:
         self._finalize()
         self._progress_label.setText(tr(
-            "update_loc_nominatim_cancelled",
+            "update_loc_online_cancelled",
             updated=result.updated,
         ))
         if result.updated > 0:
             self.location_updated.emit()
 
-    # ── Shared finalization ───────────────────────────────────────────────────
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    def _set_controls_enabled(self, enabled: bool) -> None:
+        self._start_btn.setEnabled(enabled)
+        self._scope_box.setEnabled(enabled)
+        self._cb_corrected.setEnabled(enabled)
+        if self._cb_online is not None:
+            self._cb_online.setEnabled(enabled)
+        self._cancel_btn.setEnabled(not enabled)
+        self._close_btn.setEnabled(enabled)
 
     def _finalize(self) -> None:
         self._progress.setVisible(False)
-        self._start_btn.setEnabled(True)
-        self._scope_box.setEnabled(True)
-        self._cb_corrected.setEnabled(True)
-        if self._cb_nominatim is not None:
-            self._cb_nominatim.setEnabled(True)
-        self._cancel_btn.setEnabled(False)
-        self._close_btn.setEnabled(True)
+        self._set_controls_enabled(True)
 
     def closeEvent(self, event) -> None:
         if self._worker and self._worker.isRunning():

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -188,6 +188,7 @@ class MainWindow(QMainWindow):
         self._cache_table.cache_selected.connect(self._on_cache_selected)
         self._cache_table.flags_changed.connect(self._on_flags_changed)
         self._cache_table.sort_changed.connect(self._on_sort_changed)
+        self._cache_table.location_updated.connect(self._refresh_cache_list)
         self._splitter.addWidget(self._cache_table)
 
         # Bottom container: info bar (fixed) + horisontal splitter (resizable)

--- a/src/opensak/gui/settings.py
+++ b/src/opensak/gui/settings.py
@@ -271,6 +271,17 @@ class AppSettings:
     def search_debounce_ms(self, value: int) -> None:
         self._s.setValue("search/debounce_ms", value)
 
+    # ── Location refinement ───────────────────────────────────────────────────
+
+    @property
+    def nominatim_enabled(self) -> bool:
+        """Enable Nominatim online refinement after the fast offline pass."""
+        return self._s.value("location/nominatim_enabled", False, type=bool)
+
+    @nominatim_enabled.setter
+    def nominatim_enabled(self, value: bool) -> None:
+        self._s.setValue("location/nominatim_enabled", value)
+
     # ── Last used paths ───────────────────────────────────────────────────────
 
     @property

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -301,6 +301,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: chyba — {msg}",
     "update_loc_row_skipped":       "{gc_code}: přeskočeno (žádné souřadnice)",
 
+    # Phase 2 — Nominatim refinement
+    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
+    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
+    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
+    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
+    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
+    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
+    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
+    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    "update_loc_eta_sec":           "{n}s remaining",
+    "update_loc_eta_min":           "{m}m {s}s remaining",
+    "update_loc_eta_hr":            "{h}h {m}m remaining",
+
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_new_title":                 "Nová databáze",
     "db_name_label":                "Název:",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -142,7 +142,6 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Výsledky importu se zobrazí zde…",
     "import_all_done":            "✓ Všech {count} souborů bylo zpracováno.",
     "import_geocode_checkbox":      "🌍  Geokódovat chybějící okres / kraj / zemi po importu",
-    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Geokóduji chybějící údaje o poloze…",
     
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -142,6 +142,7 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Výsledky importu se zobrazí zde…",
     "import_all_done":            "✓ Všech {count} souborů bylo zpracováno.",
     "import_geocode_checkbox":      "🌍  Geokódovat chybějící okres / kraj / zemi po importu",
+    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Geokóduji chybějící údaje o poloze…",
     
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -217,8 +218,8 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_placeholder":            "Vaše geocaching.com jméno",
     "settings_gc_username_hint":                   "Používá se k rozpoznání vlastních záznamů (např. FTF)",
     "settings_group_nominatim":                    "Location refinement",
-    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
-    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+    "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Vyhledávací engine",
     "settings_search_min_chars_label":             "Minimální počet znaků:",
@@ -304,16 +305,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: chyba — {msg}",
     "update_loc_row_skipped":       "{gc_code}: přeskočeno (žádné souřadnice)",
+    # Dynamic info text (changes when online checkbox is toggled)
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
 
-    # Phase 2 — Nominatim refinement
-    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
-    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
-    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
-    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
-    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
-    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
-    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
-    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    # Online refinement (replaces Nominatim terminology for end users)
+    "update_loc_online_cb":         "Also use online lookup for higher accuracy",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
+    "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
+    "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",
+    "update_loc_online_cancelled":  "Online lookup cancelled. {updated} refined so far.",
+    "update_loc_online_row":        "{gc_code}: online lookup → {county}",
+    "update_loc_online_skip":       "{gc_code}: no data from online lookup",
+
     "update_loc_eta_sec":           "{n}s remaining",
     "update_loc_eta_min":           "{m}m {s}s remaining",
     "update_loc_eta_hr":            "{h}h {m}m remaining",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -219,7 +219,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_hint":                   "Používá se k rozpoznání vlastních záznamů (např. FTF)",
     "settings_group_nominatim":                    "Location refinement",
     "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
-    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per waypoint. A database of 10 000 waypoints takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Vyhledávací engine",
     "settings_search_min_chars_label":             "Minimální počet znaků:",
@@ -289,10 +289,12 @@ STRINGS: dict[str, str] = {
     "found_errors":                   "Chyby:",
 
     # ── Dialog aktualizace polohy ─────────────────────────────────────────────
-    "update_loc_title":             "Aktualizovat okres / kraj / zemi",
+    "update_loc_title":             "Update Waypoint Locations",
     "update_loc_scope_group":       "Rozsah",
+    "update_loc_scope_this":        "Only this waypoint",
     "update_loc_scope_all":         "Aktualizovat všechny kešky",
-    "update_loc_scope_missing":     "Pouze kešky s chybějícími údaji o poloze",
+    "update_loc_scope_missing":     "Pouze kešky s chybějícími údaji o poloze",    "update_loc_lookup_group":      "Lookup options",
+
     "update_loc_use_corrected":     "Použít opravené souřadnice, jsou-li k dispozici",
     "update_loc_start_btn":         "▶  Spustit aktualizaci",
     "update_loc_info":              "Údaje o poloze jsou vyhledávány offline pomocí dat GeoNames — rychle, bez nutnosti sítě, bez omezení rychlosti.",
@@ -306,11 +308,11 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: chyba — {msg}",
     "update_loc_row_skipped":       "{gc_code}: přeskočeno (žádné souřadnice)",
     # Dynamic info text (changes when online checkbox is toggled)
-    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per waypoint.",
 
     # Online refinement (replaces Nominatim terminology for end users)
     "update_loc_online_cb":         "Also use online lookup for higher accuracy",
-    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per waypoint.",
     "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
     "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
     "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -71,7 +71,7 @@ STRINGS: dict[str, str] = {
     # Tools menu
     "action_settings":              "&Nastavení…",
     "action_found_update":          "⟳  Aktualizovat nálezy z referenční databáze…",
-    "action_update_location":       "🌍  Aktualizovat okres / kraj / zemi…",
+    "action_update_location":       "Update waypoint locations…",
     "action_gps_export":            "📤  Odeslat do GPS…",
 
     # Help menu

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -216,6 +216,10 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Uživatelské jméno:",
     "settings_gc_username_placeholder":            "Vaše geocaching.com jméno",
     "settings_gc_username_hint":                   "Používá se k rozpoznání vlastních záznamů (např. FTF)",
+    "settings_group_nominatim":                    "Location refinement",
+    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
+    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+
     "settings_group_search":                       "Vyhledávací engine",
     "settings_search_min_chars_label":             "Minimální počet znaků:",
     "settings_search_debounce_label":              "Zpoždění debounce (ms):",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -219,7 +219,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_hint":                   "Bruges til at genkende dine egne logs (fx FTF-detektion)",
     "settings_group_nominatim":                    "Location refinement",
     "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
-    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per waypoint. A database of 10 000 waypoints takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Søgemaskine",
     "settings_search_min_chars_label":             "Minimumstegn:",
@@ -289,10 +289,12 @@ STRINGS: dict[str, str] = {
     "found_errors":                   "Fejl:",
 
     # ── Opdater lokation dialog ───────────────────────────────────────────────
-    "update_loc_title":             "Opdater amt / region / land",
+    "update_loc_title":             "Update Waypoint Locations",
     "update_loc_scope_group":       "Omfang",
+    "update_loc_scope_this":        "Only this waypoint",
     "update_loc_scope_all":         "Opdater alle caches",
-    "update_loc_scope_missing":     "Kun caches med manglende lokationsdata",
+    "update_loc_scope_missing":     "Kun caches med manglende lokationsdata",    "update_loc_lookup_group":      "Lookup options",
+
     "update_loc_use_corrected":     "Brug korrigerede koordinater når tilgængelige",
     "update_loc_start_btn":         "▶  Start opdatering",
     "update_loc_info":              "Lokationsdata slås op offline ved hjælp af GeoNames-data — hurtigt, ingen netværk nødvendigt, ingen hastighedsbegrænsninger.",
@@ -306,11 +308,11 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: fejl — {msg}",
     "update_loc_row_skipped":       "{gc_code}: sprunget over (ingen koordinater)",
     # Dynamic info text (changes when online checkbox is toggled)
-    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per waypoint.",
 
     # Online refinement (replaces Nominatim terminology for end users)
     "update_loc_online_cb":         "Also use online lookup for higher accuracy",
-    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per waypoint.",
     "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
     "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
     "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -216,6 +216,10 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Brugernavn:",
     "settings_gc_username_placeholder":            "Dit geocaching.com brugernavn",
     "settings_gc_username_hint":                   "Bruges til at genkende dine egne logs (fx FTF-detektion)",
+    "settings_group_nominatim":                    "Location refinement",
+    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
+    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+
     "settings_group_search":                       "Søgemaskine",
     "settings_search_min_chars_label":             "Minimumstegn:",
     "settings_search_debounce_label":              "Debounce-forsinkelse (ms):",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -301,6 +301,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: fejl — {msg}",
     "update_loc_row_skipped":       "{gc_code}: sprunget over (ingen koordinater)",
 
+    # Phase 2 — Nominatim refinement
+    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
+    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
+    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
+    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
+    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
+    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
+    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
+    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    "update_loc_eta_sec":           "{n}s remaining",
+    "update_loc_eta_min":           "{m}m {s}s remaining",
+    "update_loc_eta_hr":            "{h}h {m}m remaining",
+
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_new_title":                 "Ny database",
     "db_name_label":                "Navn:",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -142,6 +142,7 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Import-resultat vises her…",
     "import_all_done":            "✓ Alle {count} filer er behandlet.",
     "import_geocode_checkbox":      "🌍  Geokod manglende amt / region / land efter import",
+    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Geokoder manglende lokationsdata…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -217,8 +218,8 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_placeholder":            "Dit geocaching.com brugernavn",
     "settings_gc_username_hint":                   "Bruges til at genkende dine egne logs (fx FTF-detektion)",
     "settings_group_nominatim":                    "Location refinement",
-    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
-    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+    "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Søgemaskine",
     "settings_search_min_chars_label":             "Minimumstegn:",
@@ -304,16 +305,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: fejl — {msg}",
     "update_loc_row_skipped":       "{gc_code}: sprunget over (ingen koordinater)",
+    # Dynamic info text (changes when online checkbox is toggled)
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
 
-    # Phase 2 — Nominatim refinement
-    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
-    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
-    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
-    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
-    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
-    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
-    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
-    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    # Online refinement (replaces Nominatim terminology for end users)
+    "update_loc_online_cb":         "Also use online lookup for higher accuracy",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
+    "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
+    "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",
+    "update_loc_online_cancelled":  "Online lookup cancelled. {updated} refined so far.",
+    "update_loc_online_row":        "{gc_code}: online lookup → {county}",
+    "update_loc_online_skip":       "{gc_code}: no data from online lookup",
+
     "update_loc_eta_sec":           "{n}s remaining",
     "update_loc_eta_min":           "{m}m {s}s remaining",
     "update_loc_eta_hr":            "{h}h {m}m remaining",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -142,7 +142,6 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Import-resultat vises her…",
     "import_all_done":            "✓ Alle {count} filer er behandlet.",
     "import_geocode_checkbox":      "🌍  Geokod manglende amt / region / land efter import",
-    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Geokoder manglende lokationsdata…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -71,7 +71,7 @@ STRINGS: dict[str, str] = {
     # Funktioner-menu
     "action_settings":              "&Indstillinger…",
     "action_found_update":          "⟳  Opdater fund fra reference database…",
-    "action_update_location":       "🌍  Opdater amt / region / land…",
+    "action_update_location":       "Update waypoint locations…",
     "action_gps_export":            "📤  Send til GPS…",
 
     # Hjælp-menu

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -219,7 +219,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_hint":                   "Wird zur Erkennung eigener Logs verwendet (z.B. FTF-Erkennung)",
     "settings_group_nominatim":                    "Location refinement",
     "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
-    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per waypoint. A database of 10 000 waypoints takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Suchmaschine",
     "settings_search_min_chars_label":             "Mindestzeichen:",
@@ -289,10 +289,12 @@ STRINGS: dict[str, str] = {
     "found_errors":                   "Fehler:",
 
     # ── Standort aktualisieren Dialog ─────────────────────────────────────────
-    "update_loc_title":             "Landkreis / Bundesland / Land aktualisieren",
+    "update_loc_title":             "Update Waypoint Locations",
     "update_loc_scope_group":       "Umfang",
+    "update_loc_scope_this":        "Only this waypoint",
     "update_loc_scope_all":         "Alle Caches aktualisieren",
-    "update_loc_scope_missing":     "Nur Caches mit fehlenden Standortdaten",
+    "update_loc_scope_missing":     "Nur Caches mit fehlenden Standortdaten",    "update_loc_lookup_group":      "Lookup options",
+
     "update_loc_use_corrected":     "Korrigierte Koordinaten verwenden wenn vorhanden",
     "update_loc_start_btn":         "▶  Aktualisierung starten",
     "update_loc_info":              "Standortdaten werden offline anhand von GeoNames-Daten abgerufen — schnell, kein Netzwerk erforderlich, keine Ratenlimitierung.",
@@ -306,11 +308,11 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: Fehler — {msg}",
     "update_loc_row_skipped":       "{gc_code}: übersprungen (keine Koordinaten)",
     # Dynamic info text (changes when online checkbox is toggled)
-    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per waypoint.",
 
     # Online refinement (replaces Nominatim terminology for end users)
     "update_loc_online_cb":         "Also use online lookup for higher accuracy",
-    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per waypoint.",
     "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
     "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
     "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -301,6 +301,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: Fehler — {msg}",
     "update_loc_row_skipped":       "{gc_code}: übersprungen (keine Koordinaten)",
 
+    # Phase 2 — Nominatim refinement
+    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
+    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
+    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
+    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
+    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
+    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
+    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
+    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    "update_loc_eta_sec":           "{n}s remaining",
+    "update_loc_eta_min":           "{m}m {s}s remaining",
+    "update_loc_eta_hr":            "{h}h {m}m remaining",
+
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_new_title":                 "Neue Datenbank",
     "db_name_label":                "Name:",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -71,7 +71,7 @@ STRINGS: dict[str, str] = {
     # Tools menu
     "action_settings":              "&Einstellungen…",
     "action_found_update":          "⟳  Funde aus Referenz-Datenbank aktualisieren",
-    "action_update_location":       "🌍  Landkreis / Bundesland / Land aktualisieren…",
+    "action_update_location":       "Update waypoint locations…",
     "action_gps_export":            "📤  An GPS senden…",
 
     # Help menu

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -142,6 +142,7 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Importergebnisse werden hier angezeigt…",
     "import_all_done":            "✓ Alle {count} Dateien verarbeitet.",
     "import_geocode_checkbox":      "🌍  Fehlende Landkreis / Bundesland / Land nach Import ermitteln",
+    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Fehlende Standortdaten werden ermittelt…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -217,8 +218,8 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_placeholder":            "Dein geocaching.com Benutzername",
     "settings_gc_username_hint":                   "Wird zur Erkennung eigener Logs verwendet (z.B. FTF-Erkennung)",
     "settings_group_nominatim":                    "Location refinement",
-    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
-    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+    "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Suchmaschine",
     "settings_search_min_chars_label":             "Mindestzeichen:",
@@ -304,16 +305,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: Fehler — {msg}",
     "update_loc_row_skipped":       "{gc_code}: übersprungen (keine Koordinaten)",
+    # Dynamic info text (changes when online checkbox is toggled)
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
 
-    # Phase 2 — Nominatim refinement
-    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
-    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
-    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
-    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
-    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
-    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
-    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
-    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    # Online refinement (replaces Nominatim terminology for end users)
+    "update_loc_online_cb":         "Also use online lookup for higher accuracy",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
+    "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
+    "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",
+    "update_loc_online_cancelled":  "Online lookup cancelled. {updated} refined so far.",
+    "update_loc_online_row":        "{gc_code}: online lookup → {county}",
+    "update_loc_online_skip":       "{gc_code}: no data from online lookup",
+
     "update_loc_eta_sec":           "{n}s remaining",
     "update_loc_eta_min":           "{m}m {s}s remaining",
     "update_loc_eta_hr":            "{h}h {m}m remaining",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -216,6 +216,10 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Benutzername:",
     "settings_gc_username_placeholder":            "Dein geocaching.com Benutzername",
     "settings_gc_username_hint":                   "Wird zur Erkennung eigener Logs verwendet (z.B. FTF-Erkennung)",
+    "settings_group_nominatim":                    "Location refinement",
+    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
+    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+
     "settings_group_search":                       "Suchmaschine",
     "settings_search_min_chars_label":             "Mindestzeichen:",
     "settings_search_debounce_label":              "Debounce-Verzögerung (ms):",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -142,7 +142,6 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Importergebnisse werden hier angezeigt…",
     "import_all_done":            "✓ Alle {count} Dateien verarbeitet.",
     "import_geocode_checkbox":      "🌍  Fehlende Landkreis / Bundesland / Land nach Import ermitteln",
-    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Fehlende Standortdaten werden ermittelt…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -219,7 +219,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_hint":                   "Used to identify your own logs (e.g. for FTF detection)",
     "settings_group_nominatim":                    "Location refinement",
     "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
-    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per waypoint. A database of 10 000 waypoints takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Search Engine",
     "settings_search_min_chars_label":             "Minimum characters:",
@@ -289,29 +289,31 @@ STRINGS: dict[str, str] = {
     "found_errors":                   "Errors:",
 
     # ── Update location dialog ────────────────────────────────────────────────
-    "update_loc_title":             "Update County / State / Country",
+    "update_loc_title":             "Update Waypoint Locations",
     "update_loc_scope_group":       "Scope",
-    "update_loc_scope_all":         "Update all caches",
-    "update_loc_scope_missing":     "Only caches with missing location data",
+    "update_loc_scope_this":        "Only this waypoint",
+    "update_loc_scope_all":         "Update all waypoints",
+    "update_loc_scope_missing":     "Only waypoints with missing location data",
+    "update_loc_lookup_group":      "Lookup options",
     "update_loc_use_corrected":     "Use corrected coordinates when available",
     "update_loc_start_btn":         "▶  Start update",
     "update_loc_info":              "Location data is looked up offline using GeoNames data — fast, no network required, no rate limits.",
-    "update_loc_running":           "Running offline lookup for {total} caches…",
+    "update_loc_running":           "Running offline lookup for {total} waypoints…",
     "update_loc_done":              "✓ Done — {updated} updated, {skipped} skipped, {errors} errors",
     "update_loc_cancelled":         "Cancelled — {updated} updated so far",
     "update_loc_log_placeholder":   "Results will appear here…",
     "update_loc_no_db":             "No database open.",
-    "update_loc_nothing_to_do":     "No caches to update with the selected scope.",
+    "update_loc_nothing_to_do":     "No waypoints to update with the selected scope.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: error — {msg}",
     "update_loc_row_skipped":       "{gc_code}: skipped (no coordinates)",
 
     # Dynamic info text (changes when online checkbox is toggled)
-    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per waypoint.",
 
     # Online refinement (replaces Nominatim terminology for end users)
     "update_loc_online_cb":         "Also use online lookup for higher accuracy",
-    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per waypoint.",
     "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
     "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
     "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -71,7 +71,7 @@ STRINGS: dict[str, str] = {
     # Tools menu
     "action_settings":              "&Settings…",
     "action_found_update":          "⟳  Update finds from reference database…",
-    "action_update_location":       "🌍  Update county / state / country…",
+    "action_update_location":       "🌍  Update waypoint locations…",
     "action_gps_export":            "📤  Send to GPS…",
 
     # Help menu

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -142,7 +142,8 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Import results will appear here…",
     "import_all_done":            "✓ All {count} files processed.",
     "import_geocode_checkbox":      "🌍  Geocode missing county / state / country after import",
-    "import_geocode_running":       "📍  Geocoding missing location data…",
+    "import_geocode_running":       "📍  Looking up missing location data (offline)…",
+    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_dialog_title":          "Set filter",
@@ -217,8 +218,8 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_placeholder":            "Your geocaching.com username",
     "settings_gc_username_hint":                   "Used to identify your own logs (e.g. for FTF detection)",
     "settings_group_nominatim":                    "Location refinement",
-    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
-    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+    "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Search Engine",
     "settings_search_min_chars_label":             "Minimum characters:",
@@ -305,15 +306,18 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: error — {msg}",
     "update_loc_row_skipped":       "{gc_code}: skipped (no coordinates)",
 
-    # Phase 2 — Nominatim refinement
-    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
-    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
-    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
-    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
-    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
-    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
-    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
-    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    # Dynamic info text (changes when online checkbox is toggled)
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+
+    # Online refinement (replaces Nominatim terminology for end users)
+    "update_loc_online_cb":         "Also use online lookup for higher accuracy",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
+    "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
+    "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",
+    "update_loc_online_cancelled":  "Online lookup cancelled. {updated} refined so far.",
+    "update_loc_online_row":        "{gc_code}: online lookup → {county}",
+    "update_loc_online_skip":       "{gc_code}: no data from online lookup",
     "update_loc_eta_sec":           "{n}s remaining",
     "update_loc_eta_min":           "{m}m {s}s remaining",
     "update_loc_eta_hr":            "{h}h {m}m remaining",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -143,7 +143,6 @@ STRINGS: dict[str, str] = {
     "import_all_done":            "✓ All {count} files processed.",
     "import_geocode_checkbox":      "🌍  Geocode missing county / state / country after import",
     "import_geocode_running":       "📍  Looking up missing location data (offline)…",
-    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_dialog_title":          "Set filter",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -301,6 +301,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: error — {msg}",
     "update_loc_row_skipped":       "{gc_code}: skipped (no coordinates)",
 
+    # Phase 2 — Nominatim refinement
+    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
+    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
+    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
+    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
+    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
+    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
+    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
+    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    "update_loc_eta_sec":           "{n}s remaining",
+    "update_loc_eta_min":           "{m}m {s}s remaining",
+    "update_loc_eta_hr":            "{h}h {m}m remaining",
+
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_new_title":                 "New database",
     "db_name_label":                "Name:",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -216,6 +216,10 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Username:",
     "settings_gc_username_placeholder":            "Your geocaching.com username",
     "settings_gc_username_hint":                   "Used to identify your own logs (e.g. for FTF detection)",
+    "settings_group_nominatim":                    "Location refinement",
+    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
+    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+
     "settings_group_search":                       "Search Engine",
     "settings_search_min_chars_label":             "Minimum characters:",
     "settings_search_debounce_label":              "Debounce delay (ms):",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -71,7 +71,7 @@ STRINGS: dict[str, str] = {
     # Tools menu
     "action_settings":              "&Paramètres…",
     "action_found_update":          "⟳  Mettre à jour les caches trouvées depuis la base de données de référence…",
-    "action_update_location":       "🌍  Mettre à jour département / région / pays…",
+    "action_update_location":       "Update waypoint locations…",
     "action_gps_export":            "📤  Envoyer au GPS…",
 
     # Help menu

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -142,7 +142,6 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Les résultats d'importation s'afficheront ici…",
     "import_all_done":            "✓ Les {count} fichiers ont été traités.",
     "import_geocode_checkbox":      "🌍  Géocoder le département / région / pays manquants après l'import",
-    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Géocodage des données de localisation manquantes…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -301,6 +301,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code} : erreur — {msg}",
     "update_loc_row_skipped":       "{gc_code} : ignoré (pas de coordonnées)",
 
+    # Phase 2 — Nominatim refinement
+    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
+    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
+    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
+    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
+    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
+    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
+    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
+    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    "update_loc_eta_sec":           "{n}s remaining",
+    "update_loc_eta_min":           "{m}m {s}s remaining",
+    "update_loc_eta_hr":            "{h}h {m}m remaining",
+
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_new_title":                 "Nouvelle base de données",
     "db_name_label":                "Nom:",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -216,6 +216,10 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Nom d'utilisateur :",
     "settings_gc_username_placeholder":            "Votre nom geocaching.com",
     "settings_gc_username_hint":                   "Utilisé pour identifier vos propres logs (ex. détection FTF)",
+    "settings_group_nominatim":                    "Location refinement",
+    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
+    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+
     "settings_group_search":                       "Moteur de recherche",
     "settings_search_min_chars_label":             "Caractères minimum :",
     "settings_search_debounce_label":              "Délai de debounce (ms) :",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -142,6 +142,7 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Les résultats d'importation s'afficheront ici…",
     "import_all_done":            "✓ Les {count} fichiers ont été traités.",
     "import_geocode_checkbox":      "🌍  Géocoder le département / région / pays manquants après l'import",
+    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Géocodage des données de localisation manquantes…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -217,8 +218,8 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_placeholder":            "Votre nom geocaching.com",
     "settings_gc_username_hint":                   "Utilisé pour identifier vos propres logs (ex. détection FTF)",
     "settings_group_nominatim":                    "Location refinement",
-    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
-    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+    "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Moteur de recherche",
     "settings_search_min_chars_label":             "Caractères minimum :",
@@ -304,16 +305,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row":               "{gc_code} : {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code} : erreur — {msg}",
     "update_loc_row_skipped":       "{gc_code} : ignoré (pas de coordonnées)",
+    # Dynamic info text (changes when online checkbox is toggled)
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
 
-    # Phase 2 — Nominatim refinement
-    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
-    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
-    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
-    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
-    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
-    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
-    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
-    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    # Online refinement (replaces Nominatim terminology for end users)
+    "update_loc_online_cb":         "Also use online lookup for higher accuracy",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
+    "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
+    "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",
+    "update_loc_online_cancelled":  "Online lookup cancelled. {updated} refined so far.",
+    "update_loc_online_row":        "{gc_code}: online lookup → {county}",
+    "update_loc_online_skip":       "{gc_code}: no data from online lookup",
+
     "update_loc_eta_sec":           "{n}s remaining",
     "update_loc_eta_min":           "{m}m {s}s remaining",
     "update_loc_eta_hr":            "{h}h {m}m remaining",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -219,7 +219,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_hint":                   "Utilisé pour identifier vos propres logs (ex. détection FTF)",
     "settings_group_nominatim":                    "Location refinement",
     "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
-    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per waypoint. A database of 10 000 waypoints takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Moteur de recherche",
     "settings_search_min_chars_label":             "Caractères minimum :",
@@ -289,10 +289,12 @@ STRINGS: dict[str, str] = {
     "found_errors":                   "Erreurs :",
 
     # ── Boîte de dialogue mise à jour de la localisation ─────────────────────
-    "update_loc_title":             "Mettre à jour département / région / pays",
+    "update_loc_title":             "Update Waypoint Locations",
     "update_loc_scope_group":       "Périmètre",
+    "update_loc_scope_this":        "Only this waypoint",
     "update_loc_scope_all":         "Mettre à jour tous les caches",
-    "update_loc_scope_missing":     "Uniquement les caches sans données de localisation",
+    "update_loc_scope_missing":     "Uniquement les caches sans données de localisation",    "update_loc_lookup_group":      "Lookup options",
+
     "update_loc_use_corrected":     "Utiliser les coordonnées corrigées si disponibles",
     "update_loc_start_btn":         "▶  Lancer la mise à jour",
     "update_loc_info":              "Les données de localisation sont recherchées hors ligne à l'aide des données GeoNames — rapide, sans réseau requis, sans limites de débit.",
@@ -306,11 +308,11 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code} : erreur — {msg}",
     "update_loc_row_skipped":       "{gc_code} : ignoré (pas de coordonnées)",
     # Dynamic info text (changes when online checkbox is toggled)
-    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per waypoint.",
 
     # Online refinement (replaces Nominatim terminology for end users)
     "update_loc_online_cb":         "Also use online lookup for higher accuracy",
-    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per waypoint.",
     "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
     "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
     "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -219,7 +219,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_hint":                   "Usado para identificar os seus próprios registos (ex. FTF)",
     "settings_group_nominatim":                    "Location refinement",
     "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
-    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per waypoint. A database of 10 000 waypoints takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Motor de Pesquisa",
     "settings_search_min_chars_label":             "Caracteres mínimos:",
@@ -289,10 +289,12 @@ STRINGS: dict[str, str] = {
     "found_errors":                   "Erros:",
 
     # ── Diálogo de atualização de localização ─────────────────────────────────
-    "update_loc_title":             "Atualizar Concelho / Estado / País",
+    "update_loc_title":             "Update Waypoint Locations",
     "update_loc_scope_group":       "Âmbito",
+    "update_loc_scope_this":        "Only this waypoint",
     "update_loc_scope_all":         "Atualizar todas as caches",
-    "update_loc_scope_missing":     "Apenas caches sem dados de localização",
+    "update_loc_scope_missing":     "Apenas caches sem dados de localização",    "update_loc_lookup_group":      "Lookup options",
+
     "update_loc_use_corrected":     "Usar coordenadas corrigidas quando disponíveis",
     "update_loc_start_btn":         "▶  Iniciar atualização",
     "update_loc_info":              "Os dados de localização são obtidos offline usando dados GeoNames — rápido, sem necessidade de rede, sem limites de pedidos.",
@@ -306,11 +308,11 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: erro — {msg}",
     "update_loc_row_skipped":       "{gc_code}: ignorado (sem coordenadas)",
     # Dynamic info text (changes when online checkbox is toggled)
-    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per waypoint.",
 
     # Online refinement (replaces Nominatim terminology for end users)
     "update_loc_online_cb":         "Also use online lookup for higher accuracy",
-    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per waypoint.",
     "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
     "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
     "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -142,6 +142,7 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Os resultados da importação aparecerão aqui…",
     "import_all_done":            "✓ Todos os {count} ficheiros foram processados.",
     "import_geocode_checkbox":      "🌍  Geocodificar concelho / estado / país em falta após importação",
+    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  A geocodificar dados de localização em falta…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -217,8 +218,8 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_placeholder":            "O seu nome geocaching.com",
     "settings_gc_username_hint":                   "Usado para identificar os seus próprios registos (ex. FTF)",
     "settings_group_nominatim":                    "Location refinement",
-    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
-    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+    "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Motor de Pesquisa",
     "settings_search_min_chars_label":             "Caracteres mínimos:",
@@ -304,16 +305,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: erro — {msg}",
     "update_loc_row_skipped":       "{gc_code}: ignorado (sem coordenadas)",
+    # Dynamic info text (changes when online checkbox is toggled)
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
 
-    # Phase 2 — Nominatim refinement
-    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
-    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
-    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
-    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
-    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
-    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
-    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
-    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    # Online refinement (replaces Nominatim terminology for end users)
+    "update_loc_online_cb":         "Also use online lookup for higher accuracy",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
+    "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
+    "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",
+    "update_loc_online_cancelled":  "Online lookup cancelled. {updated} refined so far.",
+    "update_loc_online_row":        "{gc_code}: online lookup → {county}",
+    "update_loc_online_skip":       "{gc_code}: no data from online lookup",
+
     "update_loc_eta_sec":           "{n}s remaining",
     "update_loc_eta_min":           "{m}m {s}s remaining",
     "update_loc_eta_hr":            "{h}h {m}m remaining",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -142,7 +142,6 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Os resultados da importação aparecerão aqui…",
     "import_all_done":            "✓ Todos os {count} ficheiros foram processados.",
     "import_geocode_checkbox":      "🌍  Geocodificar concelho / estado / país em falta após importação",
-    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  A geocodificar dados de localização em falta…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -301,6 +301,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: erro — {msg}",
     "update_loc_row_skipped":       "{gc_code}: ignorado (sem coordenadas)",
 
+    # Phase 2 — Nominatim refinement
+    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
+    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
+    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
+    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
+    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
+    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
+    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
+    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    "update_loc_eta_sec":           "{n}s remaining",
+    "update_loc_eta_min":           "{m}m {s}s remaining",
+    "update_loc_eta_hr":            "{h}h {m}m remaining",
+
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_new_title":                 "Nova base de dados",
     "db_name_label":                "Nome:",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -216,6 +216,10 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Nome de utilizador:",
     "settings_gc_username_placeholder":            "O seu nome geocaching.com",
     "settings_gc_username_hint":                   "Usado para identificar os seus próprios registos (ex. FTF)",
+    "settings_group_nominatim":                    "Location refinement",
+    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
+    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+
     "settings_group_search":                       "Motor de Pesquisa",
     "settings_search_min_chars_label":             "Caracteres mínimos:",
     "settings_search_debounce_label":              "Atraso de debounce (ms):",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -71,7 +71,7 @@ STRINGS: dict[str, str] = {
     # Tools menu
     "action_settings":              "&Definições…",
     "action_found_update":          "⟳  Atualizar caches encontradas da base de dados de referência…",
-    "action_update_location":       "🌍  Atualizar concelho / estado / país…",
+    "action_update_location":       "Update waypoint locations…",
     "action_gps_export":            "📤  Enviar para GPS…",
 
     # Help menu

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -142,6 +142,7 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Resultatet av importen visas här…",
     "import_all_done":            "✓ Alla {count} filer har bearbetats.",
     "import_geocode_checkbox":      "🌍  Geokoda saknad kommun / län / land efter import",
+    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Geokoderar saknade platsdata…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -217,8 +218,8 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_placeholder":            "Ditt geocaching.com-användarnamn",
     "settings_gc_username_hint":                   "Används för att identifiera egna loggningar (t.ex. FTF)",
     "settings_group_nominatim":                    "Location refinement",
-    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
-    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+    "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Sökmotor",
     "settings_search_min_chars_label":             "Minsta antal tecken:",
@@ -304,16 +305,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: fel — {msg}",
     "update_loc_row_skipped":       "{gc_code}: hoppades över (inga koordinater)",
+    # Dynamic info text (changes when online checkbox is toggled)
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
 
-    # Phase 2 — Nominatim refinement
-    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
-    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
-    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
-    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
-    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
-    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
-    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
-    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    # Online refinement (replaces Nominatim terminology for end users)
+    "update_loc_online_cb":         "Also use online lookup for higher accuracy",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
+    "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
+    "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",
+    "update_loc_online_cancelled":  "Online lookup cancelled. {updated} refined so far.",
+    "update_loc_online_row":        "{gc_code}: online lookup → {county}",
+    "update_loc_online_skip":       "{gc_code}: no data from online lookup",
+
     "update_loc_eta_sec":           "{n}s remaining",
     "update_loc_eta_min":           "{m}m {s}s remaining",
     "update_loc_eta_hr":            "{h}h {m}m remaining",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -216,6 +216,10 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_label":                  "Användarnamn:",
     "settings_gc_username_placeholder":            "Ditt geocaching.com-användarnamn",
     "settings_gc_username_hint":                   "Används för att identifiera egna loggningar (t.ex. FTF)",
+    "settings_group_nominatim":                    "Location refinement",
+    "settings_nominatim_cb":                       "Enable Nominatim online refinement",
+    "settings_nominatim_hint":                     "When enabled, county / state / country data is further refined after the fast offline pass using OpenStreetMap's Nominatim service.\n\nDrawback: requires an internet connection and takes approximately 1 second per cache — a database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you specifically need higher accuracy near administrative boundaries.",
+
     "settings_group_search":                       "Sökmotor",
     "settings_search_min_chars_label":             "Minsta antal tecken:",
     "settings_search_debounce_label":              "Debounce-fördröjning (ms):",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -219,7 +219,7 @@ STRINGS: dict[str, str] = {
     "settings_gc_username_hint":                   "Används för att identifiera egna loggningar (t.ex. FTF)",
     "settings_group_nominatim":                    "Location refinement",
     "settings_nominatim_cb":                       "Enable online lookup for higher accuracy",
-    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per cache. A database of 10 000 caches takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
+    "settings_nominatim_hint":                     "When enabled, county, state and country data is further refined using OpenStreetMap after the fast offline pass.\n\nNote: requires an internet connection and takes about 1 second per waypoint. A database of 10 000 waypoints takes around 3 hours to fully refine. Leave this off unless you need higher accuracy near administrative boundaries.",
 
     "settings_group_search":                       "Sökmotor",
     "settings_search_min_chars_label":             "Minsta antal tecken:",
@@ -289,10 +289,12 @@ STRINGS: dict[str, str] = {
     "found_errors":                  "Fel:",
 
     # ── Dialog för uppdatering av plats ───────────────────────────────────────
-    "update_loc_title":             "Uppdatera kommun / län / land",
+    "update_loc_title":             "Update Waypoint Locations",
     "update_loc_scope_group":       "Omfattning",
+    "update_loc_scope_this":        "Only this waypoint",
     "update_loc_scope_all":         "Uppdatera alla cacher",
-    "update_loc_scope_missing":     "Endast cacher som saknar platsdata",
+    "update_loc_scope_missing":     "Endast cacher som saknar platsdata",    "update_loc_lookup_group":      "Lookup options",
+
     "update_loc_use_corrected":     "Använd korrigerade koordinater när tillgängliga",
     "update_loc_start_btn":         "▶  Starta uppdatering",
     "update_loc_info":              "Platsdata slås upp offline med GeoNames-data — snabbt, inget nätverk krävs, inga hastighetsbegränsningar.",
@@ -306,11 +308,11 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: fel — {msg}",
     "update_loc_row_skipped":       "{gc_code}: hoppades över (inga koordinater)",
     # Dynamic info text (changes when online checkbox is toggled)
-    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per cache.",
+    "update_loc_info_online":       "Looks up county, state and country from local data first, then refines the result online for higher accuracy. Requires internet. About 1 second per waypoint.",
 
     # Online refinement (replaces Nominatim terminology for end users)
     "update_loc_online_cb":         "Also use online lookup for higher accuracy",
-    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per cache.",
+    "update_loc_online_tooltip":    "Uses OpenStreetMap boundary maps to refine results near county borders.\nRequires internet. About 1 second per waypoint.",
     "update_loc_offline_done":      "✓ Offline lookup complete ({updated} updated). Starting online refinement...",
     "update_loc_online_running":    "Online lookup: {done} of {total} ({eta})",
     "update_loc_online_done":       "✓ Online lookup complete: {updated} refined, {skipped} unchanged, {errors} errors",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -142,7 +142,6 @@ STRINGS: dict[str, str] = {
     "import_log_placeholder":       "Resultatet av importen visas här…",
     "import_all_done":            "✓ Alla {count} filer har bearbetats.",
     "import_geocode_checkbox":      "🌍  Geokoda saknad kommun / län / land efter import",
-    "import_geocode_online_running": "🌐  Refining location data online (this may take a while)…",
     "import_geocode_running":       "📍  Geokoderar saknade platsdata…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -301,6 +301,19 @@ STRINGS: dict[str, str] = {
     "update_loc_row_error":         "{gc_code}: fel — {msg}",
     "update_loc_row_skipped":       "{gc_code}: hoppades över (inga koordinater)",
 
+    # Phase 2 — Nominatim refinement
+    "update_loc_nominatim_cb":      "Also refine with Nominatim (online, ~1 req/sec)",
+    "update_loc_nominatim_tooltip": "Uses OpenStreetMap polygon data for higher-accuracy county lookups.\nRequires internet. Approximate time: 1 second per cache.",
+    "update_loc_phase1_done":       "✓ Phase 1 complete — {updated} updated offline. Starting Nominatim…",
+    "update_loc_nominatim_running": "Nominatim: {done} / {total} — {eta}",
+    "update_loc_nominatim_done":    "✓ Nominatim done — {updated} refined, {skipped} skipped, {errors} errors",
+    "update_loc_nominatim_cancelled": "Nominatim cancelled — {updated} refined so far",
+    "update_loc_nominatim_row":     "{gc_code}: Nominatim → {county}",
+    "update_loc_nominatim_skip":    "{gc_code}: Nominatim returned no data",
+    "update_loc_eta_sec":           "{n}s remaining",
+    "update_loc_eta_min":           "{m}m {s}s remaining",
+    "update_loc_eta_hr":            "{h}h {m}m remaining",
+
     # ── Database dialog ───────────────────────────────────────────────────────
     "db_new_title":                 "Ny databas",
     "db_name_label":                "Namn:",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -71,7 +71,7 @@ STRINGS: dict[str, str] = {
     # Tools menu
     "action_settings":              "&Inställningar…",
     "action_found_update":          "⟳  Uppdatera hittade från referensdatabasen…",
-    "action_update_location":       "🌍  Uppdatera kommun / län / land…",
+    "action_update_location":       "Update waypoint locations…",
     "action_gps_export":            "📤  Skicka till GPS…",
 
     # Help menu

--- a/tests/unit-tests/test_geocoder.py
+++ b/tests/unit-tests/test_geocoder.py
@@ -1,16 +1,19 @@
 """
-tests/unit-tests/test_geocoder.py — Unit tests for the offline reverse geocoder.
+tests/unit-tests/test_geocoder.py — Unit tests for the reverse geocoder.
 
 reverse_geocoder and pycountry are injected into sys.modules so the tests
 work even when neither library is installed in the test environment.
+Nominatim tests mock urllib.request.urlopen so no real network calls are made.
 """
 
 from __future__ import annotations
 
+import json
 import sys
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
-from opensak.geocoder import GeoLocation, fast_batch_geocode
+from opensak.geocoder import GeoLocation, fast_batch_geocode, nominatim_reverse
 
 
 def _mocks(search_results: list[dict], country_name: str | None = ""):
@@ -128,3 +131,112 @@ def test_empty_input_returns_empty_list():
         result = fast_batch_geocode([])
 
     assert result == []
+
+
+# ── nominatim_reverse tests ───────────────────────────────────────────────────
+
+def _nominatim_mock(address: dict, country_name: str | None = "United States"):
+    """
+    Build a context manager that patches urllib.request.urlopen and pycountry
+    to simulate a Nominatim response with the given address dict.
+    """
+    payload = json.dumps({"address": address}).encode()
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = payload
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    mock_urlopen = patch("urllib.request.urlopen", return_value=mock_resp)
+
+    mock_pc = MagicMock()
+    if country_name is None:
+        mock_pc.countries.get.return_value = None
+    else:
+        country_obj = MagicMock()
+        country_obj.name = country_name
+        mock_pc.countries.get.return_value = country_obj
+
+    mock_pycountry = patch.dict(sys.modules, {"pycountry": mock_pc})
+    return mock_urlopen, mock_pycountry
+
+
+def test_nominatim_full_response():
+    address = {
+        "country_code": "us",
+        "state": "California",
+        "county": "Los Angeles County",
+    }
+    mock_urlopen, mock_pycountry = _nominatim_mock(address, "United States")
+    with mock_urlopen, mock_pycountry:
+        result = nominatim_reverse(34.05, -118.24)
+
+    assert result == GeoLocation(
+        country="United States",
+        state="California",
+        county="Los Angeles County",
+    )
+
+
+def test_nominatim_falls_back_to_district():
+    address = {
+        "country_code": "gb",
+        "state": "England",
+        "district": "London Borough of Hackney",
+    }
+    mock_urlopen, mock_pycountry = _nominatim_mock(address, "United Kingdom")
+    with mock_urlopen, mock_pycountry:
+        result = nominatim_reverse(51.54, -0.06)
+
+    assert result.county == "London Borough of Hackney"
+
+
+def test_nominatim_falls_back_to_municipality():
+    address = {
+        "country_code": "dk",
+        "state": "Capital Region of Denmark",
+        "municipality": "Copenhagen Municipality",
+    }
+    mock_urlopen, mock_pycountry = _nominatim_mock(address, "Denmark")
+    with mock_urlopen, mock_pycountry:
+        result = nominatim_reverse(55.67, 12.56)
+
+    assert result.county == "Copenhagen Municipality"
+
+
+def test_nominatim_unknown_country_code():
+    address = {"country_code": "xx", "state": "Nowhere", "county": "Void County"}
+    mock_urlopen, mock_pycountry = _nominatim_mock(address, None)
+    with mock_urlopen, mock_pycountry:
+        result = nominatim_reverse(0.0, 0.0)
+
+    assert result.country is None
+    assert result.county == "Void County"
+
+
+def test_nominatim_no_county_field():
+    address = {"country_code": "us", "state": "Wyoming"}
+    mock_urlopen, mock_pycountry = _nominatim_mock(address, "United States")
+    with mock_urlopen, mock_pycountry:
+        result = nominatim_reverse(43.0, -107.5)
+
+    assert result.state == "Wyoming"
+    assert result.county is None
+
+
+def test_nominatim_network_error_returns_all_none():
+    with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+        result = nominatim_reverse(34.05, -118.24)
+
+    assert result == GeoLocation(None, None, None)
+
+
+def test_nominatim_invalid_json_returns_all_none():
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b"not-json"
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        result = nominatim_reverse(0.0, 0.0)
+
+    assert result == GeoLocation(None, None, None)


### PR DESCRIPTION
Phase 2 of #60

## Summary

- **Online location refinement** (opt-in): after the fast offline lookup, a second pass can run using the OpenStreetMap Nominatim API to produce higher-accuracy county/state/country data — especially for waypoints near administrative boundaries. Rate-limited to 1 req/sec per Nominatim's usage policy; cancellable at any time with partial progress saved.

- **Unified "Update Waypoint Locations" dialog**: the menu entry and the right-click context menu now open the same dialog. The entry point only changes the default scope — *Only this waypoint* from right-click, *Only waypoints with missing location data* from the menu. The dialog has two clearly delimited sections: **Scope** (which waypoints to process) and **Lookup options** (corrected coordinates + online refinement checkbox).

- **Online refinement checkbox**: always visible in the dialog when the feature flag is on. Its default state is controlled by **Settings → Advanced → Location refinement** but can be overridden per run. The info text at the top updates dynamically when the checkbox is toggled.

- **Auto-geocode on import**: the offline lookup runs automatically after every successful GPX/PQ import for waypoints with missing location data. The online refinement is never triggered on import — it must be run manually via **Waypoint → Update Waypoint Locations…**.

- **Bug fix**: closing the right-click update dialog now refreshes the cache list immediately without needing to reopen the app.