### PR TITLE
Performance - Phase 1 - Stop hydrating description blobs in the table query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ gc_token.json
 
 # Alembic (will add later)
 # alembic/versions/
+
+# Planning docs (local only for now)
+docs/plans/

--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -777,13 +777,23 @@ def apply_filters(
         isinstance(f, HasTrackableFilter) for f in _iter_filters(filterset)
     )
 
-    from sqlalchemy.orm import joinedload, noload
+    from sqlalchemy.orm import defer, joinedload, noload
     query = session.query(Cache).options(
         joinedload(Cache.attributes) if needs_attributes else noload(Cache.attributes),
         joinedload(Cache.trackables) if needs_trackables else noload(Cache.trackables),
         noload(Cache.logs),       # load on-demand when user opens a cache
         noload(Cache.waypoints),  # load on-demand when user opens a cache
         joinedload(Cache.user_note),  # one-to-one, cheap; needed for corrected-coords
+        # Defer the large free-text blobs — they dominate per-row size but are
+        # never shown in the cache table (only in the detail panel, which loads
+        # each cache separately via _load_full_cache()). Deferring them keeps
+        # the table refresh light on big databases. A load_only() allow-list was
+        # rejected as too fragile: the table model and Python-level filters read
+        # a wide, scattered set of scalar columns, and missing one would trigger
+        # a lazy SELECT per row (N+1). These three blobs carry ~all the weight.
+        defer(Cache.short_description),
+        defer(Cache.long_description),
+        defer(Cache.encoded_hints),
     )
 
     # Push SQL-capable filters into the query before loading rows.

--- a/tests/unit-tests/test_filters.py
+++ b/tests/unit-tests/test_filters.py
@@ -685,6 +685,40 @@ def test_where_clause_in_nested_filterset(tmp_db):
     assert "GC00001" not in codes  # D=1.5
 
 
+def test_apply_filters_defers_description_blobs(tmp_db):
+    """Phase 1: the large free-text blobs are deferred on the table query.
+
+    short_description / long_description / encoded_hints are never shown in the
+    cache table (only in the detail panel, which loads each cache separately).
+    Deferring them keeps the refresh light on large databases. They must remain
+    unloaded after apply_filters() returns.
+    """
+    from sqlalchemy import inspect as sa_inspect
+
+    with get_session() as s:
+        results = apply_filters(s)
+        assert results, "expected seeded caches"
+        for c in results:
+            unloaded = sa_inspect(c).unloaded
+            assert "short_description" in unloaded
+            assert "long_description" in unloaded
+            assert "encoded_hints" in unloaded
+            # A column the table actually reads must be loaded eagerly.
+            assert "name" not in unloaded
+            assert "cache_type" not in unloaded
+
+
+def test_apply_filters_results_unchanged_with_deferral(tmp_db):
+    """Phase 1: deferring blobs must not change which caches are returned."""
+    with get_session() as s:
+        all_codes = {c.gc_code for c in apply_filters(s)}
+        fs = FilterSet(mode="AND")
+        fs.add(CacheTypeFilter(["Traditional Cache"]))
+        traditional = {c.gc_code for c in apply_filters(s, fs)}
+    assert "GC00001" in all_codes
+    assert traditional and traditional <= all_codes
+
+
 def test_where_clause_profile_save_load(tmp_path):
     """FilterProfile containing WhereClauseFilter round-trips the SQL through JSON."""
     sql = "difficulty >= 3 AND terrain <= 4"


### PR DESCRIPTION
First phase of the performance plan (#214). Targets the single most-run query
in the app: the cache-table refresh that fires on **every debounced search
keystroke**.

### Problem

`apply_filters()` loaded every `Cache` with **all ~55 columns**, including the
large free-text blobs `short_description`, `long_description`, and
`encoded_hints` — even though the cache table never displays them. On a database
with tens of thousands of caches (typical for GSAK migrants), every refresh
pulled multiple KB of HTML per row into memory for nothing.

The detail panel doesn't depend on these objects: it loads each cache
separately via `_load_full_cache()`, so the blobs are pure dead weight in the
table path.

### Change

Defer those three columns in the table query so they're excluded from the
per-row payload. SQLAlchemy auto-loads a deferred column on the rare occasion
it's accessed, and the detail panel's own full query is unaffected.

A `load_only()` allow-list (as floated in the plan) was **rejected as too
fragile**: the table model and the Python-level filters read a wide, scattered
set of scalar columns, and forgetting any one of them would trigger a lazy
`SELECT` per row (N+1) — worse than the status quo. The three deferred blobs
carry essentially all of the per-row weight, so deferring exactly them captures
the win with near-zero risk.

### Measurement

Synthetic 30k-cache DB, ~10 KB of description text per cache, loading the full
set:

| Metric                     | Before  | After   | Delta            |
|----------------------------|---------|---------|------------------|
| Peak Python alloc on load  | 416 MB  | 188 MB  | **55% lower**    |
| Load time (best of 3)      | 794 ms  | 745 ms  | ~1.07× faster    |

The win is memory-dominated, which is the dimension that scales painfully with
database size. Time is roughly flat (SQLite reads are cheap); the point is not
to allocate hundreds of MB of HTML the UI never uses.

### Tests

- `test_apply_filters_defers_description_blobs` — asserts the three blobs are
  unloaded after `apply_filters()` while a column the table reads (`name`,
  `cache_type`) stays eager.
- `test_apply_filters_results_unchanged_with_deferral` — parity check that
  deferral doesn't change which caches are returned.
- Full suite green: **488 unit + 74 e2e**.

### Scope

- `src/opensak/filters/engine.py` — `defer()` the three blob columns in the
  table query.
- `tests/unit-tests/test_filters.py` — Phase 1 tests.

No behavioural change to the UI; descriptions still appear in the detail panel.