### PR TITLE
Test Coverage - Phase 0

### DIFF
--- a/tests/unit-tests/test_entrypoints.py
+++ b/tests/unit-tests/test_entrypoints.py
@@ -1,9 +1,4 @@
-"""Cover the console-script entry points (opensak / opensak-test).
-
-Both are thin wrappers: run_cli delegates to opensak.app.main, run_test
-shells out to pytest. We stub the heavy callees so the wrappers run
-without launching the GUI or recursing into a real test run.
-"""
+"""Cover the console-script entry points; stub the callees to avoid GUI/recursion."""
 
 import sys
 import types

--- a/tests/unit-tests/test_entrypoints.py
+++ b/tests/unit-tests/test_entrypoints.py
@@ -1,0 +1,42 @@
+"""Cover the console-script entry points (opensak / opensak-test).
+
+Both are thin wrappers: run_cli delegates to opensak.app.main, run_test
+shells out to pytest. We stub the heavy callees so the wrappers run
+without launching the GUI or recursing into a real test run.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+def test_run_cli_delegates_to_app_main(monkeypatch):
+    calls = []
+    fake_app = types.ModuleType("opensak.app")
+    fake_app.main = lambda: calls.append("ran")
+    monkeypatch.setitem(sys.modules, "opensak.app", fake_app)
+
+    from opensak.utils.run_cli import main
+
+    main()
+    assert calls == ["ran"]
+
+
+def test_run_test_forwards_argv_to_pytest_and_exits(monkeypatch):
+    captured = {}
+
+    def fake_pytest_main(args):
+        captured["args"] = args
+        return 3
+
+    monkeypatch.setattr(sys, "argv", ["opensak-test", "-k", "foo", "-x"])
+    monkeypatch.setattr(pytest, "main", fake_pytest_main)
+
+    from opensak.utils.run_test import run
+
+    with pytest.raises(SystemExit) as exit_info:
+        run()
+
+    assert exit_info.value.code == 3
+    assert captured["args"] == ["tests", "-k", "foo", "-x"]

--- a/tests/unit-tests/test_export_init.py
+++ b/tests/unit-tests/test_export_init.py
@@ -1,0 +1,10 @@
+"""Smoke-cover the export package's public API surface."""
+
+import opensak.export as export
+from opensak.export import export_kml
+
+
+def test_export_package_reexports_export_kml():
+    assert export.__all__ == ["export_kml"]
+    assert export.export_kml is export_kml
+    assert callable(export_kml)

--- a/tests/unit-tests/test_lang_modules.py
+++ b/tests/unit-tests/test_lang_modules.py
@@ -1,15 +1,4 @@
-"""Import each shipped language as a real package module so STRINGS is covered.
-
-test_languages.py validates key parity, but it (like production load_language)
-exec's the files via spec_from_file_location. Coverage never attributes that to
-opensak.lang.*, and the first such spec-exec also poisons coverage's trace
-decision for that file — so a later import wouldn't be recorded either.
-
-Importing here at collection time means coverage's first encounter with each
-language file is the genuine package import: this module is collected before
-test_languages and before the e2e fixtures call load_language(), so the eight
-files are attributed to opensak.lang.* (0% -> 100%).
-"""
+"""Cover lang/*.py by importing each language as a real package module."""
 
 import importlib
 
@@ -17,6 +6,8 @@ import pytest
 
 from opensak.lang import AVAILABLE_LANGUAGES
 
+# Import at collection time, before test_languages / e2e load_language() spec-exec
+# these files (which otherwise blocks coverage attribution for opensak.lang.*).
 _MODULES = {code: importlib.import_module(f"opensak.lang.{code}") for code in AVAILABLE_LANGUAGES}
 
 

--- a/tests/unit-tests/test_lang_modules.py
+++ b/tests/unit-tests/test_lang_modules.py
@@ -1,0 +1,27 @@
+"""Import each shipped language as a real package module so STRINGS is covered.
+
+test_languages.py validates key parity, but it (like production load_language)
+exec's the files via spec_from_file_location. Coverage never attributes that to
+opensak.lang.*, and the first such spec-exec also poisons coverage's trace
+decision for that file — so a later import wouldn't be recorded either.
+
+Importing here at collection time means coverage's first encounter with each
+language file is the genuine package import: this module is collected before
+test_languages and before the e2e fixtures call load_language(), so the eight
+files are attributed to opensak.lang.* (0% -> 100%).
+"""
+
+import importlib
+
+import pytest
+
+from opensak.lang import AVAILABLE_LANGUAGES
+
+_MODULES = {code: importlib.import_module(f"opensak.lang.{code}") for code in AVAILABLE_LANGUAGES}
+
+
+@pytest.mark.parametrize("code", sorted(AVAILABLE_LANGUAGES))
+def test_language_module_exposes_strings(code):
+    strings = _MODULES[code].STRINGS
+    assert isinstance(strings, dict)
+    assert strings


### PR DESCRIPTION
First step of the phased coverage push (#225): the quick wins. Eight language
files plus a handful of one-line entry-point modules read 0% only because
nothing imported them through the measured path. This adds focused tests to
attribute that code — **no production changes**.

## What's covered

| Module(s) | Before | After |
|---|---|---|
| `lang/{cs,da,de,en,fr,nl,pt,se}.py` | 0% | **100%** |
| `export/__init__.py` | 0% | **100%** |
| `utils/run_cli.py` | 0% | **100%** |
| `utils/run_test.py` | 0% | **100%** |

## Changes

- **`tests/unit-tests/test_lang_modules.py`** — parametrized over
  `AVAILABLE_LANGUAGES`, imports each language as a genuine package module and
  asserts a non-empty `STRINGS` dict.
- **`tests/unit-tests/test_export_init.py`** — smoke-test that
  `opensak.export` re-exports `export_kml` via `__all__` (the `kml.py`
  implementation is left for Phase 1).
- **`tests/unit-tests/test_entrypoints.py`** — covers the two console scripts:
  `run_cli` delegates to `opensak.app.main` (app stubbed, no GUI launched),
  `run_test` forwards extra args after `"tests"` and exits with pytest's return
  code (`sys.argv`/`pytest.main` stubbed).

## Note: the language coverage gotcha

`lang/*.py` looked untestable because `test_languages.py` (and production
`load_language()`) load the files via `spec_from_file_location`. Coverage never
attributes that to `opensak.lang.*`, **and** the first such spec-exec poisons
coverage's per-file trace decision — so even a later genuine import isn't
recorded. The fix is to import the languages as real package modules at
collection time, before those spec-execs run. (Refactoring `load_language()` to
drop the spec pattern is deferred to a later phase.)

## Verification

- **649 passed** (+11 over the previous 638), ~15s, no flakiness.
- Overall coverage **54.90% → 55.24%**.
- No new production code; all additions are under `tests/`.

---
Part of #225. Next: Phase 1 (pure-logic backends).