### PR TITLE
Test Coverage - Phase 2

### DIFF
--- a/src/opensak/coords.py
+++ b/src/opensak/coords.py
@@ -159,20 +159,9 @@ def parse_coords(text: str) -> Coordinate | None:
             lon = -lon
         return lat, lon
 
-    # ── DMM: "N55 47.250 E012 25.000" ────────────────────────────────────────
-    m = re.match(
-        r'^([NSns])\s*(\d{1,3})\s+(\d+\.\d+)\s+([EWew])\s*(\d{1,3})\s+(\d+\.\d+)$',
-        text
-    )
-    if m:
-        lat_h, lat_d, lat_m, lon_h, lon_d, lon_m = m.groups()
-        lat = int(lat_d) + float(lat_m) / 60
-        lon = int(lon_d) + float(lon_m) / 60
-        if lat_h.upper() == "S":
-            lat = -lat
-        if lon_h.upper() == "W":
-            lon = -lon
-        return lat, lon
+    # Plain DMM "N55 47.250 E012 25.000" is already matched by the DMM° branch
+    # above (the degree sign and apostrophe are optional there), so no separate
+    # branch is needed.
 
     # ── DMS: "N55° 47' 15.00" E012° 25' 00.00"" ──────────────────────────────
     m = re.match(

--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -160,7 +160,10 @@ def _run_migrations(engine: Engine) -> None:
         idx_names = [r[0] for r in idx_rows]
 
         if "uq_waypoint_cache_prefix_name" not in idx_names:
-            # SQLite understøtter ikke DROP CONSTRAINT — vi recreater tabellen
+            # SQLite understøtter ikke DROP CONSTRAINT — vi recreater tabellen.
+            # Unik-constraint laves som et NAVNGIVET index (ikke inline UNIQUE,
+            # der ville få et auto-genereret sqlite_autoindex-navn) så gaten
+            # ovenfor faktisk genkender den og matcher modellens constraint-navn.
             conn.execute(text("PRAGMA foreign_keys=OFF"))
             conn.execute(text("""
                 CREATE TABLE waypoints_new (
@@ -172,8 +175,7 @@ def _run_migrations(engine: Engine) -> None:
                     description TEXT,
                     comment     TEXT,
                     latitude    REAL,
-                    longitude   REAL,
-                    UNIQUE(cache_id, prefix, name)
+                    longitude   REAL
                 )
             """))
             conn.execute(text(
@@ -183,6 +185,10 @@ def _run_migrations(engine: Engine) -> None:
             ))
             conn.execute(text("DROP TABLE waypoints"))
             conn.execute(text("ALTER TABLE waypoints_new RENAME TO waypoints"))
+            conn.execute(text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_waypoint_cache_prefix_name "
+                "ON waypoints (cache_id, prefix, name)"
+            ))
             conn.execute(text(
                 "CREATE INDEX IF NOT EXISTS ix_waypoints_cache_id ON waypoints (cache_id)"
             ))

--- a/tests/unit-tests/test_column_dialog.py
+++ b/tests/unit-tests/test_column_dialog.py
@@ -1,0 +1,106 @@
+"""tests/unit-tests/test_column_dialog.py — column chooser dialog + QSettings helpers."""
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtCore import Qt
+
+from opensak.gui.dialogs import column_dialog as cd
+from opensak.gui.dialogs.column_dialog import (
+    ALWAYS_VISIBLE,
+    ColumnChooserDialog,
+    get_all_columns,
+    get_column_widths,
+    get_visible_columns,
+    set_column_widths,
+    set_visible_columns,
+)
+
+
+class _FakeSettings:
+    def __init__(self, store):
+        self._store = store
+
+    def value(self, key, default=None):
+        return self._store.get(key, default)
+
+    def setValue(self, key, val):
+        self._store[key] = val
+
+    def sync(self):
+        pass
+
+
+@pytest.fixture
+def store(monkeypatch):
+    data: dict = {}
+    monkeypatch.setattr(cd, "QSettings", lambda *a, **k: _FakeSettings(data))
+    return data
+
+
+# ── module-level helpers ──────────────────────────────────────────────────────
+
+class TestColumnHelpers:
+    def test_get_all_columns_shape(self):
+        cols = get_all_columns()
+        assert all(len(c) == 4 for c in cols)
+        assert {"gc_code", "name"} <= {c[0] for c in cols}
+
+    def test_visible_defaults_when_unset(self, store):
+        vis = get_visible_columns()
+        assert "gc_code" in vis
+        assert "country" not in vis  # not a default-visible column
+
+    def test_visible_roundtrip(self, store):
+        set_visible_columns(["gc_code", "name", "country"])
+        assert get_visible_columns() == ["gc_code", "name", "country"]
+
+    def test_widths_default_empty(self, store):
+        assert get_column_widths() == {}
+
+    def test_widths_roundtrip(self, store):
+        set_column_widths({"gc_code": 80})
+        assert get_column_widths() == {"gc_code": 80}
+
+    def test_widths_bad_json_returns_empty(self, store):
+        store["columns/widths"] = "{ not json"
+        assert get_column_widths() == {}
+
+
+# ── ColumnChooserDialog ───────────────────────────────────────────────────────
+
+class TestColumnChooserDialog:
+    def test_select_all_checks_everything(self, qtbot, store):
+        dlg = ColumnChooserDialog()
+        qtbot.addWidget(dlg)
+        dlg._select_all()
+        states = [dlg._list.item(i).checkState() for i in range(dlg._list.count())]
+        assert all(s == Qt.CheckState.Checked for s in states)
+
+    def test_select_default_unchecks_non_default(self, qtbot, store):
+        dlg = ColumnChooserDialog()
+        qtbot.addWidget(dlg)
+        dlg._select_all()
+        dlg._select_default()
+        for i in range(dlg._list.count()):
+            item = dlg._list.item(i)
+            if item.data(Qt.ItemDataRole.UserRole) == "country":
+                assert item.checkState() == Qt.CheckState.Unchecked
+
+    def test_save_persists_checked_and_always_visible(self, qtbot, store):
+        dlg = ColumnChooserDialog()
+        qtbot.addWidget(dlg)
+        dlg._select_default()
+        dlg._save_and_accept()
+        saved = get_visible_columns()
+        assert "gc_code" in saved
+        assert "name" in saved
+
+    def test_always_visible_columns_not_checkable(self, qtbot, store):
+        dlg = ColumnChooserDialog()
+        qtbot.addWidget(dlg)
+        for i in range(dlg._list.count()):
+            item = dlg._list.item(i)
+            if item.data(Qt.ItemDataRole.UserRole) in ALWAYS_VISIBLE:
+                assert not (item.flags() & Qt.ItemFlag.ItemIsUserCheckable)

--- a/tests/unit-tests/test_corrected_coords_dialog.py
+++ b/tests/unit-tests/test_corrected_coords_dialog.py
@@ -1,0 +1,85 @@
+"""tests/unit-tests/test_corrected_coords_dialog.py — corrected-coords entry dialog."""
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtWidgets import QApplication, QDialog
+
+from opensak.gui.dialogs import corrected_coords_dialog as ccd
+from opensak.gui.dialogs.corrected_coords_dialog import CorrectedCoordsDialog
+from opensak.utils.types import CoordFormat
+
+_VALID = "N55 47.250 E012 25.000"
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    m = MagicMock()
+    m.coord_format = CoordFormat.DMM
+    monkeypatch.setattr(ccd, "get_settings", lambda: m)
+    return m
+
+
+class TestCorrectedCoordsDialog:
+    def test_builds_with_no_coords(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123")
+        qtbot.addWidget(dlg)
+        assert dlg.get_coords() == (None, None)
+        assert dlg._ok_btn.isEnabled() is False
+
+    def test_original_panel_built(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123", orig_lat=55.0, orig_lon=12.0)
+        qtbot.addWidget(dlg)
+        assert dlg._ok_btn.isEnabled() is False
+
+    def test_prefilled_corrected_enables_ok(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123", corrected_lat=55.0, corrected_lon=12.0)
+        qtbot.addWidget(dlg)
+        lat, lon = dlg.get_coords()
+        assert lat == pytest.approx(55.0, abs=1e-3)
+        assert dlg._ok_btn.isEnabled() is True
+
+    def test_valid_input_enables_ok_and_sets_coords(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123")
+        qtbot.addWidget(dlg)
+        dlg._input.setText(_VALID)
+        lat, lon = dlg.get_coords()
+        assert lat is not None and lon is not None
+        assert dlg._ok_btn.isEnabled() is True
+
+    def test_invalid_input_shows_error(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123")
+        qtbot.addWidget(dlg)
+        dlg._input.setText("garbage")
+        assert dlg.get_coords() == (None, None)
+        assert dlg._ok_btn.isEnabled() is False
+        assert dlg._error_lbl.text() != ""
+
+    def test_clearing_input_resets(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123")
+        qtbot.addWidget(dlg)
+        dlg._input.setText(_VALID)
+        dlg._input.setText("")
+        assert dlg.get_coords() == (None, None)
+        assert dlg._ok_btn.isEnabled() is False
+
+    def test_accept_with_valid_coords(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123")
+        qtbot.addWidget(dlg)
+        dlg._input.setText(_VALID)
+        dlg._on_accept()
+        assert dlg.result() == QDialog.DialogCode.Accepted
+
+    def test_accept_without_coords_does_nothing(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123")
+        qtbot.addWidget(dlg)
+        dlg._on_accept()
+        assert dlg.result() != QDialog.DialogCode.Accepted
+
+    def test_copy_sets_clipboard(self, qtbot, settings):
+        dlg = CorrectedCoordsDialog("GC123")
+        qtbot.addWidget(dlg)
+        dlg._copy("hello world")
+        assert QApplication.clipboard().text() == "hello world"

--- a/tests/unit-tests/test_export_dialogs.py
+++ b/tests/unit-tests/test_export_dialogs.py
@@ -1,0 +1,199 @@
+"""tests/unit-tests/test_export_dialogs.py — KML and file (GPX/LOC/GGZ) export dialogs."""
+
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtWidgets import QDialog
+
+from opensak.gui.dialogs import file_export_dialog as fed
+from opensak.gui.dialogs import kml_export_dialog as ked
+from opensak.gui.dialogs.file_export_dialog import FileExportDialog
+from opensak.gui.dialogs.file_export_dialog import _ExportWorker as FileWorker
+from opensak.gui.dialogs.kml_export_dialog import KmlExportDialog
+from opensak.gui.dialogs.kml_export_dialog import _ExportWorker as KmlWorker
+
+
+def _cache(gc_code="GC12345", latitude=55.0, longitude=12.0):
+    return SimpleNamespace(
+        id=1, gc_code=gc_code, name="Test", cache_type="Traditional Cache",
+        latitude=latitude, longitude=longitude, difficulty=2.0, terrain=3.0,
+        placed_by="Owner", available=True, archived=False, country="Denmark",
+        encoded_hints=None, hidden_date=None, logs=[], user_note=None,
+        container="Small", found=False, short_description="", waypoints=[],
+    )
+
+
+# ── KML export worker ─────────────────────────────────────────────────────────
+
+class TestKmlExportWorker:
+    def test_run_success_emits_count(self, monkeypatch):
+        monkeypatch.setattr(ked, "export_kml", lambda *a, **k: 7)
+        w = KmlWorker([], "/tmp/x.kml", True, True)
+        got = []
+        w.finished.connect(got.append)
+        w.run()
+        assert got == [7]
+
+    def test_run_error_emits_message(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("kaboom")
+        monkeypatch.setattr(ked, "export_kml", boom)
+        w = KmlWorker([], "/tmp/x.kml", True, True)
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs and "kaboom" in errs[0]
+
+
+# ── KML export dialog ─────────────────────────────────────────────────────────
+
+class TestKmlExportDialog:
+    def test_default_path_ends_with_kml(self, qtbot):
+        dlg = KmlExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        assert dlg._path_edit.text().endswith(".kml")
+
+    def test_browse_appends_extension(self, qtbot, monkeypatch):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(ked.QFileDialog, "getSaveFileName", lambda *a, **k: ("/tmp/foo", "f"))
+        dlg._browse()
+        assert dlg._path_edit.text() == "/tmp/foo.kml"
+
+    def test_browse_cancel_keeps_path(self, qtbot, monkeypatch):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        before = dlg._path_edit.text()
+        monkeypatch.setattr(ked.QFileDialog, "getSaveFileName", lambda *a, **k: ("", ""))
+        dlg._browse()
+        assert dlg._path_edit.text() == before
+
+    def test_start_export_missing_path_warns(self, qtbot, monkeypatch):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        dlg._path_edit.setText("   ")
+        warn = MagicMock()
+        monkeypatch.setattr(ked.QMessageBox, "warning", warn)
+        dlg._start_export()
+        warn.assert_called_once()
+
+    def test_start_export_launches_worker(self, qtbot, monkeypatch):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        started = []
+
+        class FakeWorker:
+            def __init__(self, **kw):
+                self.finished = MagicMock()
+                self.error = MagicMock()
+
+            def start(self):
+                started.append(True)
+
+        monkeypatch.setattr(ked, "_ExportWorker", FakeWorker)
+        dlg._path_edit.setText("/tmp/out.kml")
+        dlg._start_export()
+        assert started == [True]
+        assert dlg._export_btn.isEnabled() is False
+        assert not dlg._progress.isHidden()
+
+    def test_on_finished_accepts(self, qtbot, monkeypatch):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(ked.QMessageBox, "information", MagicMock())
+        dlg._on_finished(3)
+        assert dlg._progress.isHidden()
+        assert dlg.result() == QDialog.DialogCode.Accepted
+
+    def test_on_error_reenables(self, qtbot, monkeypatch):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(ked.QMessageBox, "critical", MagicMock())
+        dlg._export_btn.setEnabled(False)
+        dlg._on_error("oops")
+        assert dlg._export_btn.isEnabled() is True
+        assert dlg._progress.isHidden()
+
+
+# ── File export worker ────────────────────────────────────────────────────────
+
+class TestFileExportWorker:
+    @pytest.mark.parametrize("fmt,suffix", [("gpx", ".gpx"), ("loc", ".loc"), ("ggz", ".ggz")])
+    def test_run_writes_file(self, tmp_path, fmt, suffix):
+        out = tmp_path / f"export{suffix}"
+        w = FileWorker([_cache()], out, fmt)
+        msgs = []
+        w.finished.connect(msgs.append)
+        w.run()
+        assert out.exists()
+        assert msgs  # success message emitted
+
+    def test_run_error_emits_traceback(self, tmp_path, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("gen failed")
+        monkeypatch.setattr("opensak.gps.garmin.generate_gpx", boom)
+        w = FileWorker([_cache()], tmp_path / "x.gpx", "gpx")
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs and "gen failed" in errs[0]
+
+
+# ── File export dialog ────────────────────────────────────────────────────────
+
+class TestFileExportDialog:
+    def test_current_fmt_reflects_radio(self, qtbot):
+        dlg = FileExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        assert dlg._current_fmt() == "gpx"
+        dlg._btn_loc.setChecked(True)
+        assert dlg._current_fmt() == "loc"
+        dlg._btn_ggz.setChecked(True)
+        assert dlg._current_fmt() == "ggz"
+
+    def test_do_export_cancel_does_nothing(self, qtbot, monkeypatch):
+        dlg = FileExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(fed.QFileDialog, "getSaveFileName", lambda *a, **k: ("", ""))
+        dlg._do_export()
+        assert dlg._btn_export.isEnabled() is True  # untouched
+
+    def test_do_export_launches_worker_with_suffix(self, qtbot, monkeypatch):
+        dlg = FileExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(fed.QFileDialog, "getSaveFileName", lambda *a, **k: ("/tmp/noext", "f"))
+        captured = {}
+
+        class FakeWorker:
+            def __init__(self, caches, output_path, fmt):
+                captured["path"] = output_path
+                self.finished = MagicMock()
+                self.error = MagicMock()
+
+            def start(self):
+                captured["started"] = True
+
+        monkeypatch.setattr(fed, "_ExportWorker", FakeWorker)
+        dlg._do_export()
+        assert captured["started"] is True
+        assert str(captured["path"]).endswith(".gpx")
+        assert dlg._btn_export.isEnabled() is False
+
+    def test_on_success_shows_message(self, qtbot):
+        dlg = FileExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        dlg._on_success("done")
+        assert "done" in dlg._log.toPlainText()
+        assert dlg._btn_export.isEnabled() is True
+
+    def test_on_error_shows_message(self, qtbot, monkeypatch):
+        dlg = FileExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(fed.QMessageBox, "critical", MagicMock())
+        dlg._on_error("bad")
+        assert "bad" in dlg._log.toPlainText()
+        assert dlg._btn_export.isEnabled() is True

--- a/tests/unit-tests/test_found_dialog.py
+++ b/tests/unit-tests/test_found_dialog.py
@@ -1,0 +1,173 @@
+"""tests/unit-tests/test_found_dialog.py — found-status updater dialog."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from opensak.gui.dialogs import found_dialog as fd
+from opensak.gui.dialogs.found_dialog import FoundUpdaterDialog, UpdateWorker
+
+
+def _db(name, path, exists=True):
+    return SimpleNamespace(name=name, path=Path(path), exists=exists)
+
+
+def _manager(others=None):
+    active = _db("Active", "/active.db")
+    return SimpleNamespace(active=active, databases=[active] + (others or []))
+
+
+@pytest.fixture
+def patch_manager(monkeypatch):
+    def _apply(mgr):
+        monkeypatch.setattr(fd, "get_db_manager", lambda: mgr)
+        return mgr
+    return _apply
+
+
+# ── UpdateWorker ──────────────────────────────────────────────────────────────
+
+class TestUpdateWorker:
+    def test_run_success_emits_result(self, monkeypatch):
+        result = SimpleNamespace(updated=2, errors=[])
+        monkeypatch.setattr(
+            "opensak.db.found_updater.update_found_from_reference",
+            lambda p: result,
+        )
+        w = UpdateWorker(Path("/ref.db"))
+        got = []
+        w.finished.connect(got.append)
+        w.run()
+        assert got == [result]
+
+    def test_run_error_emits_traceback(self, monkeypatch):
+        def boom(p):
+            raise RuntimeError("update failed")
+        monkeypatch.setattr(
+            "opensak.db.found_updater.update_found_from_reference", boom
+        )
+        w = UpdateWorker(Path("/ref.db"))
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs and "update failed" in errs[0]
+
+
+# ── FoundUpdaterDialog ────────────────────────────────────────────────────────
+
+class TestFoundUpdaterDialog:
+    def test_combo_lists_other_databases(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[_db("Ref", "/ref.db")]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        assert dlg._db_combo.isEnabled() is True
+        assert dlg._db_combo.count() == 1
+
+    def test_no_other_databases_disables_combo(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        assert dlg._db_combo.isEnabled() is False
+
+    def test_source_toggle_enables_disables_combo(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[_db("Ref", "/ref.db")]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        dlg._rb_file.setChecked(True)
+        assert dlg._db_combo.isEnabled() is False
+        dlg._rb_known.setChecked(True)
+        assert dlg._db_combo.isEnabled() is True
+
+    def test_browse_sets_reference_path(self, qtbot, patch_manager, monkeypatch):
+        patch_manager(_manager(others=[_db("Ref", "/ref.db")]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(fd.QFileDialog, "getOpenFileName", lambda *a, **k: ("/tmp/finds.db", "f"))
+        dlg._browse_file()
+        assert dlg._reference_path == Path("/tmp/finds.db")
+        assert dlg._rb_file.isChecked() is True
+
+    def test_browse_cancel_keeps_none(self, qtbot, patch_manager, monkeypatch):
+        patch_manager(_manager(others=[_db("Ref", "/ref.db")]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(fd.QFileDialog, "getOpenFileName", lambda *a, **k: ("", ""))
+        dlg._browse_file()
+        assert dlg._reference_path is None
+
+    def test_get_reference_path_known_vs_file(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[_db("Ref", "/ref.db")]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        assert dlg._get_reference_path() == Path("/ref.db")  # known mode
+        dlg._reference_path = Path("/file.db")
+        dlg._rb_file.setChecked(True)
+        assert dlg._get_reference_path() == Path("/file.db")
+
+    def test_start_update_without_ref_logs(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        dlg._rb_file.setChecked(True)  # file mode, no file chosen
+        dlg._start_update()
+        assert dlg._log.toPlainText() != ""
+
+    def test_start_update_rejects_same_as_active(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        dlg._rb_file.setChecked(True)
+        dlg._reference_path = Path("/active.db")  # == active
+        dlg._start_update()
+        assert dlg._log.toPlainText() != ""
+        assert dlg._update_btn.isEnabled() is True  # not started
+
+    def test_start_update_launches_worker(self, qtbot, patch_manager, monkeypatch):
+        patch_manager(_manager(others=[_db("Ref", "/ref.db")]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        started = []
+
+        class FakeWorker:
+            def __init__(self, path):
+                self.finished = MagicMock()
+                self.error = MagicMock()
+
+            def start(self):
+                started.append(True)
+
+        monkeypatch.setattr(fd, "UpdateWorker", FakeWorker)
+        dlg._start_update()
+        assert started == [True]
+        assert dlg._update_btn.isEnabled() is False
+
+    def test_on_finished_emits_completed_when_updated(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        fired = []
+        dlg.update_completed.connect(lambda: fired.append(True))
+        dlg._on_finished(SimpleNamespace(updated=3, errors=["e1"]))
+        assert fired == [True]
+        assert "e1" in dlg._log.toPlainText()
+
+    def test_on_finished_no_signal_when_zero_updated(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        fired = []
+        dlg.update_completed.connect(lambda: fired.append(True))
+        dlg._on_finished(SimpleNamespace(updated=0, errors=[]))
+        assert fired == []
+
+    def test_on_error_logs(self, qtbot, patch_manager):
+        patch_manager(_manager(others=[]))
+        dlg = FoundUpdaterDialog()
+        qtbot.addWidget(dlg)
+        dlg._on_error("boom")
+        assert "boom" in dlg._log.toPlainText()
+        assert dlg._update_btn.isEnabled() is True

--- a/tests/unit-tests/test_migrations.py
+++ b/tests/unit-tests/test_migrations.py
@@ -135,7 +135,9 @@ def test_old_schema_runs_every_migration(tmp_path):
                 "dnf_date", "favorite_points", "distance", "bearing"):
         assert col in cache_cols
     assert "is_corrected" in note_cols
-    # The waypoints rebuild (migration 2) recreates this backing index.
+    # The waypoints rebuild (migration 2) creates the named unique index
+    # (matching the model's constraint name) plus the cache_id index.
+    assert "uq_waypoint_cache_prefix_name" in idx_names
     assert "ix_waypoints_cache_id" in idx_names
     assert row == ("GPS Adventures Maze", "Micro")  # migration 5 + 7 normalisation
     assert version == SCHEMA_VERSION

--- a/tests/unit-tests/test_settings_dialog.py
+++ b/tests/unit-tests/test_settings_dialog.py
@@ -1,0 +1,304 @@
+"""tests/unit-tests/test_settings_dialog.py — settings dialog (temp-backed AppSettings)."""
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QDialog, QMessageBox
+
+from opensak.gui.dialogs import settings_dialog as sd
+from opensak.gui.dialogs.settings_dialog import (
+    SettingsDialog,
+    _OAuthWorker,
+    _ProfileWorker,
+)
+from opensak.gui.settings import AppSettings, HomePoint
+
+_VALID = "N55 47.250 E012 25.000"
+
+
+@pytest.fixture
+def settings(tmp_path, monkeypatch):
+    # Redirect the real QSettings("OpenSAK Project", "OpenSAK") (used directly by
+    # the dialog and by AppSettings) to a temp INI — no class patching, which
+    # would corrupt PySide's type system.
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
+    s = AppSettings()
+    monkeypatch.setattr(sd, "get_settings", lambda: s)
+    monkeypatch.setattr("opensak.gui.settings.get_settings", lambda: s)
+
+    def _no_manager():
+        raise RuntimeError("no manager in test")
+
+    monkeypatch.setattr("opensak.db.manager.get_db_manager", _no_manager)
+    monkeypatch.setattr("opensak.api.geocaching.is_logged_in", lambda: False)
+    yield s
+    QSettings.setDefaultFormat(QSettings.Format.NativeFormat)
+
+
+@pytest.fixture
+def dlg(qtbot, settings):
+    d = SettingsDialog()
+    qtbot.addWidget(d)
+    return d
+
+
+# ── workers ───────────────────────────────────────────────────────────────────
+
+class TestWorkers:
+    def test_oauth_success(self, monkeypatch):
+        monkeypatch.setattr("opensak.api.geocaching.start_oauth_flow", lambda: {"access_token": "T"})
+        w = _OAuthWorker()
+        got = []
+        w.success.connect(got.append)
+        w.run()
+        assert got == [{"access_token": "T"}]
+
+    def test_oauth_no_token_emits_error(self, monkeypatch):
+        monkeypatch.setattr("opensak.api.geocaching.start_oauth_flow", lambda: None)
+        w = _OAuthWorker()
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs
+
+    def test_oauth_exception_emits_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.api.geocaching.start_oauth_flow",
+            lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        w = _OAuthWorker()
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs and "boom" in errs[0]
+
+    def test_profile_success(self, monkeypatch):
+        monkeypatch.setattr("opensak.api.geocaching.get_user_profile", lambda: {"username": "bob"})
+        w = _ProfileWorker()
+        got = []
+        w.success.connect(got.append)
+        w.run()
+        assert got == [{"username": "bob"}]
+
+    def test_profile_none_emits_error(self, monkeypatch):
+        monkeypatch.setattr("opensak.api.geocaching.get_user_profile", lambda: None)
+        w = _ProfileWorker()
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs
+
+
+# ── construction (covers the three tab builders + _load) ──────────────────────
+
+class TestConstruction:
+    def test_builds_three_tabs(self, dlg):
+        assert dlg._tabs.count() == 3
+
+    def test_load_reflects_settings(self, qtbot, settings):
+        settings.gc_username = "preset"
+        settings.use_miles = True
+        d = SettingsDialog()
+        qtbot.addWidget(d)
+        assert d._gc_username.text() == "preset"
+        assert d._miles_cb.isChecked() is True
+
+
+# ── coordinate / home-location feedback ───────────────────────────────────────
+
+class TestCoordFeedback:
+    def test_coord_valid(self, dlg):
+        dlg._on_coord_changed(_VALID)
+        assert "✓" in dlg._coord_hint.text()
+
+    def test_coord_invalid(self, dlg):
+        dlg._on_coord_changed("garbage")
+        assert dlg._coord_hint.text() != ""
+
+    def test_coord_empty(self, dlg):
+        dlg._on_coord_changed("")
+        assert dlg._coord_hint.text() == ""
+
+    def test_home_loc_valid(self, dlg):
+        dlg._on_home_loc_changed(_VALID)
+        assert "✓" in dlg._home_loc_hint.text()
+
+    def test_home_loc_invalid(self, dlg):
+        dlg._on_home_loc_changed("garbage")
+        assert dlg._home_loc_hint.text() != ""
+
+    def test_home_loc_empty(self, dlg):
+        dlg._on_home_loc_changed("")
+        assert dlg._home_loc_hint.text() == ""
+
+
+# ── home points ───────────────────────────────────────────────────────────────
+
+class TestHomePoints:
+    def test_add_requires_name(self, dlg, monkeypatch):
+        warn = MagicMock()
+        monkeypatch.setattr(sd.QMessageBox, "warning", warn)
+        dlg._new_name.setText("")
+        dlg._new_coord.setText(_VALID)
+        dlg._add_point()
+        warn.assert_called_once()
+
+    def test_add_requires_coord(self, dlg, monkeypatch):
+        warn = MagicMock()
+        monkeypatch.setattr(sd.QMessageBox, "warning", warn)
+        dlg._new_name.setText("Home")
+        dlg._new_coord.setText("")
+        dlg._add_point()
+        warn.assert_called_once()
+
+    def test_add_rejects_bad_coord(self, dlg, monkeypatch):
+        warn = MagicMock()
+        monkeypatch.setattr(sd.QMessageBox, "warning", warn)
+        dlg._new_name.setText("Home")
+        dlg._new_coord.setText("garbage")
+        dlg._add_point()
+        warn.assert_called_once()
+
+    def test_add_valid_point(self, dlg, settings):
+        dlg._new_name.setText("Work")
+        dlg._new_coord.setText(_VALID)
+        dlg._add_point()
+        names = [p.name for p in settings.home_points]
+        assert "Work" in names
+        assert dlg._new_name.text() == ""  # cleared after add
+
+    def test_edit_then_rename(self, dlg, settings):
+        settings.add_or_update_home_point(HomePoint("Old", 55.0, 12.0))
+        dlg._reload_points_table()
+        # select the row for "Old"
+        for row in range(dlg._points_table.rowCount()):
+            if "Old" in dlg._points_table.item(row, 0).text():
+                dlg._points_table.setCurrentCell(row, 0)
+                break
+        dlg._edit_point()
+        assert dlg._editing_original_name == "Old"
+        dlg._new_name.setText("Renamed")
+        dlg._new_coord.setText(_VALID)
+        dlg._add_point()
+        names = [p.name for p in settings.home_points]
+        assert "Renamed" in names
+        assert "Old" not in names
+
+    def test_delete_point(self, dlg, settings, monkeypatch):
+        settings.add_or_update_home_point(HomePoint("Trash", 55.0, 12.0))
+        dlg._reload_points_table()
+        for row in range(dlg._points_table.rowCount()):
+            if "Trash" in dlg._points_table.item(row, 0).text():
+                dlg._points_table.setCurrentCell(row, 0)
+                break
+        monkeypatch.setattr(
+            sd.QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+        )
+        dlg._delete_point()
+        assert "Trash" not in [p.name for p in settings.home_points]
+
+    def test_point_selection_toggles_buttons(self, dlg, settings):
+        settings.add_or_update_home_point(HomePoint("P1", 55.0, 12.0))
+        dlg._reload_points_table()
+        dlg._points_table.setCurrentCell(0, 0)
+        dlg._on_point_selected()
+        assert dlg._btn_edit.isEnabled() is True
+
+    def test_save_home_location_valid(self, dlg, settings):
+        dlg._gc_home_location.setText(_VALID)
+        dlg._save_home_location()
+        assert settings.gc_home_location == _VALID
+
+    def test_save_home_location_empty_clears(self, dlg, settings):
+        settings.gc_home_location = _VALID
+        dlg._gc_home_location.setText("")
+        dlg._save_home_location()
+        assert settings.gc_home_location == ""
+
+
+# ── theme ─────────────────────────────────────────────────────────────────────
+
+class TestTheme:
+    def test_theme_changed_updates_preview(self, dlg):
+        dlg._on_theme_changed()
+        assert "background-color" in dlg._theme_preview.styleSheet()
+
+
+# ── geocaching login/logout/profile ───────────────────────────────────────────
+
+class TestGeocaching:
+    def test_login_without_client_id_shows_info(self, dlg, monkeypatch):
+        info = MagicMock()
+        monkeypatch.setattr(sd.QMessageBox, "information", info)
+        monkeypatch.setattr("opensak.api.geocaching.GC_CLIENT_ID", "")
+        dlg._on_gc_login()
+        info.assert_called_once()
+
+    def test_login_success_then_profile(self, dlg, monkeypatch):
+        monkeypatch.setattr(dlg, "_on_gc_refresh_profile", MagicMock())
+        dlg._on_gc_login_success({"access_token": "T"})
+        assert dlg._gc_logout_btn.isEnabled() is True
+
+    def test_login_error(self, dlg, monkeypatch):
+        monkeypatch.setattr(sd.QMessageBox, "warning", MagicMock())
+        dlg._on_gc_login_error("nope")
+        assert dlg._gc_login_btn.isEnabled() is True
+
+    def test_logout_confirmed(self, dlg, monkeypatch):
+        monkeypatch.setattr(
+            sd.QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+        )
+        logout = MagicMock()
+        monkeypatch.setattr("opensak.api.geocaching.logout", logout)
+        dlg._on_gc_logout()
+        logout.assert_called_once()
+        assert dlg._gc_logout_btn.isEnabled() is False
+
+    def test_logout_declined(self, dlg, monkeypatch):
+        monkeypatch.setattr(
+            sd.QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.No
+        )
+        logout = MagicMock()
+        monkeypatch.setattr("opensak.api.geocaching.logout", logout)
+        dlg._on_gc_logout()
+        logout.assert_not_called()
+
+    def test_profile_loaded(self, dlg):
+        dlg._on_profile_loaded({"username": "alice", "findCount": 42})
+        assert dlg._gc_username_label.text() == "alice"
+
+    def test_profile_error(self, dlg):
+        dlg._on_profile_error("bad")
+        assert dlg._gc_refresh_btn.isEnabled() is True
+
+    def test_refresh_status_logged_in(self, qtbot, settings, monkeypatch):
+        monkeypatch.setattr("opensak.api.geocaching.is_logged_in", lambda: True)
+
+        class FakeWorker:
+            def __init__(self, parent=None):
+                self.success = MagicMock()
+                self.error = MagicMock()
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr(sd, "_ProfileWorker", FakeWorker)
+        d = SettingsDialog()
+        qtbot.addWidget(d)
+        assert d._gc_logout_btn.isEnabled() is True
+
+
+# ── save ──────────────────────────────────────────────────────────────────────
+
+class TestSave:
+    def test_save_persists_and_accepts(self, dlg, settings):
+        dlg._gc_username.setText("tester")
+        dlg._miles_cb.setChecked(True)
+        dlg._save()
+        assert settings.gc_username == "tester"
+        assert settings.use_miles is True
+        assert dlg.result() == QDialog.DialogCode.Accepted

--- a/tests/unit-tests/test_update_location_dialog.py
+++ b/tests/unit-tests/test_update_location_dialog.py
@@ -1,0 +1,315 @@
+"""tests/unit-tests/test_update_location_dialog.py — reverse-geocode location updater."""
+
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+import opensak.utils.flags as flags
+from opensak.db.database import get_session, init_db
+from opensak.db.models import Cache
+from opensak.gui.dialogs import update_location_dialog as uld
+from opensak.gui.dialogs.update_location_dialog import (
+    OnlineLookupWorker,
+    ReverseGeocodeWorker,
+    UpdateLocationDialog,
+    UpdateLocationResult,
+    _CacheRow,
+    _format_eta,
+)
+
+
+def _loc(country="DK", state="ZL", county="CPH"):
+    return SimpleNamespace(country=country, state=state, county=county)
+
+
+@pytest.fixture
+def db(tmp_path):
+    init_db(db_path=tmp_path / "u.db")
+    with get_session() as s:
+        s.add(Cache(gc_code="GC1", name="A", cache_type="Traditional Cache",
+                    latitude=55.0, longitude=12.0))
+        s.add(Cache(gc_code="GC2", name="B", cache_type="Traditional Cache",
+                    latitude=56.0, longitude=10.0, country="X", state="Y", county="Z"))
+    return tmp_path
+
+
+@pytest.fixture
+def gui(monkeypatch):
+    monkeypatch.setattr(flags, "update_location", True, raising=False)
+    monkeypatch.setattr(
+        "opensak.gui.settings.get_settings",
+        lambda: SimpleNamespace(nominatim_enabled=False),
+    )
+
+
+# ── _format_eta ───────────────────────────────────────────────────────────────
+
+class TestFormatEta:
+    @pytest.mark.parametrize("secs", [30, 120, 7200])
+    def test_returns_string(self, secs):
+        assert isinstance(_format_eta(secs), str)
+
+
+# ── ReverseGeocodeWorker ──────────────────────────────────────────────────────
+
+class TestReverseGeocodeWorker:
+    def test_run_updates_db(self, db, monkeypatch):
+        monkeypatch.setattr("opensak.geocoder.fast_batch_geocode", lambda c: [_loc()])
+        w = ReverseGeocodeWorker([_CacheRow("GC1", 55.0, 12.0)])
+        done = []
+        w.all_done.connect(done.append)
+        w.run()
+        assert done[0].updated == 1
+        with get_session() as s:
+            assert s.query(Cache).filter_by(gc_code="GC1").first().country == "DK"
+
+    def test_run_cancelled_before_start(self, db):
+        w = ReverseGeocodeWorker([_CacheRow("GC1", 55.0, 12.0)])
+        w.request_cancel()
+        cancelled = []
+        w.cancelled.connect(cancelled.append)
+        w.run()
+        assert cancelled
+
+    def test_run_error_still_finishes(self, db, monkeypatch):
+        monkeypatch.setattr("opensak.geocoder.fast_batch_geocode", lambda c: [_loc()])
+        def boom():
+            raise RuntimeError("db boom")
+        monkeypatch.setattr("opensak.db.database.get_session", boom)
+        w = ReverseGeocodeWorker([_CacheRow("GC1", 55.0, 12.0)])
+        done = []
+        w.all_done.connect(done.append)
+        w.run()
+        assert done[0].errors == 1
+
+
+# ── OnlineLookupWorker ────────────────────────────────────────────────────────
+
+class TestOnlineLookupWorker:
+    def test_run_updates_partial_fields(self, db, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.geocoder.nominatim_reverse",
+            lambda lat, lon: _loc(country="NEW", state="ST", county="C2"),
+        )
+        w = OnlineLookupWorker([_CacheRow("GC1", 55.0, 12.0)])
+        done = []
+        w.all_done.connect(done.append)
+        w.run()
+        assert done[0].updated == 1
+        with get_session() as s:
+            assert s.query(Cache).filter_by(gc_code="GC1").first().country == "NEW"
+
+    def test_run_error_path(self, db, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.geocoder.nominatim_reverse", lambda lat, lon: _loc(country="X")
+        )
+        def boom():
+            raise RuntimeError("db down")
+        monkeypatch.setattr("opensak.db.database.get_session", boom)
+        w = OnlineLookupWorker([_CacheRow("GC1", 55.0, 12.0)])
+        done = []
+        w.all_done.connect(done.append)
+        w.run()
+        assert done[0].errors == 1
+
+    def test_run_skips_empty_response(self, db, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.geocoder.nominatim_reverse", lambda lat, lon: _loc(None, None, None)
+        )
+        w = OnlineLookupWorker([_CacheRow("GC1", 55.0, 12.0)])
+        done = []
+        w.all_done.connect(done.append)
+        w.run()
+        assert done[0].skipped == 1
+
+    def test_run_cancelled_before_start(self, db):
+        w = OnlineLookupWorker([_CacheRow("GC1", 55.0, 12.0)])
+        w.request_cancel()
+        cancelled = []
+        w.cancelled.connect(cancelled.append)
+        w.run()
+        assert cancelled
+
+
+# ── UpdateLocationDialog ──────────────────────────────────────────────────────
+
+class TestUpdateLocationDialog:
+    def test_menu_mode_defaults(self, qtbot, gui):
+        dlg = UpdateLocationDialog()
+        qtbot.addWidget(dlg)
+        assert dlg._rb_this.isEnabled() is False
+        assert dlg._rb_missing.isChecked() is True
+
+    def test_context_menu_mode_defaults(self, qtbot, gui):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        assert dlg._rb_this.isChecked() is True
+
+    def test_online_flag_off_hides_checkbox(self, qtbot, monkeypatch):
+        monkeypatch.setattr(flags, "update_location", False, raising=False)
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        assert dlg._cb_online is None
+
+    def test_online_toggle_changes_info(self, qtbot, gui):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        dlg._cb_online.setChecked(True)
+        on = dlg._info_label.text()
+        dlg._cb_online.setChecked(False)
+        assert on != dlg._info_label.text()
+
+    def test_build_rows_missing_scope(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog()
+        qtbot.addWidget(dlg)
+        dlg._rb_missing.setChecked(True)
+        codes = {r.gc_code for r in dlg._build_rows()}
+        assert "GC1" in codes and "GC2" not in codes
+
+    def test_build_rows_all_scope(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog()
+        qtbot.addWidget(dlg)
+        dlg._rb_all.setChecked(True)
+        assert {r.gc_code for r in dlg._build_rows()} == {"GC1", "GC2"}
+
+    def test_build_rows_this_scope(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC2"])
+        qtbot.addWidget(dlg)
+        dlg._rb_this.setChecked(True)
+        assert {r.gc_code for r in dlg._build_rows()} == {"GC2"}
+
+    def test_build_rows_uses_corrected_coords(self, qtbot, gui, tmp_path):
+        from opensak.db.models import UserNote
+        init_db(db_path=tmp_path / "corr.db")
+        with get_session() as s:
+            c = Cache(gc_code="GCX", name="X", cache_type="Traditional Cache",
+                      latitude=10.0, longitude=10.0)
+            c.user_note = UserNote(is_corrected=True, corrected_lat=20.0, corrected_lon=21.0)
+            s.add(c)
+        dlg = UpdateLocationDialog(gc_codes=["GCX"])
+        qtbot.addWidget(dlg)
+        dlg._rb_this.setChecked(True)
+        dlg._cb_corrected.setChecked(True)
+        rows = dlg._build_rows()
+        assert (rows[0].lat, rows[0].lon) == (20.0, 21.0)
+
+    def test_menu_mode_finalize_redisables_this(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog()  # menu mode
+        qtbot.addWidget(dlg)
+        dlg._cb_online.setChecked(False)
+        dlg._on_phase1_done(UpdateLocationResult(updated=1))
+        assert dlg._rb_this.isEnabled() is False
+
+    def test_start_nothing_to_do(self, qtbot, gui, db, monkeypatch):
+        dlg = UpdateLocationDialog()
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(dlg, "_build_rows", lambda: [])
+        dlg._start()
+        assert dlg._progress_label.text() != ""
+
+    def test_start_launches_phase1_worker(self, qtbot, gui, db, monkeypatch):
+        dlg = UpdateLocationDialog()
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(dlg, "_build_rows", lambda: [_CacheRow("GC1", 55.0, 12.0)])
+        started = []
+
+        class FakeWorker:
+            def __init__(self, rows):
+                self.row_done = MagicMock()
+                self.all_done = MagicMock()
+                self.cancelled = MagicMock()
+
+            def start(self):
+                started.append(True)
+
+            def isRunning(self):
+                return False
+
+        monkeypatch.setattr(uld, "ReverseGeocodeWorker", FakeWorker)
+        dlg._start()
+        assert started == [True]
+        assert dlg._start_btn.isEnabled() is False
+
+    def test_phase1_done_finalizes_without_online(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        dlg._cb_online.setChecked(False)
+        fired = []
+        dlg.location_updated.connect(lambda: fired.append(True))
+        dlg._on_phase1_done(UpdateLocationResult(updated=2))
+        assert fired == [True]
+        assert dlg._start_btn.isEnabled() is True
+
+    def test_phase1_done_starts_online_phase(self, qtbot, gui, db, monkeypatch):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        dlg._cb_online.setChecked(True)
+        dlg._pending_rows = [_CacheRow("GC1", 55.0, 12.0)]
+        started = []
+
+        class FakeWorker:
+            def __init__(self, rows):
+                self.row_done = MagicMock()
+                self.progress = MagicMock()
+                self.all_done = MagicMock()
+                self.cancelled = MagicMock()
+
+            def start(self):
+                started.append(True)
+
+            def isRunning(self):
+                return False
+
+        monkeypatch.setattr(uld, "OnlineLookupWorker", FakeWorker)
+        dlg._on_phase1_done(UpdateLocationResult(updated=1))
+        assert started == [True]
+
+    def test_phase1_cancelled_emits_when_updated(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        fired = []
+        dlg.location_updated.connect(lambda: fired.append(True))
+        dlg._on_phase1_cancelled(UpdateLocationResult(updated=1))
+        assert fired == [True]
+
+    def test_online_progress_updates_bar(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        dlg._progress.setRange(0, 10)
+        dlg._on_online_progress(3, 10)
+        assert dlg._progress.value() == 3
+
+    def test_online_done_and_cancelled(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        fired = []
+        dlg.location_updated.connect(lambda: fired.append(True))
+        dlg._on_online_done(UpdateLocationResult(updated=1))
+        dlg._on_online_cancelled(UpdateLocationResult(updated=1))
+        assert fired.count(True) >= 1
+        assert dlg._progress_label.text() != ""
+
+    def test_row_done_appends_to_log(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        dlg._on_row_done("GC1", "a log line")
+        assert "a log line" in dlg._log.toPlainText()
+
+    def test_request_cancel(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        dlg._worker = MagicMock()
+        dlg._request_cancel()
+        dlg._worker.request_cancel.assert_called_once()
+
+    def test_close_event_cancels_running_worker(self, qtbot, gui, db):
+        dlg = UpdateLocationDialog(gc_codes=["GC1"])
+        qtbot.addWidget(dlg)
+        worker = MagicMock()
+        worker.isRunning.return_value = True
+        dlg._worker = worker
+        dlg.close()
+        worker.request_cancel.assert_called_once()

--- a/tests/unit-tests/test_waypoint_dialog.py
+++ b/tests/unit-tests/test_waypoint_dialog.py
@@ -1,0 +1,224 @@
+"""tests/unit-tests/test_waypoint_dialog.py — add/edit cache & custom-waypoint dialog."""
+
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtWidgets import QDialog
+
+from opensak.gui.dialogs import waypoint_dialog as wpd
+from opensak.gui.dialogs.waypoint_dialog import WaypointDialog
+from opensak.utils.types import CoordFormat
+
+_VALID = "N55 47.250 E012 25.000"
+
+
+@pytest.fixture(autouse=True)
+def settings(monkeypatch):
+    m = MagicMock()
+    m.coord_format = CoordFormat.DMM
+    monkeypatch.setattr(wpd, "get_settings", lambda: m)
+    return m
+
+
+@pytest.fixture
+def warn(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr(wpd.QMessageBox, "warning", mock)
+    return mock
+
+
+def _cache(gc_code="GC12345", cache_type="Traditional Cache"):
+    return SimpleNamespace(
+        gc_code=gc_code, name="Edit Me", cache_type=cache_type, container="Small",
+        parent_gc_code=None, difficulty=2.5, terrain=3.0,
+        latitude=55.0, longitude=12.0, placed_by="Owner", country="Denmark",
+        state="Zealand", short_description="s", long_description="l",
+        encoded_hints="hint", available=True, archived=False, premium_only=False,
+        found=True, dnf=False, favorite_point=False, first_to_find=False,
+    )
+
+
+# ── construction / mode ───────────────────────────────────────────────────────
+
+class TestConstruction:
+    def test_add_mode_defaults_to_geocache(self, qtbot):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        assert dlg._is_custom is False
+        assert dlg._gc_code.isVisible() or not dlg.isVisible()
+
+    def test_edit_geocache_populates_and_locks_mode(self, qtbot):
+        dlg = WaypointDialog(cache=_cache())
+        qtbot.addWidget(dlg)
+        assert dlg._is_edit is True
+        assert dlg._gc_code.text() == "GC12345"
+        assert dlg._name.text() == "Edit Me"
+        assert dlg._radio_geocache.isEnabled() is False
+
+    def test_edit_custom_when_gc_not_gc_prefixed(self, qtbot):
+        dlg = WaypointDialog(cache=_cache(gc_code="CW001", cache_type="Parking Area"))
+        qtbot.addWidget(dlg)
+        assert dlg._is_custom is True
+        assert dlg._cw_id.text() == "CW001"
+
+    def test_mode_switch_to_custom(self, qtbot):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._radio_custom.setChecked(True)
+        dlg._on_mode_changed(None)
+        assert dlg._is_custom is True
+
+
+# ── input feedback ────────────────────────────────────────────────────────────
+
+class TestInputFeedback:
+    def test_coord_valid(self, qtbot):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._coord_input.setText(_VALID)
+        assert dlg._parsed_lat is not None
+        assert "✓" in dlg._coord_feedback.text()
+
+    def test_coord_invalid(self, qtbot):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._coord_input.setText("nonsense")
+        assert dlg._parsed_lat is None
+        assert dlg._coord_feedback.text() != ""
+
+    def test_coord_cleared(self, qtbot):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._coord_input.setText(_VALID)
+        dlg._coord_input.setText("")
+        assert dlg._parsed_lat is None
+        assert dlg._coord_feedback.text() == ""
+
+    def test_parent_gc_valid_and_invalid(self, qtbot):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._parent_gc.setText("ABC")
+        assert dlg._parent_gc_feedback.text() != ""
+        dlg._parent_gc.setText("GC999")
+        assert dlg._parent_gc_feedback.text() == ""
+        dlg._parent_gc.setText("")
+        assert dlg._parent_gc_feedback.text() == ""
+
+
+# ── validation ────────────────────────────────────────────────────────────────
+
+class TestValidation:
+    def test_name_required(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._validate_and_accept()
+        warn.assert_called_once()
+        assert dlg.result() != QDialog.DialogCode.Accepted
+
+    def test_bad_coord_blocks_accept(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._name.setText("X")
+        dlg._coord_input.setText("garbage")
+        dlg._validate_and_accept()
+        warn.assert_called_once()
+
+    def test_geocache_gc_required(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._name.setText("X")
+        dlg._validate_and_accept()
+        warn.assert_called_once()
+
+    def test_geocache_gc_invalid(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._name.setText("X")
+        dlg._gc_code.setText("XYZ123")
+        dlg._validate_and_accept()
+        warn.assert_called_once()
+
+    def test_geocache_invalid_dt(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._name.setText("X")
+        dlg._gc_code.setText("GC123")
+        dlg._difficulty.setValue(1.3)  # not a valid 0.5-step value
+        dlg._validate_and_accept()
+        warn.assert_called_once()
+
+    def test_geocache_invalid_terrain(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._name.setText("X")
+        dlg._gc_code.setText("GC123")
+        dlg._difficulty.setValue(1.5)  # valid
+        dlg._terrain.setValue(1.3)     # invalid -> terrain branch
+        dlg._validate_and_accept()
+        warn.assert_called_once()
+
+    def test_geocache_valid_accepts(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._name.setText("Good")
+        dlg._gc_code.setText("GC123")
+        dlg._coord_input.setText(_VALID)
+        dlg._validate_and_accept()
+        warn.assert_not_called()
+        assert dlg.result() == QDialog.DialogCode.Accepted
+
+    def test_custom_invalid_parent(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._radio_custom.setChecked(True)
+        dlg._on_mode_changed(None)
+        dlg._name.setText("WP")
+        dlg._parent_gc.setText("ABC")
+        dlg._validate_and_accept()
+        warn.assert_called_once()
+
+    def test_custom_valid_accepts(self, qtbot, warn):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._radio_custom.setChecked(True)
+        dlg._on_mode_changed(None)
+        dlg._name.setText("WP")
+        dlg._parent_gc.setText("GC999")
+        dlg._validate_and_accept()
+        warn.assert_not_called()
+        assert dlg.result() == QDialog.DialogCode.Accepted
+
+
+# ── data extraction ───────────────────────────────────────────────────────────
+
+class TestGetData:
+    def test_geocache_data(self, qtbot):
+        dlg = WaypointDialog()
+        qtbot.addWidget(dlg)
+        dlg._name.setText("My Cache")
+        dlg._gc_code.setText("gc123")
+        dlg._coord_input.setText(_VALID)
+        dlg._found.setChecked(True)
+        data = dlg.get_data()
+        assert data["gc_code"] == "GC123"
+        assert data["name"] == "My Cache"
+        assert data["found"] is True
+        assert data["latitude"] is not None
+        assert data["parent_gc_code"] is None
+
+    def test_custom_data(self, qtbot):
+        dlg = WaypointDialog(next_cw_id="CW042")
+        qtbot.addWidget(dlg)
+        dlg._radio_custom.setChecked(True)
+        dlg._on_mode_changed(None)
+        dlg._name.setText("Parking")
+        dlg._parent_gc.setText("gc999")
+        data = dlg.get_data()
+        assert data["gc_code"] == "CW042"
+        assert data["parent_gc_code"] == "GC999"
+        assert data["difficulty"] is None
+        assert data["container"] is None


### PR DESCRIPTION
Third step of the phased coverage push (#225): `pytest-qt` widget tests for the
0%-covered dialogs, plus the two pre-existing issues flagged during Phase 1.

**10 files changed · +1421 / −18 · 9 commits.** Suite: **959 passing** (was
~828), no flakiness. Overall coverage **61% → 76%**.

## 🔧 Pre-existing fixes (bundled per request)

- **`coords.py`** — removed the unreachable plain-DMM parse branch (the
  degree-sign DMM regex above already matches every input it would). `coords.py`
  → 100%.
- **`db/database.py`** — migration 2 rebuilt the waypoints table with an inline
  `UNIQUE(...)`, which SQLite auto-names `sqlite_autoindex_*`. The migration's
  own idempotency gate checks for `uq_waypoint_cache_prefix_name`, so it never
  matched (only the `user_version` gate stopped a re-run) and the index name
  diverged from the model. Now builds it as an explicitly **named** unique index.

## Coverage by dialog

| Dialog | Before | After |
|---|---|---|
| `corrected_coords_dialog.py` | 0% | **100%** |
| `kml_export_dialog.py` | 0% | **100%** |
| `file_export_dialog.py` | 0% | **100%** |
| `found_dialog.py` | 0% | **100%** |
| `waypoint_dialog.py` | 0% | **100%** |
| `column_dialog.py` | 0% | **99%** |
| `update_location_dialog.py` | 0% | **97%** |
| `settings_dialog.py` | 0% | **92%** |

## What's tested

- **settings_dialog** — backed by a temp-INI `AppSettings`; OAuth/profile
  workers, three-tab construction + load, coord/home-location feedback,
  home-point add/edit/delete/select, theme preview, GC login/logout/profile
  handlers + logged-in refresh, and the save round-trip.
- **waypoint_dialog** — both modes (geocache / custom WP): construction,
  edit-mode populate, live coord/parent-GC feedback, all validation paths,
  and `get_data()` for both shapes.
- **update_location_dialog** — `_format_eta`, both geocoding workers
  (update / skip-empty / error / cancel) against a temp DB with a mocked
  geocoder, plus scope row-building, two-phase start/finish/cancel handlers.
- **found_dialog / export dialogs / corrected_coords / column** — workers,
  file/format selection, browse, validation, persistence, and result handlers.
- Network, `QFileDialog`, `QMessageBox` and the DB manager are mocked
  throughout; real threads are replaced with fakes.

## Testing note (why no test patches a QObject method/type)

Patching a `QObject`/`QThread` subclass **method** — or a PySide type like
`QSettings` — with a `MagicMock` segfaults PySide's meta-object builder
(`parsePythonType`) the moment an instance is constructed or a signal is
`.connect()`ed. Tests therefore patch the **worker class** (not its methods) and
isolate `QSettings` via `setDefaultFormat`/`setPath` rather than replacing it.

## Follow-up found (not changed here)

`settings_dialog._save_home_location` / `_save` "validate" home coordinates with
`parse_coords()` inside a `try/except`, but `parse_coords` returns `None` (it
never raises) for bad input — so invalid text is saved anyway and the warning
branch is dead. Flagged for a separate fix.

## Notes for reviewers

- Production changes are limited to the two fixes (`coords.py`,
  `db/database.py`); everything else is under `tests/`.
- The deliberately-uncovered remainder of `settings_dialog` (92%) is the
  live-OAuth login worker start, the theme/language-change save side effects,
  and the dead validation branch above.

---
Part of #225. Builds on Phase 1 (#230).