### PR TITLE
Test Coverage - Phase 1

### DIFF
--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -23,6 +23,7 @@ import json
 import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -3,11 +3,21 @@ tests/unit-tests/test_config.py — config path and language preference tests.
 """
 
 import json
+import os
+from pathlib import Path
 
 import pytest
 
 import opensak.config as config_module
-from opensak.config import get_language, set_language
+from opensak.config import (
+    get_db_path,
+    get_gc_token_path,
+    get_gpx_import_dir,
+    get_language,
+    get_log_path,
+    print_config,
+    set_language,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -69,3 +79,67 @@ class TestSetLanguage:
         set_language("nl")
         data = json.loads(isolate_prefs.read_text(encoding="utf-8"))
         assert data["language"] == "nl"
+
+    def test_corrupt_existing_file_is_replaced(self, isolate_prefs):
+        isolate_prefs.write_text("{ broken", encoding="utf-8")
+        set_language("pt")
+        assert get_language() == "pt"
+
+
+# ── get_app_data_dir (per-OS branches) ────────────────────────────────────────
+
+class TestAppDataDir:
+    def test_posix_with_xdg(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(os, "name", "posix")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        d = config_module.get_app_data_dir()
+        assert d == tmp_path / "opensak"
+        assert d.exists()
+
+    def test_posix_without_xdg(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(os, "name", "posix")
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert config_module.get_app_data_dir() == tmp_path / ".local" / "share" / "opensak"
+
+    # The Windows branch is not testable here: pathlib.Path keys off os.name at
+    # instantiation, so forcing os.name="nt" makes Path() raise on macOS/Linux.
+
+    def test_other_os_uses_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(os, "name", "java")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert config_module.get_app_data_dir() == tmp_path / "opensak"
+
+
+# ── derived paths ─────────────────────────────────────────────────────────────
+
+class TestDerivedPaths:
+    @pytest.fixture(autouse=True)
+    def _xdg(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(os, "name", "posix")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setattr(config_module, "_PREFS_FILE", None)
+        self.base = tmp_path / "opensak"
+
+    def test_db_path(self):
+        assert get_db_path() == self.base / "opensak.db"
+
+    def test_gpx_import_dir_created(self):
+        d = get_gpx_import_dir()
+        assert d == self.base / "imports"
+        assert d.exists()
+
+    def test_log_path(self):
+        assert get_log_path() == self.base / "opensak.log"
+
+    def test_gc_token_path(self):
+        assert get_gc_token_path() == self.base / "gc_token.json"
+
+    def test_prefs_file_recomputed_when_none(self):
+        assert config_module._get_prefs_file() == self.base / "preferences.json"
+
+    def test_print_config(self, capsys):
+        print_config()
+        out = capsys.readouterr().out
+        assert "App data dir" in out
+        assert "Language" in out

--- a/tests/unit-tests/test_coords.py
+++ b/tests/unit-tests/test_coords.py
@@ -6,6 +6,8 @@ from opensak.coords import (
     FORMAT_DMM,
     FORMAT_DMS,
     format_coords,
+    format_lat,
+    format_lon,
     parse_coords,
 )
 
@@ -250,3 +252,45 @@ class TestParseCoordsRoundtrip:
         assert result is not None
         # DMS has lower precision (seconds rounded to 2 dp)
         assert result == pytest.approx((lat, lon), abs=1e-3)
+
+
+# ── format_lat / format_lon (single-axis, used by table columns) ──────────────
+
+class TestFormatLat:
+    def test_dd(self):
+        assert format_lat(55.78750, FORMAT_DD) == "55.787500"
+
+    def test_dd_negative(self):
+        assert format_lat(-33.86785, FORMAT_DD) == "-33.867850"
+
+    def test_dmm_north(self):
+        assert format_lat(55.7875, FORMAT_DMM) == "N55 47.250"
+
+    def test_dmm_south(self):
+        assert format_lat(-33.5, FORMAT_DMM) == "S33 30.000"
+
+    def test_dms_north(self):
+        assert format_lat(55.7875, FORMAT_DMS) == "N55° 47' 15.00\""
+
+    def test_dms_south(self):
+        assert format_lat(-1.5, FORMAT_DMS).startswith("S01°")
+
+
+class TestFormatLon:
+    def test_dd(self):
+        assert format_lon(12.41667, FORMAT_DD) == "12.416670"
+
+    def test_dd_negative(self):
+        assert format_lon(-0.12776, FORMAT_DD) == "-0.127760"
+
+    def test_dmm_east_pads_three_digits(self):
+        assert format_lon(12.41667, FORMAT_DMM) == "E012 25.000"
+
+    def test_dmm_west(self):
+        assert format_lon(-90.379567, FORMAT_DMM) == "W090 22.774"
+
+    def test_dms_east(self):
+        assert format_lon(12.41667, FORMAT_DMS) == "E012° 25' 00.01\""
+
+    def test_dms_west(self):
+        assert format_lon(-90.5, FORMAT_DMS).startswith("W090°")

--- a/tests/unit-tests/test_db.py
+++ b/tests/unit-tests/test_db.py
@@ -262,6 +262,24 @@ class TestDisposeEngine:
         assert database._engine is None
 
 
+class TestModelReprs:
+    def test_waypoint_repr(self):
+        assert "Waypoint" in repr(Waypoint(prefix="PK", cache_id=1))
+
+    def test_log_repr(self):
+        assert "Log" in repr(Log(log_type="Found it", finder="Tester"))
+
+    def test_attribute_repr(self):
+        assert "Attribute" in repr(Attribute(name="Kids", is_on=True))
+        assert "Attribute" in repr(Attribute(name="Dogs", is_on=False))
+
+    def test_trackable_repr(self):
+        assert "Trackable" in repr(Trackable())
+
+    def test_usernote_repr(self):
+        assert "UserNote" in repr(UserNote(cache_id=1))
+
+
 class TestInitDbDefaultPath:
     def test_uses_manager_active_path(self, tmp_path, monkeypatch):
         path = tmp_path / "managed.db"

--- a/tests/unit-tests/test_db.py
+++ b/tests/unit-tests/test_db.py
@@ -1,10 +1,20 @@
 """tests/unit-tests/test_db.py — database model, session and CRUD tests."""
 
+from types import SimpleNamespace
+
 import pytest
 from pathlib import Path
 from datetime import datetime
 
-from opensak.db.database import init_db, get_session, db_health_check
+from opensak.db import database
+from opensak.db.database import (
+    init_db,
+    get_session,
+    get_engine,
+    make_session,
+    dispose_engine,
+    db_health_check,
+)
 from opensak.db.models import Cache, Waypoint, Log, Attribute, Trackable, UserNote
 
 
@@ -199,3 +209,84 @@ def test_health_check(tmp_db):
     assert "logs" in stats
     assert "waypoints" in stats
     assert all(isinstance(v, int) for v in stats.values())
+
+
+# ── Engine lifecycle ──────────────────────────────────────────────────────────
+
+class TestEngineGuards:
+    def test_get_engine_raises_when_uninitialised(self, monkeypatch):
+        monkeypatch.setattr(database, "_engine", None)
+        with pytest.raises(RuntimeError):
+            get_engine()
+
+    def test_get_session_raises_when_uninitialised(self, monkeypatch):
+        monkeypatch.setattr(database, "_SessionLocal", None)
+        with pytest.raises(RuntimeError):
+            with get_session():
+                pass
+
+    def test_make_session_raises_when_uninitialised(self, monkeypatch):
+        monkeypatch.setattr(database, "_SessionLocal", None)
+        with pytest.raises(RuntimeError):
+            make_session()
+
+    def test_get_session_rolls_back_on_error(self, tmp_db):
+        with pytest.raises(ValueError):
+            with get_session() as s:
+                s.add(Cache(gc_code="GCROLL", name="x", cache_type="Traditional Cache"))
+                raise ValueError("boom")
+        with get_session() as s:
+            assert s.query(Cache).filter_by(gc_code="GCROLL").first() is None
+
+
+class TestDisposeEngine:
+    def test_noop_when_no_engine(self, monkeypatch):
+        monkeypatch.setattr(database, "_engine", None)
+        dispose_engine()  # must not raise
+
+    def test_disposes_active_engine(self, tmp_path):
+        init_db(db_path=tmp_path / "d.db")
+        assert database._engine is not None
+        dispose_engine()
+        assert database._engine is None
+
+    def test_skips_when_path_mismatch(self, tmp_path):
+        init_db(db_path=tmp_path / "keep.db")
+        dispose_engine(tmp_path / "other.db")
+        assert database._engine is not None
+
+    def test_disposes_when_path_matches(self, tmp_path):
+        target = tmp_path / "match.db"
+        init_db(db_path=target)
+        dispose_engine(target)
+        assert database._engine is None
+
+
+class TestInitDbDefaultPath:
+    def test_uses_manager_active_path(self, tmp_path, monkeypatch):
+        path = tmp_path / "managed.db"
+        monkeypatch.setattr(
+            "opensak.db.manager.get_db_manager",
+            lambda: SimpleNamespace(active_path=path),
+        )
+        init_db()
+        assert "managed.db" in str(get_engine().url)
+
+    def test_falls_back_to_config_when_no_active_path(self, tmp_path, monkeypatch):
+        path = tmp_path / "configured.db"
+        monkeypatch.setattr(
+            "opensak.db.manager.get_db_manager",
+            lambda: SimpleNamespace(active_path=None),
+        )
+        monkeypatch.setattr("opensak.config.get_db_path", lambda: path)
+        init_db()
+        assert "configured.db" in str(get_engine().url)
+
+    def test_falls_back_to_config_when_manager_unavailable(self, tmp_path, monkeypatch):
+        path = tmp_path / "fallback.db"
+        def boom():
+            raise RuntimeError("no manager")
+        monkeypatch.setattr("opensak.db.manager.get_db_manager", boom)
+        monkeypatch.setattr("opensak.config.get_db_path", lambda: path)
+        init_db()
+        assert "fallback.db" in str(get_engine().url)

--- a/tests/unit-tests/test_db_manager.py
+++ b/tests/unit-tests/test_db_manager.py
@@ -1,5 +1,7 @@
 """tests/unit-tests/test_db_manager.py — DatabaseManager unit tests (QSettings mocked)."""
 
+from datetime import datetime
+
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -150,3 +152,105 @@ class TestDeleteDatabase:
         info = manager.new_database("Ghost", db_path)
         manager.delete_database(info)  # file never existed — must not raise
         assert info not in manager.databases
+
+
+# ── DatabaseInfo (pure logic) ─────────────────────────────────────────────────
+
+class TestDatabaseInfo:
+    def test_exists_reflects_file(self, tmp_path):
+        p = tmp_path / "x.db"
+        info = DatabaseInfo("X", p)
+        assert info.exists is False
+        p.touch()
+        assert info.exists is True
+
+    def test_size_mb(self, tmp_path):
+        p = tmp_path / "x.db"
+        p.write_bytes(b"a" * (1024 * 1024))
+        assert DatabaseInfo("X", p).size_mb == pytest.approx(1.0, abs=0.01)
+
+    def test_size_mb_zero_when_missing(self, tmp_path):
+        assert DatabaseInfo("X", tmp_path / "missing.db").size_mb == 0.0
+
+    def test_modified_returns_datetime(self, tmp_path):
+        p = tmp_path / "x.db"
+        p.touch()
+        assert isinstance(DatabaseInfo("X", p).modified, datetime)
+
+    def test_modified_none_when_missing(self, tmp_path):
+        assert DatabaseInfo("X", tmp_path / "missing.db").modified is None
+
+    def test_to_from_dict_roundtrip(self, tmp_path):
+        p = tmp_path / "x.db"
+        d = DatabaseInfo("X", p).to_dict()
+        assert d == {"name": "X", "path": str(p)}
+        restored = DatabaseInfo.from_dict(d)
+        assert restored.name == "X"
+        assert restored.path == p
+
+    def test_repr(self, tmp_path):
+        assert "DatabaseInfo" in repr(DatabaseInfo("X", tmp_path / "x.db"))
+
+
+# ── open_database ─────────────────────────────────────────────────────────────
+
+class TestOpenDatabase:
+    def test_file_not_found_raises(self, manager, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            manager.open_database(tmp_path / "nope.db")
+
+    def test_opens_existing_file(self, manager, tmp_path):
+        p = tmp_path / "ext.db"
+        p.touch()
+        info = manager.open_database(p)
+        assert info.path == p
+        assert info in manager.databases
+
+    def test_returns_existing_entry_for_same_path(self, manager, tmp_path):
+        p = tmp_path / "ext.db"
+        p.touch()
+        assert manager.open_database(p) is manager.open_database(p)
+
+    def test_dedupes_name_collision(self, manager, tmp_path):
+        manager.new_database("data", tmp_path / "a.db")
+        p = tmp_path / "data.db"
+        p.touch()
+        assert manager.open_database(p).name == "data (2)"
+
+
+# ── switch_to / copy_database / ensure_active_initialised ──────────────────────
+
+class TestSwitchTo:
+    def test_switch_sets_active(self, manager, tmp_path):
+        info = manager.new_database("Other", tmp_path / "other.db")
+        manager.switch_to(info)
+        assert manager.active is info
+        assert manager.active_path == info.path
+
+
+class TestCopyDatabase:
+    def test_copies_file_and_adds_entry(self, manager, tmp_path):
+        src = manager.new_database("Src", tmp_path / "src.db")
+        src.path.touch()
+        copy = manager.copy_database(src, "Copy", tmp_path / "copy.db")
+        assert copy.path.exists()
+        assert copy in manager.databases
+
+    def test_default_path_uses_app_data_dir(self, manager, tmp_path):
+        src = manager.new_database("Src", tmp_path / "src.db")
+        src.path.touch()
+        copy = manager.copy_database(src, "CopyDefault")
+        assert copy.path == tmp_path / "CopyDefault.db"
+        assert copy.path.exists()
+
+    def test_rejects_duplicate_name(self, manager, tmp_path):
+        src = manager.new_database("Src", tmp_path / "src.db")
+        src.path.touch()
+        with pytest.raises(ValueError):
+            manager.copy_database(src, "Default", tmp_path / "c.db")
+
+
+class TestEnsureActiveInitialised:
+    def test_initialises_active(self, manager):
+        manager.ensure_active_initialised()  # init_db is patched; exercises the call path
+        assert manager.active is not None

--- a/tests/unit-tests/test_doctor.py
+++ b/tests/unit-tests/test_doctor.py
@@ -1,16 +1,25 @@
 """tests/unit-tests/test_doctor.py — doctor checks (python, deps, config dir, metadata)."""
 
 import importlib
+import importlib.metadata
+import subprocess
 import sys
-from pathlib import Path
-from unittest.mock import patch
+import tomllib
+from types import SimpleNamespace
 
 import pytest
 
+from opensak.utils import doctor
 from opensak.utils.doctor import (
     check_config_dir,
     check_dependencies,
+    check_feature_flags,
+    check_git,
     check_python,
+    check_venv,
+    extract_package_name,
+    parse_python_requirement,
+    run,
     _project_metadata,
 )
 
@@ -152,3 +161,122 @@ class TestProjectMetadata:
         data = _project_metadata()
         for dep in data["dependencies"]:
             assert "extra ==" not in dep
+
+    def test_falls_back_to_pyproject_when_package_missing(self, monkeypatch):
+        def boom(_name):
+            raise importlib.metadata.PackageNotFoundError("opensak")
+        monkeypatch.setattr(importlib.metadata, "metadata", boom)
+        data = _project_metadata()
+        assert "requires-python" in data
+        assert isinstance(data["dependencies"], list)
+
+    def test_returns_empty_when_both_sources_fail(self, monkeypatch):
+        def boom_meta(_name):
+            raise importlib.metadata.PackageNotFoundError("opensak")
+        def boom_load(_f):
+            raise ValueError("bad toml")
+        monkeypatch.setattr(importlib.metadata, "metadata", boom_meta)
+        monkeypatch.setattr(tomllib, "load", boom_load)
+        assert _project_metadata() == {}
+
+
+# ── small helpers ─────────────────────────────────────────────────────────────
+
+class TestHelpers:
+    @pytest.mark.parametrize("dep,expected", [
+        ("PySide6>=6.5", "PySide6"),
+        ("sqlalchemy[asyncio]>=2.0", "sqlalchemy"),
+        ("pkg!=1.0", "pkg"),
+        ("pkg; python_version>'3.8'", "pkg"),
+        ("trailing ", "trailing"),
+    ])
+    def test_extract_package_name(self, dep, expected):
+        assert extract_package_name(dep) == expected
+
+    @pytest.mark.parametrize("spec,expected", [
+        (">=3.11", (3, 11)),
+        ("3.13", (3, 13)),
+        (">=3.10.2", (3, 10, 2)),
+    ])
+    def test_parse_python_requirement(self, spec, expected):
+        assert parse_python_requirement(spec) == expected
+
+
+# ── check_venv ────────────────────────────────────────────────────────────────
+
+class TestCheckVenv:
+    def test_returns_name_and_bool(self):
+        name, active, msg = check_venv()
+        assert name == "Virtualenv"
+        assert isinstance(active, bool)
+        assert msg in ("active", "not active")
+
+
+# ── check_git ─────────────────────────────────────────────────────────────────
+
+class TestCheckGit:
+    def test_success(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="git version 2.40.0\n"),
+        )
+        name, ok, msg = check_git()
+        assert name == "Git" and ok is True
+        assert "git version" in msg
+
+    def test_nonzero_exit(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout=""),
+        )
+        _, ok, msg = check_git()
+        assert ok is False
+        assert "error" in msg
+
+    def test_git_not_installed(self, monkeypatch):
+        def boom(*a, **k):
+            raise FileNotFoundError
+        monkeypatch.setattr(subprocess, "run", boom)
+        _, ok, msg = check_git()
+        assert ok is False
+        assert "not found" in msg
+
+
+# ── check_feature_flags ───────────────────────────────────────────────────────
+
+class TestCheckFeatureFlags:
+    def test_success(self):
+        name, ok, _ = check_feature_flags()
+        assert name == "Feature flags"
+        assert ok is True
+
+    def test_failure_branch(self, monkeypatch):
+        # Drop a flag attribute so getattr() inside the check raises -> except branch.
+        from opensak.utils import flags
+        monkeypatch.delattr(flags, "where_filter", raising=False)
+        _, ok, _ = check_feature_flags()
+        assert ok is False
+
+
+# ── run ───────────────────────────────────────────────────────────────────────
+
+class TestRun:
+    def test_real_run_prints_report(self, capsys):
+        run()
+        out = capsys.readouterr().out
+        assert "OpenSAK Doctor" in out
+        assert "Python:" in out
+
+    def test_all_passed_branch(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor, "CHECKS", [lambda: ("X", True, "ok")])
+        monkeypatch.setattr(doctor, "_TAKES_PROJECT", set())
+        run()
+        assert "All checks passed." in capsys.readouterr().out
+
+    def test_failure_branch_suggests_fix(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor, "CHECKS", [lambda: ("X", False, "bad")])
+        monkeypatch.setattr(doctor, "_TAKES_PROJECT", set())
+        run()
+        out = capsys.readouterr().out
+        assert "Some checks failed." in out
+        assert "pip install" in out

--- a/tests/unit-tests/test_filters.py
+++ b/tests/unit-tests/test_filters.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from pathlib import Path
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from opensak.db.database import get_session
 from opensak.db.models import Cache, Attribute, Trackable
@@ -16,6 +17,8 @@ from opensak.filters.engine import (
     DistanceFilter, AttributeFilter, HasTrackableFilter,
     PremiumFilter, NonPremiumFilter,
     WhereClauseFilter,
+    HasCorrectedFilter, UserFlagFilter, DnfFilter, FtfFilter,
+    FavoritePointsFilter, FoundByMeDateFilter, DnfDateFilter, LastLogDateFilter,
     # Helpers
     _haversine_km, _iter_filters, FILTER_REGISTRY, SORT_FIELDS,
 )
@@ -727,3 +730,99 @@ def test_where_clause_profile_save_load(tmp_path):
     ]
     assert len(where_filters) == 1
     assert where_filters[0].sql == sql
+
+
+# ── Python-side matches for flag/date/points filters ──────────────────────────
+
+def _cache(**kw):
+    base = dict(
+        user_note=None, user_flag=False, dnf=False, first_to_find=False,
+        favorite_points=0, found=False, found_date=None, dnf_date=None,
+        last_log_date=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class TestFlagFilters:
+    def test_has_corrected(self):
+        f = HasCorrectedFilter()
+        assert f.matches(_cache(user_note=SimpleNamespace(is_corrected=True))) is True
+        assert f.matches(_cache(user_note=None)) is False
+
+    def test_user_flag(self):
+        f = UserFlagFilter(flagged=True)
+        assert f.matches(_cache(user_flag=True)) is True
+        assert f.matches(_cache(user_flag=False)) is False
+        assert UserFlagFilter.from_dict(f.to_dict()).flagged is True
+
+    def test_dnf(self):
+        f = DnfFilter(has_dnf=True)
+        assert f.matches(_cache(dnf=True)) is True
+        assert f.matches(_cache(dnf=False)) is False
+        assert DnfFilter.from_dict(f.to_dict()).has_dnf is True
+
+    def test_ftf(self):
+        f = FtfFilter(has_ftf=True)
+        assert f.matches(_cache(first_to_find=True)) is True
+        assert f.matches(_cache(first_to_find=False)) is False
+        assert FtfFilter.from_dict(f.to_dict()).has_ftf is True
+
+    def test_favorite_points(self):
+        f = FavoritePointsFilter(min_pts=5, max_pts=10)
+        assert f.matches(_cache(favorite_points=7)) is True
+        assert f.matches(_cache(favorite_points=2)) is False
+        assert f.matches(_cache(favorite_points=None)) is False
+        restored = FavoritePointsFilter.from_dict(f.to_dict())
+        assert (restored.min_pts, restored.max_pts) == (5, 10)
+
+
+class TestDateFilters:
+    FROM = datetime(2020, 1, 1)
+    TO = datetime(2020, 12, 31)
+
+    def test_found_by_me_date(self):
+        f = FoundByMeDateFilter(from_date=self.FROM, to_date=self.TO)
+        assert f.matches(_cache(found=False)) is False
+        assert f.matches(_cache(found=True, found_date=None)) is True
+        assert f.matches(_cache(found=True, found_date=datetime(2020, 6, 1))) is True
+        assert f.matches(_cache(found=True, found_date=datetime(2019, 6, 1))) is False
+        assert f.matches(_cache(found=True, found_date=datetime(2021, 6, 1))) is False
+        restored = FoundByMeDateFilter.from_dict(f.to_dict())
+        assert restored.from_date == self.FROM and restored.to_date == self.TO
+
+    def test_dnf_date(self):
+        f = DnfDateFilter(from_date=self.FROM, to_date=self.TO)
+        assert f.matches(_cache(dnf=False)) is False
+        assert f.matches(_cache(dnf=True, dnf_date=None)) is True
+        assert f.matches(_cache(dnf=True, dnf_date=datetime(2020, 6, 1))) is True
+        assert f.matches(_cache(dnf=True, dnf_date=datetime(2019, 6, 1))) is False
+        restored = DnfDateFilter.from_dict(f.to_dict())
+        assert restored.from_date == self.FROM
+
+    def test_last_log_date(self):
+        f = LastLogDateFilter(from_date=self.FROM, to_date=self.TO)
+        assert f.matches(_cache(last_log_date=None)) is False
+        assert f.matches(_cache(last_log_date=datetime(2020, 6, 1))) is True
+        assert f.matches(_cache(last_log_date=datetime(2019, 6, 1))) is False
+        assert f.matches(_cache(last_log_date=datetime(2021, 6, 1))) is False
+        restored = LastLogDateFilter.from_dict(f.to_dict())
+        assert restored.to_date == self.TO
+
+
+class TestFilterSetEdges:
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            FilterSet(mode="XOR")
+
+    def test_clear_and_len(self):
+        fs = FilterSet("AND").add(FoundFilter())
+        assert len(fs) == 1
+        fs.clear()
+        assert len(fs) == 0
+
+    def test_empty_set_matches_everything(self):
+        assert FilterSet("AND").matches(_cache()) is True
+
+    def test_repr(self):
+        assert "FilterSet" in repr(FilterSet("OR"))

--- a/tests/unit-tests/test_found_updater.py
+++ b/tests/unit-tests/test_found_updater.py
@@ -1,10 +1,12 @@
 """tests/unit-tests/test_found_updater.py — found-status sync from a reference DB."""
 
+from datetime import datetime
+
 import pytest
 from pathlib import Path
 
 from opensak.db.database import init_db, get_session
-from opensak.db.models import Cache
+from opensak.db.models import Cache, Log
 from opensak.db.found_updater import get_found_gc_codes, update_found_from_reference
 
 
@@ -58,6 +60,17 @@ class TestGetFoundGcCodes:
         with pytest.raises(RuntimeError, match="Kunne ikke læse reference database"):
             get_found_gc_codes(bad_path)
 
+    def test_parses_found_it_log_date(self, tmp_path, make_cache):
+        ref_path = tmp_path / "ref.db"
+        init_db(db_path=ref_path)
+        with get_session() as s:
+            c = make_cache("GC00001")
+            c.logs.append(Log(log_type="Found it", log_date=datetime(2020, 5, 1)))
+            s.add(c)
+        found = get_found_gc_codes(ref_path)
+        assert found["GC00001"] is not None
+        assert found["GC00001"].year == 2020
+
 
 # ── update_found_from_reference ───────────────────────────────────────────────
 
@@ -101,6 +114,25 @@ class TestUpdateFoundFromReference:
 
         assert result.already == 1
         assert result.updated == 1
+
+    def test_already_found_updates_date_from_reference(self, tmp_path, make_cache):
+        ref_path = tmp_path / "ref.db"
+        active_path = tmp_path / "active.db"
+
+        init_db(db_path=ref_path)
+        with get_session() as s:
+            c = make_cache("GC00001")
+            c.logs.append(Log(log_type="Found it", log_date=datetime(2018, 3, 4)))
+            s.add(c)
+        _setup_active_db(active_path, [{"gc_code": "GC00001", "found": True}], make_cache)
+
+        result = update_found_from_reference(ref_path)
+
+        assert result.already == 1
+        with get_session() as s:
+            cache = s.query(Cache).filter_by(gc_code="GC00001").first()
+            assert cache.found_date is not None
+            assert cache.found_date.year == 2018
 
     def test_not_found_counts_ref_codes_missing_from_active(self, tmp_path, make_cache):
         ref_path = tmp_path / "ref.db"

--- a/tests/unit-tests/test_garmin.py
+++ b/tests/unit-tests/test_garmin.py
@@ -1,6 +1,8 @@
-"""tests/unit-tests/test_garmin.py — Garmin GPX generation/export (no device needed)."""
+"""tests/unit-tests/test_garmin.py — Garmin GPX/LOC/GGZ generation/export (no device needed)."""
 
+import io
 import xml.etree.ElementTree as ET
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,10 +16,15 @@ from opensak.gps.garmin import (
     _cache_symbol,
     _effective_coords,
     _is_garmin,
+    _macos_volumes,
+    debug_scan,
     delete_gpx_files,
     export_to_device,
     export_to_file,
+    find_garmin_devices,
+    generate_ggz,
     generate_gpx,
+    generate_loc,
     get_garmin_gpx_path,
 )
 
@@ -412,3 +419,178 @@ class TestExportResult:
         r = ExportResult()
         r.error = "Permission denied"
         assert "Permission denied" in str(r)
+
+
+# ── generate_loc ──────────────────────────────────────────────────────────────
+
+class TestGenerateLoc:
+    def test_xml_declaration_and_root(self):
+        out = generate_loc([_cache()])
+        assert out.startswith('<?xml version="1.0"')
+        root = ET.fromstring(out.split("\n", 1)[1])
+        assert root.tag == "loc"
+        assert root.get("src") == "OpenSAK"
+
+    def test_waypoint_fields(self):
+        out = generate_loc([_cache(gc_code="GCLOC1", name="LocCache",
+                                   placed_by="Owner", difficulty=2.0, terrain=3.0,
+                                   container="Small")])
+        assert 'id="GCLOC1"' in out
+        assert "coord.info/GCLOC1" in out
+        assert "<container>Small</container>" in out
+
+    def test_cdata_label_restored(self):
+        out = generate_loc([_cache(name="My Cache", placed_by="Bob",
+                                   difficulty=1.5, terrain=2.0)])
+        assert "<![CDATA[My Cache by Bob (1.5/2)]]>" in out
+
+    def test_container_defaults_to_unknown(self):
+        out = generate_loc([_cache(container=None)])
+        assert "<container>Unknown</container>" in out
+
+    def test_corrected_coords_used(self):
+        c = _cache(latitude=55.0, longitude=12.0,
+                   user_note=_note(is_corrected=True, corrected_lat=60.0, corrected_lon=20.0))
+        out = generate_loc([c])
+        assert 'lat="60.000000"' in out
+        assert 'lon="20.000000"' in out
+
+    def test_skips_cache_without_coords(self):
+        c = _cache(gc_code="GCNULL")
+        c.latitude = None
+        out = generate_loc([c])
+        assert "GCNULL" not in out
+
+
+# ── generate_ggz ──────────────────────────────────────────────────────────────
+
+def _ggz_entries(blob: bytes) -> dict[str, bytes]:
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        return {n: zf.read(n) for n in zf.namelist() if not n.endswith("/")}
+
+
+class TestGenerateGgz:
+    def test_returns_valid_zip(self):
+        blob = generate_ggz([_cache()])
+        assert isinstance(blob, bytes)
+        assert zipfile.is_zipfile(io.BytesIO(blob))
+
+    def test_contains_gpx_and_index(self):
+        entries = _ggz_entries(generate_ggz([_cache()], filename="myexport"))
+        assert "data/myexport.gpx" in entries
+        assert "index/com/garmin/geocaches/v0/index.xml" in entries
+
+    def test_index_lists_cache(self):
+        entries = _ggz_entries(generate_ggz([_cache(gc_code="GCGGZ1", name="GgzCache")]))
+        index = entries["index/com/garmin/geocaches/v0/index.xml"].decode("utf-8")
+        assert "GCGGZ1" in index
+        assert "GgzCache" in index
+        assert "<crc>" in index
+
+    def test_container_size_mapping(self):
+        index = _ggz_entries(generate_ggz([_cache(container="Regular")]))[
+            "index/com/garmin/geocaches/v0/index.xml"].decode("utf-8")
+        assert "<size>4.0</size>" in index
+
+    def test_unknown_container_omits_size(self):
+        index = _ggz_entries(generate_ggz([_cache(container="Huge")]))[
+            "index/com/garmin/geocaches/v0/index.xml"].decode("utf-8")
+        assert "<size>" not in index
+
+    def test_no_container_omits_size(self):
+        index = _ggz_entries(generate_ggz([_cache(container=None)]))[
+            "index/com/garmin/geocaches/v0/index.xml"].decode("utf-8")
+        assert "<size>" not in index
+
+    def test_found_flag_in_index(self):
+        c = _cache(gc_code="GCFOUND")
+        c.found = True
+        index = _ggz_entries(generate_ggz([c]))[
+            "index/com/garmin/geocaches/v0/index.xml"].decode("utf-8")
+        assert "<found>true</found>" in index
+
+    def test_skips_cache_without_coords(self):
+        c = _cache(gc_code="GCNULL")
+        c.longitude = None
+        index = _ggz_entries(generate_ggz([_cache(gc_code="GCOK"), c]))[
+            "index/com/garmin/geocaches/v0/index.xml"].decode("utf-8")
+        assert "GCOK" in index
+        assert "GCNULL" not in index
+
+
+# ── device scanning ───────────────────────────────────────────────────────────
+
+class TestDeviceScan:
+    def test_find_garmin_devices_filters_to_garmin(self, tmp_path, monkeypatch):
+        garmin = tmp_path / "GARMIN_DEV"
+        (garmin / "Garmin").mkdir(parents=True)
+        (garmin / "Garmin" / "GarminDevice.xml").write_text("<device/>")
+        plain = tmp_path / "USB"
+        plain.mkdir()
+        monkeypatch.setattr("opensak.gps.garmin._get_mount_points", lambda: [garmin, plain])
+        assert find_garmin_devices() == [garmin]
+
+    def test_debug_scan_reports_devices(self, tmp_path, monkeypatch):
+        garmin = tmp_path / "GARMIN_DEV"
+        (garmin / "Garmin").mkdir(parents=True)
+        (garmin / "Garmin" / "GarminDevice.xml").write_text("<device/>")
+        monkeypatch.setattr("opensak.gps.garmin._get_mount_points", lambda: [garmin])
+        report = debug_scan()
+        assert "Garmin scan debug" in report
+        assert "GARMIN" in report
+
+    def test_macos_volumes_returns_list(self):
+        # On the test host /Volumes exists; just assert the shape.
+        assert isinstance(_macos_volumes(), list)
+
+
+# ── error paths ───────────────────────────────────────────────────────────────
+
+class TestErrorPaths:
+    def _device_with_gpx(self, root, names):
+        gpx_dir = root / GARMIN_GPX_SUBPATH
+        gpx_dir.mkdir(parents=True)
+        for n in names:
+            (gpx_dir / n).write_text("x")
+        return gpx_dir
+
+    def test_delete_skips_non_file_match(self, tmp_path):
+        gpx_dir = self._device_with_gpx(tmp_path, ["a.gpx"])
+        (gpx_dir / "dir.gpx").mkdir()  # matches *.gpx but is not a file
+        result = delete_gpx_files(tmp_path)
+        assert result.deleted_count == 1
+
+    def test_delete_records_failed_unlink(self, tmp_path, monkeypatch):
+        self._device_with_gpx(tmp_path, ["a.gpx"])
+        def boom(self, *a, **k):
+            raise OSError("locked")
+        monkeypatch.setattr(Path, "unlink", boom)
+        result = delete_gpx_files(tmp_path)
+        assert result.failed_count == 1
+        assert result.deleted_count == 0
+
+    def test_delete_outer_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gps.garmin.get_garmin_gpx_path",
+            lambda root: (_ for _ in ()).throw(OSError("boom")),
+        )
+        result = delete_gpx_files(tmp_path)
+        assert result.success is False
+        assert "fejl" in result.error.lower()
+
+    def test_export_to_device_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gps.garmin.generate_gpx",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("nope")),
+        )
+        result = export_to_device([_cache()], tmp_path / "dev")
+        assert result.success is False
+
+    def test_export_to_file_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gps.garmin.generate_gpx",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("nope")),
+        )
+        result = export_to_file([_cache()], tmp_path / "out.gpx")
+        assert result.success is False
+        assert "nope" in result.error

--- a/tests/unit-tests/test_geocaching_api.py
+++ b/tests/unit-tests/test_geocaching_api.py
@@ -11,12 +11,25 @@ import pytest
 
 import opensak.api.geocaching as gc_module
 from opensak.api.geocaching import (
+    _api_get,
     _delete_token,
+    _exchange_code,
     _generate_pkce,
+    _get_user_logs,
     _is_token_valid,
     _load_token,
+    _refresh_token,
     _save_token,
     get_cache_details,
+    get_favorite_points,
+    get_trackables_in_cache,
+    get_user_activity,
+    get_user_archives,
+    get_user_dnfs,
+    get_user_finds,
+    get_user_notes,
+    get_user_profile,
+    get_valid_token,
     is_logged_in,
     logout,
 )
@@ -235,3 +248,164 @@ class TestGetCacheDetails:
         with patch.object(gc_module, "GC_CLIENT_ID", "test_client_id"):
             result = get_cache_details("GC12345")
         assert result is None
+
+
+# ── token persistence edge branches ───────────────────────────────────────────
+
+class TestTokenEdges:
+    def test_save_ignores_chmod_failure(self, token_file, monkeypatch):
+        monkeypatch.setattr(gc_module.os, "chmod", lambda *a, **k: (_ for _ in ()).throw(OSError()))
+        _save_token({"access_token": "x", "expires_at": 9_999_999_999})
+        assert token_file.exists()
+
+    def test_load_returns_none_on_corrupt_json(self, token_file):
+        token_file.write_text("not json", encoding="utf-8")
+        gc_module._cached_token = None
+        assert _load_token() is None
+
+
+# ── _exchange_code / _refresh_token ───────────────────────────────────────────
+
+class TestTokenExchange:
+    def test_exchange_code_saves_token(self, token_file):
+        payload = {"access_token": "AT", "refresh_token": "RT", "expires_in": 1000}
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+            token = _exchange_code("auth_code", "verifier")
+        assert token["access_token"] == "AT"
+        assert "expires_at" in token
+        assert _load_token()["refresh_token"] == "RT"
+
+    def test_refresh_returns_none_without_refresh_token(self, token_file):
+        _save_token({"access_token": "AT", "expires_at": 1})  # no refresh_token
+        assert _refresh_token() is None
+
+    def test_refresh_success(self, token_file):
+        _save_token({"access_token": "old", "refresh_token": "RT", "expires_at": 1})
+        payload = {"access_token": "new", "refresh_token": "RT2", "expires_in": 1000}
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+            token = _refresh_token()
+        assert token["access_token"] == "new"
+        assert "expires_at" in token
+
+    def test_refresh_returns_none_on_exception(self, token_file):
+        _save_token({"access_token": "old", "refresh_token": "RT", "expires_at": 1})
+        with patch("urllib.request.urlopen", side_effect=RuntimeError("net")):
+            assert _refresh_token() is None
+
+
+# ── get_valid_token ───────────────────────────────────────────────────────────
+
+class TestGetValidToken:
+    def test_none_when_no_token(self, token_file):
+        assert get_valid_token() is None
+
+    def test_returns_access_token_when_valid(self, token_file):
+        _save_token({"access_token": "AT", "expires_at": time.time() + 3600})
+        assert get_valid_token() == "AT"
+
+    def test_refreshes_when_expired(self, token_file):
+        _save_token({"access_token": "old", "refresh_token": "RT", "expires_at": time.time() - 1})
+        payload = {"access_token": "fresh", "refresh_token": "RT2", "expires_in": 1000}
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+            assert get_valid_token() == "fresh"
+
+    def test_none_when_expired_and_refresh_fails(self, token_file):
+        _save_token({"access_token": "old", "refresh_token": "RT", "expires_at": time.time() - 1})
+        with patch("urllib.request.urlopen", side_effect=RuntimeError("net")):
+            assert get_valid_token() is None
+
+
+# ── _api_get ──────────────────────────────────────────────────────────────────
+
+class TestApiGet:
+    def test_returns_none_when_not_logged_in(self, token_file):
+        assert _api_get("/x") is None
+
+    def test_success_with_params(self, logged_in_client):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen({"ok": True})):
+            assert _api_get("/x", params={"a": 1}) == {"ok": True}
+
+    def test_other_http_error_returns_none(self, logged_in_client):
+        err = urllib.error.HTTPError(url=None, code=500, msg="x", hdrs=None, fp=None)
+        with patch("urllib.request.urlopen", side_effect=err):
+            assert _api_get("/x") is None
+
+    def test_generic_exception_returns_none(self, logged_in_client):
+        with patch("urllib.request.urlopen", side_effect=RuntimeError("boom")):
+            assert _api_get("/x") is None
+
+    def test_401_triggers_refresh_and_retry(self, token_file):
+        _save_token({"access_token": "valid", "refresh_token": "RT", "expires_at": time.time() + 3600})
+        err401 = urllib.error.HTTPError(url=None, code=401, msg="x", hdrs=None, fp=None)
+        with patch.object(gc_module, "GC_CLIENT_ID", "cid"):
+            with patch("urllib.request.urlopen", side_effect=[
+                err401,
+                _mock_urlopen({"access_token": "new", "refresh_token": "RT2", "expires_in": 1000}),
+                _mock_urlopen({"retried": True}),
+            ]):
+                assert _api_get("/x") == {"retried": True}
+
+
+# ── higher-level API functions ────────────────────────────────────────────────
+
+class TestHigherLevelApi:
+    def test_trackables_list_response(self, logged_in_client):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen([{"referenceCode": "TB1"}])):
+            result = get_trackables_in_cache("GC12345")
+        assert result == [{"referenceCode": "TB1"}]
+
+    def test_trackables_data_wrapped_response(self, logged_in_client):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen({"data": [{"referenceCode": "TB2"}]})):
+            result = get_trackables_in_cache("GC12345")
+        assert result == [{"referenceCode": "TB2"}]
+
+    def test_trackables_none_when_client_id_empty(self, token_file):
+        with patch.object(gc_module, "GC_CLIENT_ID", ""):
+            assert get_trackables_in_cache("GC12345") is None
+
+    def test_trackables_none_for_invalid_gc(self, logged_in_client):
+        assert get_trackables_in_cache("INVALID") is None
+
+    def test_trackables_none_when_api_fails(self, logged_in_client):
+        with patch("urllib.request.urlopen", side_effect=RuntimeError("net")):
+            assert get_trackables_in_cache("GC12345") is None
+
+    def test_get_user_logs_none_when_api_fails(self, logged_in_client):
+        with patch("urllib.request.urlopen", side_effect=RuntimeError("net")):
+            assert _get_user_logs("bob", max_results=10) is None
+
+    def test_user_profile_success(self, logged_in_client):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen({"username": "bob"})):
+            assert get_user_profile()["username"] == "bob"
+
+    def test_user_profile_none_without_client_id(self, token_file):
+        with patch.object(gc_module, "GC_CLIENT_ID", ""):
+            assert get_user_profile() is None
+
+    def test_get_user_logs_with_types(self, logged_in_client):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen({"data": [{"referenceCode": "L1"}]})):
+            result = _get_user_logs("bob", log_types=list(gc_module.LogType), max_results=50)
+        assert result == [{"referenceCode": "L1"}]
+
+    def test_get_user_logs_list_response(self, logged_in_client):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen([{"referenceCode": "L2"}])):
+            assert _get_user_logs("bob", max_results=10) == [{"referenceCode": "L2"}]
+
+    def test_get_user_logs_none_without_client_id(self, token_file):
+        with patch.object(gc_module, "GC_CLIENT_ID", ""):
+            assert _get_user_logs("bob", max_results=10) is None
+
+    @pytest.mark.parametrize("func", [
+        get_user_finds, get_user_dnfs, get_user_notes, get_user_archives, get_user_activity,
+    ])
+    def test_user_log_wrappers(self, logged_in_client, func):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen([{"referenceCode": "LW"}])):
+            assert func("bob", 25) == [{"referenceCode": "LW"}]
+
+    def test_favorite_points(self, logged_in_client):
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen({"favoritePoints": 7})):
+            assert get_favorite_points()["favoritePoints"] == 7
+
+    def test_favorite_points_none_without_client_id(self, token_file):
+        with patch.object(gc_module, "GC_CLIENT_ID", ""):
+            assert get_favorite_points() is None

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -3,13 +3,14 @@
 import pytest
 from pathlib import Path
 
-from opensak.db.database import get_session
+from opensak.db.database import get_session, init_db
 from opensak.db.models import Cache
-from opensak.importer import import_gpx, import_zip
+from opensak.importer import import_gpx, import_zip, ImportResult
 
 from tests.data import (
     SAMPLE_GPX, SAMPLE_WPTS_GPX, EMPTY_GPX,
     make_variant_gpx, make_gpx_with_inline_wpt, write_gpx, make_zip,
+    build_gpx, cache_wpt,
 )
 
 
@@ -265,3 +266,72 @@ def test_import_gpx_inline_extra_waypoints(tmp_db, tmp_path):
         assert wp.prefix == "PK"
         assert wp.wp_type == "Parking Area"
         assert wp.comment == "Street parking available."
+
+
+# ── ImportResult.__str__ ──────────────────────────────────────────────────────
+
+def test_import_result_str_lists_warnings_and_caps_errors():
+    r = ImportResult()
+    r.created, r.updated, r.waypoints, r.skipped = 3, 1, 2, 4
+    r.warnings.append("limited data")
+    r.errors.extend(f"err{i}" for i in range(7))
+    text = str(r)
+    assert "Caches created : 3" in text
+    assert "⚠ limited data" in text
+    assert "Errors         : 7" in text
+    assert text.count("    - err") == 5  # only first 5 shown
+
+
+# ── import_gpx error/edge paths ───────────────────────────────────────────────
+
+def test_import_gpx_reimport_updates_existing(tmp_path):
+    init_db(db_path=tmp_path / "re.db")
+    first = build_gpx(cache_wpt(
+        "GCUP01", name="Original", difficulty=1.0,
+        logs=[{"type": "Found it", "finder": "A"}],
+        attributes=[{"id": 6, "inc": 1, "name": "Kids"}],
+    ))
+    second = build_gpx(cache_wpt(
+        "GCUP01", name="Updated", difficulty=4.0,
+        logs=[{"type": "Found it", "finder": "B"}],
+        attributes=[{"id": 7, "inc": 0, "name": "Other"}],
+    ))
+    r1 = import_gpx(write_gpx(tmp_path, "a.gpx", first))
+    r2 = import_gpx(write_gpx(tmp_path, "b.gpx", second))
+    assert r1.created == 1
+    assert r2.updated == 1
+    with get_session() as s:
+        c = s.query(Cache).filter_by(gc_code="GCUP01").one()
+        assert c.name == "Updated"
+        assert c.difficulty == pytest.approx(4.0)
+
+
+def test_import_gpx_minimal_cache_without_optional_fields(tmp_path):
+    init_db(db_path=tmp_path / "min.db")
+    f = write_gpx(tmp_path, "min.gpx", build_gpx(cache_wpt("GCMIN1")))
+    result = import_gpx(f)
+    assert result.created == 1
+    assert result.errors == []
+
+
+def test_import_gpx_fatal_parse_error(tmp_path):
+    init_db(db_path=tmp_path / "bad.db")
+    f = write_gpx(tmp_path, "broken.gpx", "<gpx><wpt this is not valid xml")
+    result = import_gpx(f)
+    assert len(result.errors) > 0
+
+
+def test_import_gpx_companion_wpts_file_error(tmp_path):
+    init_db(db_path=tmp_path / "comp.db")
+    gpx = write_gpx(tmp_path, "main.gpx", SAMPLE_GPX)
+    bad_wpts = write_gpx(tmp_path, "main-wpts.gpx", "definitely not xml <<<")
+    result = import_gpx(gpx, wpts_path=bad_wpts)
+    assert any("Waypoints file error" in e for e in result.errors)
+
+
+# ── import_zip edge paths ─────────────────────────────────────────────────────
+
+def test_import_zip_no_gpx_in_archive(tmp_path):
+    z = make_zip(tmp_path, "no_gpx.zip", {"readme.txt": "hello"})
+    result = import_zip(z)
+    assert any("No .gpx" in e for e in result.errors)

--- a/tests/unit-tests/test_kml.py
+++ b/tests/unit-tests/test_kml.py
@@ -1,0 +1,235 @@
+"""tests/unit-tests/test_kml.py — KML export for Google Maps (no GUI/DB needed)."""
+
+import xml.etree.ElementTree as ET
+from types import SimpleNamespace
+
+import pytest
+
+from opensak.export.kml import (
+    _cache_description,
+    _esc,
+    _style_id_for_cache,
+    _style_id_for_waypoint,
+    _waypoint_description,
+    export_kml,
+)
+
+KML_NS = "{http://www.opengis.net/kml/2.2}"
+
+
+def _note(is_corrected=True, corrected_lat=60.0, corrected_lon=20.0):
+    return SimpleNamespace(
+        is_corrected=is_corrected,
+        corrected_lat=corrected_lat,
+        corrected_lon=corrected_lon,
+    )
+
+
+def _wpt(name="WP1", wp_type="Parking Area", latitude=55.0, longitude=12.0,
+         description="desc", comment="note"):
+    return SimpleNamespace(
+        name=name, wp_type=wp_type, latitude=latitude, longitude=longitude,
+        description=description, comment=comment,
+    )
+
+
+def _cache(
+    gc_code="GC12345", name="Test Cache", cache_type="Traditional Cache",
+    latitude=55.6761, longitude=12.5683, difficulty=2.0, terrain=3.0,
+    container="Regular", placed_by="Owner", short_description="A nice cache",
+    encoded_hints=None, found=False, user_note=None, waypoints=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        gc_code=gc_code, name=name, cache_type=cache_type,
+        latitude=latitude, longitude=longitude, difficulty=difficulty,
+        terrain=terrain, container=container, placed_by=placed_by,
+        short_description=short_description, encoded_hints=encoded_hints,
+        found=found, user_note=user_note, waypoints=waypoints or [],
+    )
+
+
+def _parse(path):
+    return ET.fromstring(path.read_bytes())
+
+
+# ── _esc ────────────────────────────────────────────────────────────────────
+
+class TestEsc:
+    def test_none_returns_empty(self):
+        assert _esc(None) == ""
+
+    def test_value_stringified(self):
+        assert _esc(123) == "123"
+        assert _esc("abc") == "abc"
+
+
+# ── _cache_description ──────────────────────────────────────────────────────
+
+class TestCacheDescription:
+    def test_includes_type_dt_size(self):
+        text = _cache_description(_cache(difficulty=1.5, terrain=4.0, container="Micro"))
+        assert "Traditional Cache" in text
+        assert "D1.5 / T4.0" in text
+        assert "Micro" in text
+
+    def test_unknown_dt_and_size_use_placeholder(self):
+        text = _cache_description(_cache(difficulty=None, terrain=None, container=None))
+        assert "D? / T?" in text
+        assert "?" in text
+
+    def test_placed_by_omitted_when_empty(self):
+        assert "By:" not in _cache_description(_cache(placed_by=""))
+
+    def test_short_description_included(self):
+        assert "A nice cache" in _cache_description(_cache(short_description="A nice cache"))
+
+    def test_hint_rot13_decoded(self):
+        # "Haqre n ebpx" is rot13 of "Under a rock"
+        text = _cache_description(_cache(encoded_hints="Haqre n ebpx"))
+        assert "Under a rock" in text
+
+    def test_hint_decode_failure_falls_back(self):
+        # bytes can't be rot_13-decoded → except branch keeps the raw value
+        text = _cache_description(_cache(encoded_hints=b"\xff\xfe"))
+        assert "Hint:" in text
+
+    def test_gc_link_present(self):
+        text = _cache_description(_cache(gc_code="GCABCDE"))
+        assert "geocaching.com/geocache/GCABCDE" in text
+
+
+# ── _waypoint_description ───────────────────────────────────────────────────
+
+class TestWaypointDescription:
+    def test_full(self):
+        text = _waypoint_description(_wpt(), "GC12345")
+        assert "Parking Area" in text
+        assert "desc" in text
+        assert "note" in text
+        assert "(GC12345)" in text
+
+    def test_minimal_only_gc_code(self):
+        text = _waypoint_description(
+            _wpt(wp_type=None, description=None, comment=None), "GC1"
+        )
+        assert text == "(GC1)"
+
+
+# ── style ids ───────────────────────────────────────────────────────────────
+
+class TestStyleIds:
+    def test_cache_found(self):
+        assert _style_id_for_cache(_cache(found=True)) == "style_found"
+
+    def test_cache_type_normalised(self):
+        assert _style_id_for_cache(_cache(cache_type="Multi-cache")) == "style_Multi_cache"
+
+    def test_cache_empty_type_default(self):
+        assert _style_id_for_cache(_cache(cache_type="")) == "style_default"
+
+    def test_waypoint_type_normalised(self):
+        assert _style_id_for_waypoint(_wpt(wp_type="Parking Area")) == "style_wpt_Parking_Area"
+
+    def test_waypoint_empty_type_default(self):
+        assert _style_id_for_waypoint(_wpt(wp_type="")) == "style_wpt_default"
+
+
+# ── export_kml ──────────────────────────────────────────────────────────────
+
+class TestExportKml:
+    def test_returns_count_and_writes_file(self, tmp_path):
+        out = tmp_path / "out.kml"
+        count = export_kml([_cache(), _cache(gc_code="GC99999")], out)
+        assert count == 2
+        assert out.exists()
+        assert _parse(out).tag == f"{KML_NS}kml"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        out = tmp_path / "nested" / "deep" / "out.kml"
+        export_kml([_cache()], out)
+        assert out.exists()
+
+    def test_empty_list_valid_kml(self, tmp_path):
+        out = tmp_path / "empty.kml"
+        assert export_kml([], out) == 0
+        assert _parse(out).tag == f"{KML_NS}kml"
+
+    def test_gc_code_and_name_in_output(self, tmp_path):
+        out = tmp_path / "out.kml"
+        export_kml([_cache(gc_code="GCXYZ", name="My Cache")], out)
+        body = out.read_text(encoding="utf-8")
+        assert "GCXYZ" in body
+        assert "My Cache" in body
+
+    def test_found_cache_marked_and_styled(self, tmp_path):
+        out = tmp_path / "out.kml"
+        export_kml([_cache(found=True)], out)
+        body = out.read_text(encoding="utf-8")
+        assert "✓" in body
+        assert "#style_found" in body
+
+    def test_include_found_false_filters(self, tmp_path):
+        out = tmp_path / "out.kml"
+        count = export_kml(
+            [_cache(gc_code="GCFOUND", found=True), _cache(gc_code="GCNEW")],
+            out, include_found=False,
+        )
+        assert count == 1
+        assert "GCFOUND" not in out.read_text(encoding="utf-8")
+
+    def test_corrected_coords_used(self, tmp_path):
+        out = tmp_path / "out.kml"
+        c = _cache(latitude=55.0, longitude=12.0, user_note=_note(corrected_lat=60.0, corrected_lon=20.0))
+        export_kml([c], out)
+        assert "20.0,60.0,0" in out.read_text(encoding="utf-8")
+
+    def test_uncorrected_note_uses_original(self, tmp_path):
+        out = tmp_path / "out.kml"
+        c = _cache(latitude=55.0, longitude=12.0, user_note=_note(is_corrected=False))
+        export_kml([c], out)
+        assert "12.0,55.0,0" in out.read_text(encoding="utf-8")
+
+    def test_cache_without_coords_skipped(self, tmp_path):
+        out = tmp_path / "out.kml"
+        c = _cache(gc_code="GCNULL", latitude=None, longitude=None)
+        export_kml([_cache(gc_code="GCOK"), c], out)
+        body = out.read_text(encoding="utf-8")
+        # still counted in the header total, but no placemark written
+        placemarks = _parse(out).iter(f"{KML_NS}Placemark")
+        names = [p.find(f"{KML_NS}name").text for p in placemarks]
+        assert any("GCOK" in n for n in names)
+        assert not any("GCNULL" in n for n in names)
+
+    def test_waypoints_folder_written(self, tmp_path):
+        out = tmp_path / "out.kml"
+        c = _cache(waypoints=[_wpt(name="Parking", wp_type="Parking Area")])
+        export_kml([c], out)
+        body = out.read_text(encoding="utf-8")
+        assert "Waypoints" in body
+        assert "Parking" in body
+
+    def test_include_waypoints_false_skips_folder(self, tmp_path):
+        out = tmp_path / "out.kml"
+        c = _cache(waypoints=[_wpt(name="Parking")])
+        export_kml([c], out, include_waypoints=False)
+        folder_names = [f.find(f"{KML_NS}name").text for f in _parse(out).iter(f"{KML_NS}Folder")]
+        assert "Waypoints" not in folder_names
+
+    def test_waypoint_without_coords_skipped(self, tmp_path):
+        out = tmp_path / "out.kml"
+        c = _cache(waypoints=[_wpt(name="NoCoords", latitude=None, longitude=None)])
+        export_kml([c], out)
+        # waypoint folder may exist (built from list) but no placemark for it
+        body = out.read_text(encoding="utf-8")
+        assert "NoCoords" not in body
+
+    def test_special_chars_escaped_roundtrip(self, tmp_path):
+        out = tmp_path / "out.kml"
+        export_kml([_cache(name="A & B <test>")], out)
+        names = [p.find(f"{KML_NS}name").text for p in _parse(out).iter(f"{KML_NS}Placemark")]
+        assert any("A & B <test>" in n for n in names)
+
+    def test_known_type_icon_present(self, tmp_path):
+        out = tmp_path / "out.kml"
+        export_kml([_cache(cache_type="EarthCache")], out)
+        assert "grn-diamond.png" in out.read_text(encoding="utf-8")

--- a/tests/unit-tests/test_migrations.py
+++ b/tests/unit-tests/test_migrations.py
@@ -16,7 +16,26 @@ Tests assert:
 import pytest
 from sqlalchemy import event, text
 
-from opensak.db.database import init_db, get_engine, _run_migrations, SCHEMA_VERSION
+from opensak.db.database import (
+    init_db,
+    get_engine,
+    _make_engine,
+    _run_migrations,
+    SCHEMA_VERSION,
+)
+
+# The original pre-migration schema: only the columns/tables the migrations read
+# or rebuild. Running the migrations against it exercises every add-column /
+# table-rebuild / data-normalisation branch.
+_OLD_SCHEMA = [
+    "CREATE TABLE caches (id INTEGER PRIMARY KEY AUTOINCREMENT, gc_code TEXT, cache_type TEXT, "
+    "container TEXT, difficulty REAL, terrain REAL, hidden_date DATETIME, found_date DATETIME, "
+    "found BOOLEAN, archived BOOLEAN, available BOOLEAN, latitude REAL, longitude REAL)",
+    "CREATE TABLE waypoints (id INTEGER PRIMARY KEY AUTOINCREMENT, cache_id INTEGER, prefix TEXT, "
+    "wp_type TEXT, name TEXT, description TEXT, comment TEXT, latitude REAL, longitude REAL)",
+    "CREATE TABLE user_notes (id INTEGER PRIMARY KEY AUTOINCREMENT, cache_id INTEGER)",
+    "CREATE TABLE logs (id INTEGER PRIMARY KEY AUTOINCREMENT, cache_id INTEGER, log_date DATETIME)",
+]
 
 
 def _capture_statements(engine):
@@ -84,3 +103,39 @@ def test_indexes_present_after_init(tmp_path):
         }
     for expected in ("ix_caches_cache_type", "ix_caches_lat_lon", "ix_caches_found"):
         assert expected in names
+
+
+def test_old_schema_runs_every_migration(tmp_path):
+    """A v0 database with the original schema must apply all migrations."""
+    engine = _make_engine(tmp_path / "old.db")
+    with engine.connect() as c:
+        for ddl in _OLD_SCHEMA:
+            c.execute(text(ddl))
+        # Rows that trigger the data-normalisation migrations (5 and 7).
+        c.execute(text(
+            "INSERT INTO caches (gc_code, cache_type, container) "
+            "VALUES ('GC1', 'gps adventures exhibit', 'Nano')"
+        ))
+        c.execute(text("INSERT INTO logs (cache_id, log_date) VALUES (1, '2024-01-01')"))
+        c.execute(text("PRAGMA user_version = 0"))
+        c.commit()
+
+    _run_migrations(engine)
+
+    with engine.connect() as c:
+        cache_cols = {r[1] for r in c.execute(text("PRAGMA table_info(caches)"))}
+        note_cols = {r[1] for r in c.execute(text("PRAGMA table_info(user_notes)"))}
+        idx_names = {r[0] for r in c.execute(text(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='waypoints'"
+        ))}
+        row = c.execute(text("SELECT cache_type, container FROM caches WHERE gc_code='GC1'")).first()
+        version = c.execute(text("PRAGMA user_version")).scalar()
+
+    for col in ("county", "log_count", "parent_gc_code", "owner_name", "last_log_date",
+                "dnf_date", "favorite_points", "distance", "bearing"):
+        assert col in cache_cols
+    assert "is_corrected" in note_cols
+    # The waypoints rebuild (migration 2) recreates this backing index.
+    assert "ix_waypoints_cache_id" in idx_names
+    assert row == ("GPS Adventures Maze", "Micro")  # migration 5 + 7 normalisation
+    assert version == SCHEMA_VERSION


### PR DESCRIPTION
Second step of the phased coverage push (#225): unit tests for the pure-logic
backend modules (export, GPS, API, DB, filters, importer, config). Fast,
deterministic, no GUI. Includes **one production bug fix** that the tests
surfaced.

**13 files changed · +1316 / −9 · 12 commits.** Suite: **828 passing** (was
~789), no flakiness. Overall coverage **55% → 61%**.

## 🐛 Bug found & fixed

The new filter tests surfaced a real, shipping bug: `filters/engine.py` calls
`datetime.fromisoformat(...)` at runtime in the `from_dict` of the date filters
(`found_by_me_date`, `dnf_date`, `last_log_date`), but **`datetime` was never
imported** — it only appeared in `Optional[datetime]` type hints, which
`from __future__ import annotations` turns into strings. Loading any saved
filter **profile that contains a date filter crashed with `NameError`**. Fixed
with a one-line import, with round-trip tests proving it.

## Coverage by module

| Module | Before | After |
|---|---|---|
| `export/kml.py` | 0% | **100%** |
| `db/models.py` | 95% | **100%** |
| `utils/doctor.py` | 55% | **100%** |
| `db/database.py` | 64% | **98%** |
| `db/found_updater.py` | 88% | **97%** |
| `config.py` | 75% | **95%** |
| `filters/engine.py` | 86% | **95%** |
| `coords.py` | 68% | **92%** |
| `gps/garmin.py` | 46% | **82%** |
| `api/geocaching.py` | 46% | **81%** |
| `db/manager.py` | 57% | **78%** |
| `importer/__init__.py` | 73% | **~75%** |

## What's tested

- **`export/kml.py`** — full KML generation: corrected-coords fallback, found
  filtering, coordless cache/waypoint skipping, special-char escaping
  (round-trip parse), rot13 hint decode + failure branch, file/dir creation.
- **`gps/garmin.py`** — LOC + GGZ generation (zip structure, index, CRC,
  container-size mapping, found flag), device scanning (mocked mounts), and
  delete/export error paths.
- **`api/geocaching.py`** — OAuth token exchange/refresh, `get_valid_token`,
  `_api_get` (401 refresh-and-retry, HTTP/generic errors), trackables, profile,
  user logs + wrappers, favorite points — all network-mocked.
- **`db/database.py`** — engine lifecycle (guards, dispose, `init_db`
  default-path resolution) + every migration run against an original-schema v0
  DB (add-column, waypoints rebuild, data normalisation, index creation).
- **`db/manager.py`** — `DatabaseInfo` logic + `open_database` / `switch_to` /
  `copy_database` / `ensure_active_initialised`.
- **`filters/engine.py`** — Python-side `matches` + `to_dict`/`from_dict`
  round-trips for the flag/date/points filters, plus `FilterSet` edges.
- **`importer/__init__.py`** — `ImportResult.__str__`, reimport-update, fatal
  parse error, malformed companion `-wpts`, and zip-with-no-gpx.
- **`coords.py`**, **`config.py`**, **`db/found_updater.py`**,
  **`utils/doctor.py`**, **`db/models.py`** — remaining branches closed.

## Deliberately left uncovered

Genuine integration / platform glue, not unit-testable here:
- Garmin Linux/Windows mount detection (can't exercise on the CI/macOS host).
- Geocaching OAuth browser + local-callback HTTP server flow (needs live
  socket + browser).
- `config` Windows branch (`pathlib.Path` picks its class from `os.name` at
  instantiation, so forcing `nt` breaks `Path` on POSIX).
- `db/manager` QSettings load/migrate path (needs populated settings state).
- Importer's deep `_upsert_cache` / `_parse_wpt` optional-field branches.

## Notes for reviewers

- The only production change is the one-line `datetime` import in
  `filters/engine.py`; everything else is under `tests/`.
- Two pre-existing issues are flagged in commit messages but **not** changed
  here: a dead-code branch in `coords.py` (the plain-DMM regex is shadowed by
  the degree-sign one) and a migration that creates an auto-named unique index
  instead of the named one it checks for (harmless due to the `user_version`
  gate). Happy to file follow-ups.

---
Part of #225. Builds on Phase 0 (#226).