### PR TITLE
Performance - Phase 4 - Distance computation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "PySide6>=6.6",
     "reverse_geocoder>=1.5",
     "pycountry>=23.12",
+    "numpy>=1.24",
 ]
 
 [project.optional-dependencies]

--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -343,6 +343,10 @@ def _run_migrations(engine: Engine) -> None:
             ("ix_caches_found",         "found"),
             # Composite for the availability quick-filter (archived + available)
             ("ix_caches_archived_available", "archived, available"),
+            # Composite for DistanceFilter's lat/lon bounding-box pre-narrow
+            # (#214 phase 4). Leading latitude column serves the latitude
+            # BETWEEN range; longitude refines.
+            ("ix_caches_lat_lon", "latitude, longitude"),
         ]
         existing_idx = {
             row[0]

--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -43,6 +43,31 @@ def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
+def haversine_km_batch(lat0: float, lon0: float, lats, lons):
+    """Great-circle distance (km) from (lat0, lon0) to each (lats[i], lons[i]).
+
+    Vectorised with numpy when available — turning a per-row Python loop over
+    tens of thousands of caches (run on every table refresh) into a single
+    array operation. Falls back to a Python list comprehension if numpy is not
+    installed, so behaviour is identical either way (within float tolerance).
+    Returns a numpy array or a list of floats; callers index/iterate it.
+    """
+    try:
+        import numpy as np
+    except ImportError:
+        return [_haversine_km(lat0, lon0, la, lo) for la, lo in zip(lats, lons)]
+
+    R = 6371.0
+    p0 = math.radians(lat0)
+    l0 = math.radians(lon0)
+    la = np.radians(np.asarray(lats, dtype=float))
+    lo = np.radians(np.asarray(lons, dtype=float))
+    dphi = la - p0
+    dlam = lo - l0
+    a = np.sin(dphi / 2) ** 2 + math.cos(p0) * np.cos(la) * np.sin(dlam / 2) ** 2
+    return R * 2 * np.arctan2(np.sqrt(a), np.sqrt(1 - a))
+
+
 # ── Base filter ───────────────────────────────────────────────────────────────
 
 class BaseFilter(ABC):
@@ -515,6 +540,31 @@ class DistanceFilter(BaseFilter):
         self.lon = lon
         self.max_km = max_km
         self.min_km = min_km
+
+    def apply_to_query(self, query):
+        """Pre-narrow with a lat/lon bounding box that *contains* the circle.
+
+        The box is a conservative superset of the max_km circle, so SQLite can
+        discard far-away caches (using the (latitude, longitude) index) before
+        any Python object is built, while matches() still applies the exact
+        haversine test — results are therefore identical. Skipped (returns None,
+        i.e. pure Python) for max_km<=0 or near the poles / antimeridian, where
+        a simple box could wrap and wrongly drop matches.
+        """
+        if self.max_km <= 0 or not (-89.0 < self.lat < 89.0):
+            return None
+        dlat = self.max_km / 111.0  # ~111 km per degree of latitude
+        coslat = math.cos(math.radians(self.lat))
+        if coslat <= 1e-6:
+            return None
+        dlon = self.max_km / (111.0 * coslat)
+        if dlon >= 180.0 or self.lon - dlon < -180.0 or self.lon + dlon > 180.0:
+            return None  # box would wrap the antimeridian — let Python handle it
+        from sqlalchemy import and_
+        return query.filter(and_(
+            Cache.latitude.between(self.lat - dlat, self.lat + dlat),
+            Cache.longitude.between(self.lon - dlon, self.lon + dlon),
+        ))
 
     def matches(self, cache: Cache) -> bool:
         if cache.latitude is None or cache.longitude is None:
@@ -1049,11 +1099,13 @@ def annotate_distances(
     Return a dict mapping cache.id → distance_km from (lat, lon).
     Useful for displaying distances in the UI without filtering.
     """
-    return {
-        c.id: _haversine_km(lat, lon, c.latitude, c.longitude)
-        for c in caches
-        if c.latitude is not None and c.longitude is not None
-    }
+    valid = [c for c in caches if c.latitude is not None and c.longitude is not None]
+    if not valid:
+        return {}
+    dists = haversine_km_batch(
+        lat, lon, [c.latitude for c in valid], [c.longitude for c in valid]
+    )
+    return {c.id: float(dists[i]) for i, c in enumerate(valid)}
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -13,7 +13,7 @@ from PySide6.QtGui import QColor, QFont
 from PySide6.QtWidgets import QTableView, QHeaderView, QAbstractItemView, QMenu, QApplication
 
 from opensak.db.models import Cache
-from opensak.filters.engine import _haversine_km
+from opensak.filters.engine import _haversine_km, haversine_km_batch
 from opensak.gui.settings import get_settings
 from opensak.coords import format_coords, format_lat, format_lon, format_lat, format_lon
 from opensak.lang import tr
@@ -31,6 +31,27 @@ def _bearing_deg(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     x = math.sin(dlon) * math.cos(la2)
     y = math.cos(la1) * math.sin(la2) - math.sin(la1) * math.cos(la2) * math.cos(dlon)
     return (math.degrees(math.atan2(x, y)) + 360) % 360
+
+
+def _bearing_deg_batch(lat0: float, lon0: float, lats, lons):
+    """Vectorised bearing (deg 0-360) from (lat0, lon0) to each (lats[i], lons[i]).
+
+    numpy-accelerated counterpart of _bearing_deg, used to compute every cache's
+    bearing in one array op on table refresh. Falls back to a Python loop when
+    numpy is unavailable. Returns a numpy array or a list of floats.
+    """
+    try:
+        import numpy as np
+    except ImportError:
+        return [_bearing_deg(lat0, lon0, la, lo) for la, lo in zip(lats, lons)]
+
+    r = math.pi / 180
+    la0 = lat0 * r
+    la = np.asarray(lats, dtype=float) * r
+    dlon = (np.asarray(lons, dtype=float) - lon0) * r
+    x = np.sin(dlon) * np.cos(la)
+    y = math.cos(la0) * np.sin(la) - math.sin(la0) * np.cos(la) * np.cos(dlon)
+    return (np.degrees(np.arctan2(x, y)) + 360) % 360
 
 
 def _bearing_compass(deg: float) -> str:
@@ -453,18 +474,26 @@ class CacheTableModel(QAbstractTableModel):
         self.endResetModel()
 
     def _update_distances(self) -> None:
+        # Vectorised: compute distance + bearing for every cache in one numpy
+        # pass instead of a per-row Python loop. This runs on every table
+        # refresh, so on large databases (100k+ caches) the loop was a real
+        # per-keystroke cost; the batch form is ~negligible.
         settings = get_settings()
         self._distances = {}
-        for c in self._caches:
-            if c.latitude is not None and c.longitude is not None:
-                self._distances[c.id] = _haversine_km(
-                    settings.home_lat, settings.home_lon,
-                    c.latitude, c.longitude
-                )
-                self._bearings[c.id] = _bearing_deg(
-                    settings.home_lat, settings.home_lon,
-                    c.latitude, c.longitude
-                )
+        self._bearings = {}
+        valid = [
+            c for c in self._caches
+            if c.latitude is not None and c.longitude is not None
+        ]
+        if not valid:
+            return
+        lats = [c.latitude for c in valid]
+        lons = [c.longitude for c in valid]
+        dists = haversine_km_batch(settings.home_lat, settings.home_lon, lats, lons)
+        bears = _bearing_deg_batch(settings.home_lat, settings.home_lon, lats, lons)
+        for i, c in enumerate(valid):
+            self._distances[c.id] = float(dists[i])
+            self._bearings[c.id] = float(bears[i])
 
     def cache_at(self, row: int) -> Optional[Cache]:
         if 0 <= row < len(self._caches):

--- a/tests/unit-tests/test_phase4_distance.py
+++ b/tests/unit-tests/test_phase4_distance.py
@@ -1,0 +1,140 @@
+"""
+tests/unit-tests/test_phase4_distance.py — Phase 4 tests.
+
+Phase 4 vectorises the great-circle distance/bearing computation (numpy) and
+adds a lat/lon bounding-box pre-narrow to DistanceFilter so distance filtering
+on large databases does not haversine every row in Python.
+
+Tests assert:
+  * the batch (numpy) haversine/bearing match the scalar versions exactly
+  * DistanceFilter with the SQL bounding-box returns the *same* caches as the
+    pure-Python exact filter (the box is a conservative superset; matches()
+    refines), including the antimeridian/pole fall-back cases
+  * the (latitude, longitude) index exists
+"""
+
+import math
+
+import pytest
+
+from opensak.db.database import get_session, make_session
+from opensak.db.models import Cache
+from opensak.filters.engine import (
+    _haversine_km, haversine_km_batch, apply_filters, FilterSet, DistanceFilter,
+)
+from opensak.gui.cache_table import _bearing_deg, _bearing_deg_batch
+
+
+# ── Batch vs scalar parity ────────────────────────────────────────────────────
+
+SAMPLE_POINTS = [
+    (55.6761, 12.5683),   # Copenhagen
+    (56.1629, 10.2039),   # Aarhus
+    (52.5200, 13.4050),   # Berlin
+    (-33.8688, 151.2093), # Sydney (southern hemisphere)
+    (64.1466, -21.9426),  # Reykjavik
+    (0.0, 0.0),           # null island
+    (55.6761, 12.5683),   # exact same as origin → distance 0
+]
+
+
+@pytest.mark.parametrize("origin", [(55.6761, 12.5683), (-10.0, 170.0)])
+def test_haversine_batch_matches_scalar(origin):
+    lat0, lon0 = origin
+    lats = [p[0] for p in SAMPLE_POINTS]
+    lons = [p[1] for p in SAMPLE_POINTS]
+    batch = haversine_km_batch(lat0, lon0, lats, lons)
+    for i, (la, lo) in enumerate(SAMPLE_POINTS):
+        assert float(batch[i]) == pytest.approx(_haversine_km(lat0, lon0, la, lo), abs=1e-6)
+
+
+@pytest.mark.parametrize("origin", [(55.6761, 12.5683), (-10.0, 170.0)])
+def test_bearing_batch_matches_scalar(origin):
+    lat0, lon0 = origin
+    lats = [p[0] for p in SAMPLE_POINTS]
+    lons = [p[1] for p in SAMPLE_POINTS]
+    batch = _bearing_deg_batch(lat0, lon0, lats, lons)
+    for i, (la, lo) in enumerate(SAMPLE_POINTS):
+        assert float(batch[i]) == pytest.approx(_bearing_deg(lat0, lon0, la, lo), abs=1e-6)
+
+
+def test_haversine_batch_empty():
+    assert list(haversine_km_batch(55.0, 12.0, [], [])) == []
+
+
+# ── Bounding-box DistanceFilter parity ────────────────────────────────────────
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_grid(tmp_db):
+    """A grid of caches around Copenhagen + a couple of far-away ones."""
+    rows = []
+    n = 0
+    for dlat in range(-10, 11):
+        for dlon in range(-10, 11):
+            n += 1
+            rows.append(Cache(
+                gc_code=f"GCG{n:04d}", name=f"grid {n}", cache_type="Traditional Cache",
+                latitude=55.6761 + dlat * 0.05, longitude=12.5683 + dlon * 0.05,
+            ))
+    # Far away — must always be excluded by a Copenhagen-centred filter
+    rows.append(Cache(gc_code="GCFAR1", name="Sydney", cache_type="Traditional Cache",
+                      latitude=-33.8688, longitude=151.2093))
+    rows.append(Cache(gc_code="GCFAR2", name="Berlin", cache_type="Traditional Cache",
+                      latitude=52.52, longitude=13.405))
+    s = make_session()
+    for r in rows:
+        s.add(r)
+    s.commit()
+    s.close()
+
+
+def _python_only(fs):
+    """Result if the filter ran purely in Python (no SQL pre-narrow)."""
+    with get_session() as s:
+        rows = s.query(Cache).all()
+        return {c.gc_code for c in rows if fs.matches(c)}
+
+
+def _via_apply_filters(fs):
+    with get_session() as s:
+        return {c.gc_code for c in apply_filters(s, fs)}
+
+
+@pytest.mark.parametrize("max_km", [1.0, 5.0, 10.0, 25.0, 100.0])
+def test_distance_filter_bbox_matches_python(max_km):
+    fs = FilterSet().add(DistanceFilter(lat=55.6761, lon=12.5683, max_km=max_km))
+    assert _via_apply_filters(fs) == _python_only(fs)
+
+
+def test_distance_filter_with_min_km():
+    fs = FilterSet().add(DistanceFilter(lat=55.6761, lon=12.5683, max_km=20.0, min_km=5.0))
+    assert _via_apply_filters(fs) == _python_only(fs)
+
+
+def test_distance_filter_bbox_skipped_near_antimeridian():
+    # lon close to 180 → box would wrap; apply_to_query must return None so the
+    # filter falls back to Python and still returns the correct set.
+    f = DistanceFilter(lat=0.0, lon=179.9, max_km=50.0)
+    with get_session() as s:
+        assert f.apply_to_query(s.query(Cache)) is None
+    fs = FilterSet().add(f)
+    assert _via_apply_filters(fs) == _python_only(fs)
+
+
+def test_distance_filter_bbox_skipped_for_zero_radius():
+    f = DistanceFilter(lat=55.0, lon=12.0, max_km=0.0)
+    with get_session() as s:
+        assert f.apply_to_query(s.query(Cache)) is None
+
+
+# ── Index exists ──────────────────────────────────────────────────────────────
+
+def test_lat_lon_index_created(tmp_db):
+    from sqlalchemy import text
+    with get_session() as s:
+        names = {
+            row[0] for row in s.execute(text(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='caches'"
+            ))
+        }
+    assert "ix_caches_lat_lon" in names


### PR DESCRIPTION
Fourth phase of the performance plan (#214). Distance was the last big
`O(rows)`-in-Python hot path: a per-cache haversine loop, and a `DistanceFilter`
that ran entirely in Python — so a small-radius filter on a large database
loaded *every* `Cache` as an ORM object just to discard ~99% of them.

### Bounding-box pre-narrow for `DistanceFilter`

`DistanceFilter.apply_to_query()` now adds a lat/lon bounding box that
**contains** the `max_km` circle, so SQLite discards far-away rows (via a new
`(latitude, longitude)` index) before any Python object is built. `matches()`
still applies the exact haversine test, so **results are identical** — the box
is just a conservative superset that `matches()` refines down to the circle.

Correctness guard: the box is skipped (pure Python) when `max_km <= 0` or near
the poles / antimeridian, where a simple lat/lon box could wrap and wrongly drop
matches.

### Vectorised haversine / bearing

`haversine_km_batch()` and `_bearing_deg_batch()` compute distance + bearing for
all caches in one numpy array op (with a pure-Python fallback when numpy is
absent, so behaviour is identical either way). The table model's
`_update_distances()` — which recomputes every visible cache's distance on each
refresh — now uses them, as does `annotate_distances()`.

`numpy` is promoted to an explicit dependency (already present transitively via
`reverse_geocoder`); the fallback keeps things correct if it's ever missing.

### Measurement (80k caches)

| Operation | Before | After | Speedup |
|---|---|---|---|
| Selective 10 km `DistanceFilter` | 1869 ms | 14 ms | **~135×** |
| Batch haversine ×100k (warm) | 35 ms | 4 ms | **~8.5×** |

The 135× comes from not building 80k ORM objects to keep ~800; `EXPLAIN` shows
`SEARCH caches USING INDEX ix_caches_lat_lon`.

### Why not persist distance into the `Cache.distance` column?

The plan floated persisting distance/bearing into the existing (currently
unused) columns on every center-point change. I deliberately didn't: vectorising
the per-refresh computation makes it negligible **without** a persisted cache and
its staleness/invalidation risk (distances depend on the per-database home
point, which changes on edit, import, and DB switch). The bounding-box filter is
where the real win was, and it needs an arbitrary reference point a fixed column
can't serve anyway.

### Tests

`tests/unit-tests/test_phase4_distance.py`:
- batch == scalar haversine/bearing (both hemispheres, zero distance, empty input)
- `DistanceFilter` bbox == pure-Python result across radii and with `min_km`
- antimeridian / zero-radius fall back to Python and stay correct
- `(latitude, longitude)` index exists

**554 unit + full 74-test e2e suite green.**

### Scope
- `src/opensak/filters/engine.py` — `haversine_km_batch`, `DistanceFilter` bbox, vectorised `annotate_distances`
- `src/opensak/gui/cache_table.py` — `_bearing_deg_batch`, vectorised `_update_distances`
- `src/opensak/db/database.py` — `(latitude, longitude)` index
- `pyproject.toml` — numpy dependency
- `tests/unit-tests/test_phase4_distance.py`