### PR TITLE
Fix: e2e test crash 

### DIFF
--- a/tests/e2e-tests/conftest.py
+++ b/tests/e2e-tests/conftest.py
@@ -50,6 +50,8 @@ def seeded_window(qtbot, tmp_path, monkeypatch):
 
     yield window
 
+    window.close()
+    qtbot.wait(200)
     mgr_module._manager = None
 
 
@@ -79,4 +81,6 @@ def empty_window(qtbot, tmp_path, monkeypatch):
 
     yield window
 
+    window.close()
+    qtbot.wait(200)
     mgr_module._manager = None


### PR DESCRIPTION
## Fix e2e SIGTRAP crash in `test_import_dialog_worker_succeeds`

### Problem

The e2e suite was crashing with exit code 133 (SIGTRAP, core dump) at
`test_import_dialog_worker_succeeds` on CI (Ubuntu + xvfb/xcb).

The crash was a hard C-level WebEngine crash. The `empty_window` fixture
creates a full `MainWindow` with a `QWebEngineView` (map widget).
At teardown, it set `mgr_module._manager = None` without calling
`window.close()` first, leaving the `QWebEnginePage` alive while Qt
destroyed the `QWebEngineProfile`. This corrupted internal Chromium state
and crashed the next test.

The same issue was present in `seeded_window`.
The `monkey_window` fixture already had the correct pattern with an
explanatory comment — it just wasn't applied to the other two fixtures.

### Fix

Added `window.close()` + `qtbot.wait(200)` to the teardown of both
`seeded_window` and `empty_window`, matching `monkey_window`.

### Test plan

- [x] All 74 e2e tests pass locally
- [ ] CI green on Python 3.11 and 3.12