### PR TITLE
Link MIT License text in site footer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2024 AgreeDK
+Copyright (c) 2026 OpenSAK Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 AgreeDK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/site/index.html
+++ b/site/index.html
@@ -485,6 +485,8 @@
     }
 
     .footer-left strong { color: var(--accent); }
+    .footer-left a { color: var(--muted); text-decoration: none; transition: color 0.2s; }
+    .footer-left a:hover { color: var(--text); }
 
     .footer-links {
       display: flex;
@@ -766,7 +768,7 @@
 <footer>
   <div class="footer-left">
     <strong>OpenSAK</strong> · Open Source Geocache Manager<br>
-    MIT License · Made in Denmark 🇩🇰
+    <a href="https://github.com/AgreeDK/opensak/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a> · Made in Denmark 🇩🇰
   </div>
   <div class="footer-links">
     <a href="https://github.com/AgreeDK/opensak">GitHub</a>


### PR DESCRIPTION
## Description
The site footer already displayed the text "MIT License", but it was plain text with no hyperlink.
Users reading the landing page had no direct way to inspect the actual license terms without navigating to the repository manually.

This change wraps the "MIT License" text in an anchor tag pointing to the `LICENSE` file on GitHub (`/blob/main/LICENSE`), opening in a new tab. A matching pair of CSS rules is added so the link inherits the muted footer colour and gains the same hover effect as the other footer links — keeping the visual style consistent.

**Why it matters:**
- Open-source transparency: visitors can verify the license terms with one click.
- Compliance best-practice: linking the license from the product page is a common expectation for OSS projects.
- No visual disruption: the link blends into the existing footer design.
