### PR TITLE
Performance - Phase 6 - Startup migrations gate

### DIFF
--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -58,6 +58,12 @@ _engine: Engine | None = None
 _SessionLocal: sessionmaker | None = None
 _migrated_paths: set = set()  # undgår at køre migrationer to gange på samme DB
 
+# Schema version stored in the SQLite header (PRAGMA user_version). MUST be
+# bumped to the highest migration number whenever a new migration is added
+# below — _run_migrations() skips the whole block when the database already
+# reports this version, so a stale constant means new migrations never run.
+SCHEMA_VERSION = 11
+
 
 def init_db(db_path: Path | None = None) -> Engine:
     """
@@ -120,6 +126,17 @@ def _run_migrations(engine: Engine) -> None:
     over hvis ja — så er det sikkert at kalde ved hver opstart.
     """
     with engine.connect() as conn:
+        # ── Gate: skip all probes when the DB is already at the current schema ─
+        # Every migration below is idempotent but still runs ~10 PRAGMA
+        # table_info probes on each launch. Once a database reports the current
+        # SCHEMA_VERSION we can skip the whole block and only pay a single
+        # PRAGMA user_version read. Existing databases default to user_version=0
+        # and run the (idempotent) migrations once, after which the version is
+        # stamped and subsequent launches short-circuit here.
+        current_version = conn.execute(text("PRAGMA user_version")).scalar() or 0
+        if current_version >= SCHEMA_VERSION:
+            return
+
         # ── Migration 1: Tilføj is_corrected til user_notes ──────────────────
         existing_notes = [
             row[1]
@@ -364,6 +381,12 @@ def _run_migrations(engine: Engine) -> None:
         if created_idx:
             conn.commit()
             print(f"Migration: oprettede {len(created_idx)} indexes på caches ({', '.join(created_idx)})")
+
+        # ── Stamp the schema version so the next launch skips the probes ─────
+        # PRAGMA does not accept bind parameters; SCHEMA_VERSION is a trusted
+        # int constant, so inlining it is safe.
+        conn.execute(text(f"PRAGMA user_version = {SCHEMA_VERSION}"))
+        conn.commit()
 
 
 def dispose_engine(db_path: Path | None = None) -> None:

--- a/tests/unit-tests/test_phase6_migrations_gate.py
+++ b/tests/unit-tests/test_phase6_migrations_gate.py
@@ -1,0 +1,86 @@
+"""
+tests/unit-tests/test_phase6_migrations_gate.py — Phase 6 tests.
+
+Phase 6 gates the startup migration block behind PRAGMA user_version so a
+database already at the current schema skips the ~10 idempotent PRAGMA
+table_info probes that ran on every launch. The migrations themselves are
+unchanged; only the gate (skip-when-current, stamp-after-run) is new.
+
+Tests assert:
+  * init_db stamps user_version to SCHEMA_VERSION
+  * a current database short-circuits — no table_info probes
+  * a stale database (user_version=0) re-runs the probes and is re-stamped
+  * the schema migrations still produced their indexes (gate opened at least once)
+"""
+
+import pytest
+from sqlalchemy import event, text
+
+from opensak.db.database import init_db, get_engine, _run_migrations, SCHEMA_VERSION
+
+
+def _capture_statements(engine):
+    """Return (list, detach) capturing every SQL statement run on *engine*."""
+    seen: list[str] = []
+
+    def _listener(conn, cursor, statement, params, context, executemany):
+        seen.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _listener)
+    return seen, lambda: event.remove(engine, "before_cursor_execute", _listener)
+
+
+def test_user_version_stamped_after_init(tmp_path):
+    init_db(db_path=tmp_path / "v.db")
+    with get_engine().connect() as c:
+        assert c.execute(text("PRAGMA user_version")).scalar() == SCHEMA_VERSION
+
+
+def test_migrations_skipped_when_current(tmp_path):
+    """A second migration pass on an up-to-date DB must not probe table_info."""
+    init_db(db_path=tmp_path / "skip.db")
+    engine = get_engine()
+
+    seen, detach = _capture_statements(engine)
+    try:
+        _run_migrations(engine)
+    finally:
+        detach()
+
+    assert not any("table_info" in s for s in seen), \
+        f"gate did not short-circuit: {[s for s in seen if 'table_info' in s]}"
+    # The only thing it should have read is the version gate.
+    assert any("user_version" in s for s in seen)
+
+
+def test_migrations_rerun_when_version_stale(tmp_path):
+    """Resetting user_version=0 must re-open the gate and re-stamp afterwards."""
+    init_db(db_path=tmp_path / "stale.db")
+    engine = get_engine()
+
+    with engine.connect() as c:
+        c.execute(text("PRAGMA user_version = 0"))
+        c.commit()
+
+    seen, detach = _capture_statements(engine)
+    try:
+        _run_migrations(engine)
+    finally:
+        detach()
+
+    assert any("table_info" in s for s in seen), "gate stayed shut on a stale DB"
+    with engine.connect() as c:
+        assert c.execute(text("PRAGMA user_version")).scalar() == SCHEMA_VERSION
+
+
+def test_indexes_present_after_init(tmp_path):
+    """Sanity: the gated migration block still created the filter/sort indexes."""
+    init_db(db_path=tmp_path / "idx.db")
+    with get_engine().connect() as c:
+        names = {
+            row[0] for row in c.execute(text(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='caches'"
+            ))
+        }
+    for expected in ("ix_caches_cache_type", "ix_caches_lat_lon", "ix_caches_found"):
+        assert expected in names


### PR DESCRIPTION
`_run_migrations()` ran on every launch and issued ~10 idempotent
`PRAGMA table_info` probes (plus index/data-fix queries) just to discover there
was nothing to do. This phase stamps the SQLite header with a `SCHEMA_VERSION`
and skips the whole block when the database already reports it.

### Changes
- Read `PRAGMA user_version` at the top of `_run_migrations()`; **return early**
  when it is already at `SCHEMA_VERSION`.
- Stamp `PRAGMA user_version = SCHEMA_VERSION` after the last migration.
- Existing databases default to `user_version=0`, so they run the (idempotent)
  migrations **once** and are then stamped; every later launch short-circuits.

The per-migration "if column/index exists" checks stay as the safety net, so the
gate can never skip an unapplied migration — provided `SCHEMA_VERSION` is bumped
whenever a new migration is added (called out in a comment next to the constant).

This is the **short-term gate** from the plan, not the full Alembic adoption —
deliberately low-risk.

### Effect
A launch on an up-to-date database now issues **1 statement** (the version read)
instead of **20** (7 `table_info` probes eliminated). Migrations are otherwise
byte-for-byte unchanged.

### Tests
- New `tests/unit-tests/test_phase6_migrations_gate.py` (4 tests): version
  stamped after `init_db`; current DB short-circuits (no `table_info` probes);
  stale DB (`user_version=0`) re-runs the probes and is re-stamped; filter/sort
  indexes still present (gate opened at least once).
- Full suite green: **565 unit + 74 e2e**.

Closes #214.