### PR TITLE
Test Coverage - Phase 3

### DIFF
--- a/src/opensak/gui/dialogs/filter_dialog.py
+++ b/src/opensak/gui/dialogs/filter_dialog.py
@@ -1218,10 +1218,9 @@ class FilterDialog(QDialog):
             else:
                 flat_filters.append(f)
 
-        if attr_mode_or_detected:
-            self._attr_mode_any.setChecked(True)
-        else:
-            self._attr_mode_all.setChecked(True)
+        # OR-mode = "any selected"; the UI only has the "all selected" checkbox,
+        # so unchecking it expresses ANY (avoids a crash on the missing widget).
+        self._attr_mode_all.setChecked(not attr_mode_or_detected)
 
         for f in flat_filters:
             ftype = getattr(f, "filter_type", None)

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -705,10 +705,8 @@ class SettingsDialog(QDialog):
             get_settings().sync()
             self._reload_points_table()
             return
-        try:
-            from opensak.coords import parse_coords
-            parse_coords(text)  # valider
-        except Exception:
+        from opensak.coords import parse_coords
+        if parse_coords(text) is None:  # returns None on failure, never raises
             from opensak.gui.icon import OpenSAKMessageBox
             OpenSAKMessageBox.warning(self, tr("warning"), tr("settings_hp_coord_invalid"))
             return
@@ -831,12 +829,9 @@ class SettingsDialog(QDialog):
         if not home_text:
             s.gc_home_location = ""
         else:
-            try:
-                from opensak.coords import parse_coords
-                parse_coords(home_text)
+            from opensak.coords import parse_coords
+            if parse_coords(home_text) is not None:  # keep existing if invalid
                 s.gc_home_location = home_text
-            except Exception:
-                pass  # behold eksisterende hvis invalid
         s.use_miles         = self._miles_cb.isChecked()
         s.show_archived     = self._archived_cb.isChecked()
         s.show_found        = self._found_cb.isChecked()

--- a/src/opensak/gui/settings.py
+++ b/src/opensak/gui/settings.py
@@ -196,11 +196,6 @@ class AppSettings:
         except Exception:
             return None
 
-    def is_setup_complete(self) -> bool:
-        has_username = bool(self.gc_username.strip())
-        has_home = bool(self.gc_home_location.strip()) or bool(self.home_points)
-        return has_username and has_home
-
     # ── Theme / appearance ────────────────────────────────────────────────────
 
     @property

--- a/tests/e2e-tests/test_e2e_mainwindow.py
+++ b/tests/e2e-tests/test_e2e_mainwindow.py
@@ -1,0 +1,809 @@
+"""tests/e2e-tests/test_e2e_mainwindow.py — MainWindow actions, dialogs, slots."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtCore import QSettings
+
+import opensak.gui.icon as icon_mod
+from opensak.gui.mainwindow import MainWindow
+
+# Captured before conftest's autouse fixture no-ops them on the class.
+_REAL_INITIAL_LOAD = MainWindow._initial_load
+_REAL_CHECK_SETUP = MainWindow._check_setup_complete
+_REAL_CHECK_UPDATE_BG = MainWindow._check_update_background
+
+_RealQSettings = QSettings
+
+
+# ── fakes ─────────────────────────────────────────────────────────────────────
+
+class _Sig:
+    def __init__(self):
+        self._cbs = []
+
+    def connect(self, cb):
+        self._cbs.append(cb)
+
+    def emit(self, *a):
+        for cb in list(self._cbs):
+            cb(*a)
+
+
+def fake_dialog(*, exec_result=0, signals=(), data=None, attrs=None):
+    """Build a non-modal dialog stub class."""
+    class _Fake:
+        def __init__(self, *a, **k):
+            self.args = a
+            self.kwargs = k
+            for s in signals:
+                setattr(self, s, _Sig())
+            for name, val in (attrs or {}).items():
+                setattr(self, name, val)
+
+        def exec(self):
+            return exec_result
+
+        def add_files(self, paths):
+            self.files = paths
+
+        def get_data(self):
+            return data
+    return _Fake
+
+
+def fake_worker():
+    """Stub UpdateCheckWorker that never spawns a thread (safe for closeEvent)."""
+    class _W:
+        def __init__(self, *a, **k):
+            self.update_available = _Sig()
+            self.check_done = _Sig()
+
+        def start(self):
+            pass
+
+        def isRunning(self):
+            return False
+
+        def quit(self):
+            pass
+
+        def wait(self, *a):
+            pass
+    return _W
+
+
+def _wp_data(gc_code="CW001"):
+    return {
+        "gc_code": gc_code, "name": "New WP", "cache_type": "Traditional Cache",
+        "latitude": 55.5, "longitude": 12.5, "difficulty": 1.0, "terrain": 1.0,
+        "available": True, "archived": False, "found": False,
+    }
+
+
+# ── shared isolation fixture ──────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def iso_settings(tmp_path, monkeypatch):
+    """Redirect AppSettings + raw QSettings("OpenSAK...") to throwaway INIs."""
+    from opensak.gui import settings as smod
+    appset = smod.get_settings()
+    orig = appset._s
+    appset._s = _RealQSettings(str(tmp_path / "appset.ini"),
+                               _RealQSettings.Format.IniFormat)
+
+    raw_ini = str(tmp_path / "raw.ini")
+
+    def factory(*a, **k):
+        if len(a) >= 2 and isinstance(a[0], str) and "OpenSAK" in a[0]:
+            return _RealQSettings(raw_ini, _RealQSettings.Format.IniFormat)
+        return _RealQSettings(*a, **k)
+
+    monkeypatch.setattr("PySide6.QtCore.QSettings", factory)
+    yield SimpleNamespace(appset=appset, raw_ini=raw_ini)
+    appset._s = orig
+
+
+@pytest.fixture
+def mbox_yes(monkeypatch):
+    monkeypatch.setattr(icon_mod.QMessageBox, "exec",
+                        lambda self: icon_mod.QMessageBox.StandardButton.Yes)
+
+
+@pytest.fixture
+def mbox_no(monkeypatch):
+    monkeypatch.setattr(icon_mod.QMessageBox, "exec",
+                        lambda self: icon_mod.QMessageBox.StandardButton.No)
+
+
+@pytest.fixture
+def mbox_ok(monkeypatch):
+    monkeypatch.setattr(icon_mod.QMessageBox, "exec",
+                        lambda self: icon_mod.QMessageBox.StandardButton.Ok)
+
+
+# ── title / db combo / db manager ─────────────────────────────────────────────
+
+class TestDbCombo:
+    def test_update_title_with_active(self, seeded_window):
+        seeded_window._update_title()
+        assert "v" in seeded_window.windowTitle()
+
+    def test_open_db_manager(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.database_dialog.DatabaseManagerDialog",
+            fake_dialog(signals=("database_switched",)))
+        seeded_window._open_db_manager()
+
+    def test_open_db_manager_blocked_by_trip(self, seeded_window, monkeypatch):
+        seeded_window._trip_planner_win = SimpleNamespace(
+            isVisible=lambda: True, raise_=lambda: None, activateWindow=lambda: None)
+        called = []
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.database_dialog.DatabaseManagerDialog",
+            lambda *a, **k: called.append(True))
+        seeded_window._open_db_manager()
+        assert called == []
+
+    def test_on_database_switched(self, seeded_window):
+        info = SimpleNamespace(name="OtherDB")
+        seeded_window._on_database_switched(info)
+
+    def test_reload_db_combo(self, seeded_window):
+        seeded_window._reload_db_combo()
+        assert seeded_window._db_combo.count() >= 1
+
+    def test_on_db_combo_changed_no_data(self, seeded_window):
+        seeded_window._on_db_combo_changed(999)  # itemData None → early return
+
+    def test_on_db_combo_changed_same_active(self, seeded_window):
+        seeded_window._on_db_combo_changed(0)  # equals active → early return
+
+
+# ── splitter / restore / close ────────────────────────────────────────────────
+
+class TestLayout:
+    def test_restore_splitter_ratios(self, seeded_window):
+        seeded_window._restore_splitter_ratios()
+
+    def test_save_splitter_ratios(self, seeded_window):
+        seeded_window._save_splitter_ratios()
+
+
+# ── cache list / info bar / filterset ─────────────────────────────────────────
+
+class TestCacheList:
+    def test_refresh_table_only_single(self, seeded_window):
+        seeded_window._search_gc.setText("GC12345")
+        seeded_window._refresh_table_only()
+        assert seeded_window._cache_table.row_count() == 1
+
+    def test_refresh_table_only_many(self, seeded_window):
+        seeded_window._refresh_table_only()
+        assert seeded_window._cache_table.row_count() >= 1
+
+    def test_build_filterset_quick_filters(self, seeded_window):
+        for idx in range(6):
+            seeded_window._quick_filter.setCurrentIndex(idx)
+            fs = seeded_window._build_current_filterset()
+            assert fs is not None
+
+    def test_build_filterset_search_fields(self, seeded_window):
+        seeded_window._search_gc.setText("GC123")
+        seeded_window._search_box.setText("Test")
+        fs = seeded_window._build_current_filterset()
+        assert len(fs) >= 2
+
+    def test_refresh_with_active_filterset(self, seeded_window):
+        from opensak.filters.engine import FilterSet, GcCodeFilter
+        fs = FilterSet(mode="AND")
+        fs.add(GcCodeFilter("GC12345"))
+        seeded_window._current_filterset = fs
+        seeded_window._refresh_cache_list()
+
+    def test_update_info_bar(self, seeded_window):
+        seeded_window._update_info_bar()
+
+    def test_update_info_bar_with_owner(self, seeded_window, iso_settings):
+        iso_settings.appset.gc_username = "TestOwner"
+        seeded_window._update_info_bar()
+
+
+# ── selection slots ───────────────────────────────────────────────────────────
+
+class TestSelectionSlots:
+    def test_on_cache_selected(self, seeded_window):
+        cache = seeded_window._cache_table._model.cache_at(0)
+        seeded_window._on_cache_selected(cache)
+
+    def test_on_cache_selected_missing(self, seeded_window):
+        seeded_window._on_cache_selected(SimpleNamespace(gc_code="NOPE"))
+
+    def test_on_map_cache_selected(self, seeded_window):
+        seeded_window._on_map_cache_selected("GC12345")
+
+    def test_on_map_cache_selected_missing(self, seeded_window):
+        seeded_window._on_map_cache_selected("NOPE")
+
+    def test_on_corrected_coords_changed(self, seeded_window):
+        seeded_window._on_corrected_coords_changed("GC12345")
+
+    def test_load_full_cache(self, seeded_window):
+        assert seeded_window._load_full_cache("GC12345") is not None
+
+
+# ── search ────────────────────────────────────────────────────────────────────
+
+class TestSearch:
+    def test_search_changed_empty(self, seeded_window):
+        seeded_window._on_search_changed("")
+
+    def test_search_changed_above_threshold(self, seeded_window):
+        seeded_window._on_search_changed("abcdef")
+
+    def test_search_changed_below_threshold(self, seeded_window):
+        seeded_window._db_count = 50_000  # forces min_chars=3
+        seeded_window._on_search_changed("a")
+
+    def test_search_thresholds_adaptive(self, seeded_window):
+        for cnt in (0, 5_000, 20_000):
+            seeded_window._db_count = cnt
+            assert len(seeded_window._search_thresholds()) == 2
+
+    def test_quick_filter_changed(self, seeded_window):
+        seeded_window._on_quick_filter_changed(1)
+
+
+# ── drag & drop ───────────────────────────────────────────────────────────────
+
+def _evt(paths, accept, ignore):
+    urls = [SimpleNamespace(toLocalFile=lambda p=p: p) for p in paths]
+    mime = SimpleNamespace(hasUrls=lambda: bool(urls), urls=lambda: urls)
+    return SimpleNamespace(
+        mimeData=lambda: mime,
+        acceptProposedAction=accept,
+        ignore=ignore,
+    )
+
+
+class TestDragDrop:
+    def test_drag_enter_accepts_gpx(self, seeded_window):
+        flags = {"accept": False, "ignore": False}
+        e = _evt(["/x/a.gpx"],
+                 lambda: flags.update(accept=True),
+                 lambda: flags.update(ignore=True))
+        seeded_window.dragEnterEvent(e)
+        assert flags["accept"] is True
+
+    def test_drag_enter_ignores_other(self, seeded_window):
+        flags = {"ignore": False}
+        e = _evt(["/x/a.txt"], lambda: None, lambda: flags.update(ignore=True))
+        seeded_window.dragEnterEvent(e)
+        assert flags["ignore"] is True
+
+    def test_drop_imports(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.import_dialog.ImportDialog",
+            fake_dialog(signals=("import_completed",)))
+        flags = {"accept": False}
+        e = _evt(["/x/a.gpx"], lambda: flags.update(accept=True), lambda: None)
+        seeded_window.dropEvent(e)
+        assert flags["accept"] is True
+
+    def test_drop_no_valid_paths(self, seeded_window):
+        flags = {"ignore": False}
+        e = _evt(["/x/a.txt"], lambda: None, lambda: flags.update(ignore=True))
+        seeded_window.dropEvent(e)
+        assert flags["ignore"] is True
+
+    def test_drop_blocked_by_trip(self, seeded_window):
+        seeded_window._trip_planner_win = SimpleNamespace(
+            isVisible=lambda: True, raise_=lambda: None, activateWindow=lambda: None)
+        flags = {"ignore": False}
+        e = _evt(["/x/a.gpx"], lambda: None, lambda: flags.update(ignore=True))
+        seeded_window.dropEvent(e)
+        assert flags["ignore"] is True
+
+
+# ── import / settings / home ──────────────────────────────────────────────────
+
+class TestImportSettingsHome:
+    def test_open_import_dialog(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.import_dialog.ImportDialog",
+            fake_dialog(signals=("import_completed",)))
+        seeded_window._open_import_dialog()
+
+    def test_open_import_blocked_by_trip(self, seeded_window):
+        seeded_window._trip_planner_win = SimpleNamespace(
+            isVisible=lambda: True, raise_=lambda: None, activateWindow=lambda: None)
+        seeded_window._open_import_dialog()  # warns, returns
+
+    def test_refresh_after_import(self, seeded_window):
+        seeded_window._refresh_after_import()
+
+    def test_open_settings_accepted(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.settings_dialog.SettingsDialog",
+            fake_dialog(exec_result=1))
+        seeded_window._open_settings()
+
+    def test_open_settings_rejected(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.settings_dialog.SettingsDialog",
+            fake_dialog(exec_result=0))
+        seeded_window._open_settings()
+
+    def test_reload_home_combo_with_points(self, seeded_window):
+        seeded_window._reload_home_combo()
+        assert seeded_window._home_combo.count() >= 1
+
+    def test_reload_home_combo_no_points(self, seeded_window, monkeypatch):
+        from opensak.gui.settings import AppSettings
+        monkeypatch.setattr(AppSettings, "home_points", property(lambda self: []))
+        seeded_window._reload_home_combo()
+
+    def test_on_home_changed_no_name(self, seeded_window):
+        seeded_window._home_combo.addItem("none", None)
+        seeded_window._on_home_changed(seeded_window._home_combo.count() - 1)
+
+
+# ── startup hooks ─────────────────────────────────────────────────────────────
+
+class TestStartup:
+    def test_initial_load_not_ready(self, seeded_window):
+        _REAL_INITIAL_LOAD(seeded_window)
+
+    def test_initial_load_ready(self, seeded_window):
+        seeded_window._map_widget._ready = True
+        _REAL_INITIAL_LOAD(seeded_window)
+
+    def test_check_setup_complete_already(self, seeded_window, monkeypatch):
+        from opensak.gui.settings import AppSettings
+        monkeypatch.setattr(AppSettings, "is_setup_complete", lambda self: True)
+        _REAL_CHECK_SETUP(seeded_window)
+
+    def test_check_setup_incomplete_opens_settings(self, seeded_window, monkeypatch, mbox_ok):
+        from opensak.gui.settings import AppSettings
+        monkeypatch.setattr(AppSettings, "is_setup_complete", lambda self: False)
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.settings_dialog.SettingsDialog",
+            fake_dialog(exec_result=0))
+        _REAL_CHECK_SETUP(seeded_window)
+
+    def test_check_update_background(self, seeded_window, monkeypatch):
+        monkeypatch.setattr("opensak.gui.mainwindow.UpdateCheckWorker", fake_worker())
+        _REAL_CHECK_UPDATE_BG(seeded_window)
+
+
+# ── waypoint CRUD ─────────────────────────────────────────────────────────────
+
+class TestWaypoints:
+    def test_next_cw_id(self, seeded_window):
+        assert seeded_window._next_cw_id() == "CW001"
+
+    def test_add_waypoint(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.waypoint_dialog.WaypointDialog",
+            fake_dialog(exec_result=1, data=_wp_data("CW001")))
+        seeded_window._add_waypoint()
+        assert seeded_window._load_full_cache("CW001") is not None
+
+    def test_add_waypoint_existing_warns(self, seeded_window, monkeypatch, mbox_ok):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.waypoint_dialog.WaypointDialog",
+            fake_dialog(exec_result=1, data=_wp_data("GC12345")))
+        seeded_window._add_waypoint()
+
+    def test_add_waypoint_cancelled(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.waypoint_dialog.WaypointDialog",
+            fake_dialog(exec_result=0))
+        seeded_window._add_waypoint()
+
+    def test_edit_waypoint_no_selection(self, seeded_window):
+        seeded_window._cache_table.clearSelection()
+        seeded_window._edit_waypoint()
+
+    def test_edit_waypoint_from_cache(self, seeded_window, monkeypatch):
+        cache = seeded_window._load_full_cache("GC12345")
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.waypoint_dialog.WaypointDialog",
+            fake_dialog(exec_result=1, data=_wp_data("GC12345")))
+        seeded_window._edit_waypoint_from_cache(cache)
+
+    def test_edit_waypoint_from_cache_cancelled(self, seeded_window, monkeypatch):
+        cache = seeded_window._load_full_cache("GC12345")
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.waypoint_dialog.WaypointDialog",
+            fake_dialog(exec_result=0))
+        seeded_window._edit_waypoint_from_cache(cache)
+
+    def test_delete_waypoint_no_selection(self, seeded_window):
+        seeded_window._cache_table.clearSelection()
+        seeded_window._delete_waypoint()
+
+    def test_delete_waypoint_confirmed(self, seeded_window, monkeypatch, mbox_yes):
+        seeded_window._cache_table.select_by_gc_code("GC99999")
+        seeded_window._delete_waypoint()
+        assert seeded_window._load_full_cache("GC99999") is None
+
+    def test_delete_waypoint_declined(self, seeded_window, monkeypatch, mbox_no):
+        seeded_window._cache_table.select_by_gc_code("GC12345")
+        seeded_window._delete_waypoint()
+        assert seeded_window._load_full_cache("GC12345") is not None
+
+
+# ── bulk delete / flags ───────────────────────────────────────────────────────
+
+class TestBulkAndFlags:
+    def _flag(self, window, gc_code):
+        from opensak.db.database import get_session
+        from opensak.db.models import Cache
+        with get_session() as s:
+            c = s.query(Cache).filter_by(gc_code=gc_code).first()
+            c.user_flag = True
+        window._refresh_cache_list()
+
+    def test_delete_flagged_none(self, seeded_window, mbox_ok):
+        seeded_window._delete_flagged_caches()  # info, returns
+
+    def test_delete_flagged_confirmed(self, seeded_window, mbox_yes):
+        self._flag(seeded_window, "GC12345")
+        seeded_window._delete_flagged_caches()
+        assert seeded_window._load_full_cache("GC12345") is None
+
+    def test_delete_filtered_none(self, empty_window, mbox_ok):
+        empty_window._delete_filtered_caches()  # info, returns
+
+    def test_delete_filtered_confirmed(self, seeded_window, mbox_yes):
+        seeded_window._delete_filtered_caches()
+        assert seeded_window._cache_table.row_count() == 0
+
+    def test_bulk_delete_empty_codes(self, seeded_window):
+        seeded_window._bulk_delete_caches(["NONEXIST"])  # cache_ids empty branch
+
+    def test_clear_all_flags_confirmed(self, seeded_window, mbox_yes):
+        self._flag(seeded_window, "GC12345")
+        seeded_window._clear_all_flags()
+
+    def test_clear_all_flags_declined(self, seeded_window, mbox_no):
+        seeded_window._clear_all_flags()
+
+    def test_on_flags_changed(self, seeded_window):
+        self._flag(seeded_window, "GC12345")
+        seeded_window._on_flags_changed()
+
+
+# ── sort save/load ────────────────────────────────────────────────────────────
+
+class TestSort:
+    def test_on_sort_changed(self, seeded_window):
+        seeded_window._on_sort_changed("name", False)
+        assert seeded_window._current_sort.field == "name"
+
+    def test_save_sort_no_active(self, seeded_window, monkeypatch):
+        monkeypatch.setattr("opensak.db.manager.get_db_manager",
+                            lambda: SimpleNamespace(active=None))
+        seeded_window._save_sort_for_active_db()
+
+    def test_load_sort_no_active(self, seeded_window, monkeypatch):
+        monkeypatch.setattr("opensak.db.manager.get_db_manager",
+                            lambda: SimpleNamespace(active=None))
+        seeded_window._load_sort_for_active_db()
+
+    def test_load_sort_with_saved_profile(self, seeded_window, monkeypatch, iso_settings):
+        from opensak.db.manager import get_db_manager
+        from opensak.filters.engine import FilterSet, SortSpec
+        key = f"sort/{get_db_manager().active.path}"
+        s = _RealQSettings(iso_settings.raw_ini, _RealQSettings.Format.IniFormat)
+        s.setValue(f"{key}/filter_profile", "MyProfile")
+        s.sync()
+        prof = SimpleNamespace(name="MyProfile", filterset=FilterSet(),
+                               sort=SortSpec("name"))
+        monkeypatch.setattr("opensak.filters.engine.FilterProfile.list_profiles",
+                            staticmethod(lambda: [Path("/x/p.json")]))
+        monkeypatch.setattr("opensak.filters.engine.FilterProfile.load",
+                            staticmethod(lambda p: prof))
+        seeded_window._load_sort_for_active_db()
+        assert seeded_window._active_filter_name == "MyProfile"
+
+    def test_load_sort_profile_load_error(self, seeded_window, monkeypatch, iso_settings):
+        from opensak.db.manager import get_db_manager
+        key = f"sort/{get_db_manager().active.path}"
+        s = _RealQSettings(iso_settings.raw_ini, _RealQSettings.Format.IniFormat)
+        s.setValue(f"{key}/filter_profile", "Ghost")
+        s.sync()
+        monkeypatch.setattr("opensak.filters.engine.FilterProfile.list_profiles",
+                            staticmethod(lambda: [Path("/x/p.json")]))
+        monkeypatch.setattr(
+            "opensak.filters.engine.FilterProfile.load",
+            staticmethod(lambda p: (_ for _ in ()).throw(RuntimeError("bad"))))
+        seeded_window._load_sort_for_active_db()  # except → reset to no filter
+        assert seeded_window._active_filter_name == ""
+
+
+# ── filter dialog / profiles ──────────────────────────────────────────────────
+
+class TestFilters:
+    def test_open_filter_dialog(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.filter_dialog.FilterDialog",
+            fake_dialog(signals=("filter_applied",)))
+        seeded_window._open_filter_dialog()
+
+    def test_open_filter_blocked_by_trip(self, seeded_window):
+        seeded_window._trip_planner_win = SimpleNamespace(
+            isVisible=lambda: True, raise_=lambda: None, activateWindow=lambda: None)
+        seeded_window._open_filter_dialog()
+
+    def test_on_filter_applied(self, seeded_window):
+        from opensak.filters.engine import FilterSet, SortSpec
+        seeded_window._on_filter_applied(FilterSet(), SortSpec("name"), "Prof")
+        assert seeded_window._active_filter_name == "Prof"
+
+    def test_on_filter_applied_single(self, seeded_window):
+        from opensak.filters.engine import FilterSet, SortSpec, GcCodeFilter
+        fs = FilterSet(mode="AND")
+        fs.add(GcCodeFilter("GC12345"))
+        seeded_window._on_filter_applied(fs, SortSpec("name"), "")
+
+    def test_set_clear_filter_active(self, seeded_window):
+        seeded_window._set_clear_filter_active(True)
+        seeded_window._set_clear_filter_active(False)
+
+    def test_clear_filter(self, seeded_window):
+        seeded_window._clear_filter()
+
+    def test_populate_filter_profile_combo(self, seeded_window):
+        seeded_window._populate_filter_profile_combo()
+
+    def test_populate_combo_load_error(self, seeded_window, monkeypatch):
+        monkeypatch.setattr("opensak.filters.engine.FilterProfile.list_profiles",
+                            staticmethod(lambda: [Path("/x/p.json")]))
+        monkeypatch.setattr(
+            "opensak.filters.engine.FilterProfile.load",
+            staticmethod(lambda p: (_ for _ in ()).throw(RuntimeError("bad"))))
+        seeded_window._populate_filter_profile_combo()
+
+    def test_filter_profile_combo_changed_none(self, seeded_window):
+        seeded_window._on_filter_profile_combo_changed(0)  # → clear_filter
+
+    def test_filter_profile_combo_changed_none_data(self, seeded_window):
+        seeded_window._filter_profile_combo.addItem("X", userData=None)
+        idx = seeded_window._filter_profile_combo.count() - 1
+        seeded_window._on_filter_profile_combo_changed(idx)  # path None → return
+
+    def test_filter_profile_combo_changed_single(self, seeded_window, monkeypatch):
+        from opensak.filters.engine import FilterSet, SortSpec, GcCodeFilter
+        fs = FilterSet(mode="AND")
+        fs.add(GcCodeFilter("GC12345"))
+        prof = SimpleNamespace(name="P1", filterset=fs, sort=SortSpec("name"))
+        monkeypatch.setattr("opensak.filters.engine.FilterProfile.load",
+                            staticmethod(lambda p: prof))
+        seeded_window._filter_profile_combo.addItem("P1", userData=Path("/x/p.json"))
+        idx = seeded_window._filter_profile_combo.count() - 1
+        seeded_window._on_filter_profile_combo_changed(idx)
+        assert seeded_window._cache_table.row_count() == 1
+
+    def test_filter_profile_combo_changed_profile(self, seeded_window, monkeypatch):
+        from opensak.filters.engine import FilterSet, SortSpec
+        prof = SimpleNamespace(name="P", filterset=FilterSet(), sort=SortSpec("name"))
+        monkeypatch.setattr("opensak.filters.engine.FilterProfile.load",
+                            staticmethod(lambda p: prof))
+        seeded_window._filter_profile_combo.addItem("P", userData=Path("/x/p.json"))
+        idx = seeded_window._filter_profile_combo.count() - 1
+        seeded_window._on_filter_profile_combo_changed(idx)
+        assert seeded_window._active_filter_name == "P"
+
+    def test_filter_profile_combo_changed_load_error(self, seeded_window, monkeypatch):
+        def boom(p):
+            raise RuntimeError("bad")
+        monkeypatch.setattr("opensak.filters.engine.FilterProfile.load",
+                            staticmethod(boom))
+        seeded_window._filter_profile_combo.addItem("P", userData=Path("/x/p.json"))
+        idx = seeded_window._filter_profile_combo.count() - 1
+        seeded_window._on_filter_profile_combo_changed(idx)
+
+
+# ── tool/export dialogs ───────────────────────────────────────────────────────
+
+class TestToolDialogs:
+    def test_open_column_chooser(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.column_dialog.ColumnChooserDialog",
+            fake_dialog(exec_result=1))
+        seeded_window._open_column_chooser()
+
+    def test_open_gps_export(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.gps_dialog.GpsExportDialog", fake_dialog())
+        seeded_window._open_gps_export()
+
+    def test_open_file_export_formats(self, seeded_window, monkeypatch):
+        attrs = {
+            "_btn_loc": SimpleNamespace(setChecked=lambda v: None),
+            "_btn_ggz": SimpleNamespace(setChecked=lambda v: None),
+            "_btn_gpx": SimpleNamespace(setChecked=lambda v: None),
+        }
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.file_export_dialog.FileExportDialog",
+            fake_dialog(attrs=attrs))
+        for fmt in ("gpx", "loc", "ggz"):
+            seeded_window._open_file_export(fmt)
+
+    def test_open_file_export_no_caches(self, empty_window, mbox_ok):
+        empty_window._open_file_export("gpx")
+
+    def test_open_kml_export(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.kml_export_dialog.KmlExportDialog", fake_dialog())
+        seeded_window._open_kml_export()
+
+    def test_open_kml_export_no_caches(self, empty_window, mbox_ok):
+        empty_window._open_kml_export()
+
+    def test_open_found_updater(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.found_dialog.FoundUpdaterDialog",
+            fake_dialog(signals=("update_completed",)))
+        seeded_window._open_found_updater()
+
+    def test_open_update_location(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.update_location_dialog.UpdateLocationDialog",
+            fake_dialog(signals=("location_updated",)))
+        seeded_window._open_update_location()
+
+    @pytest.mark.parametrize("attr,mod,cls", [
+        ("_open_coord_converter", "coord_converter_dialog", "CoordConverterDialog"),
+        ("_open_projection", "projection_dialog", "ProjectionDialog"),
+        ("_open_checksum", "checksum_dialog", "ChecksumDialog"),
+        ("_open_midpoint", "midpoint_dialog", "MidpointDialog"),
+        ("_open_dist_bearing", "distance_bearing_dialog", "DistanceBearingDialog"),
+    ])
+    def test_open_coord_tools_with_selection(self, seeded_window, monkeypatch, attr, mod, cls):
+        monkeypatch.setattr(f"opensak.gui.dialogs.{mod}.{cls}", fake_dialog())
+        seeded_window._cache_table.select_by_gc_code("GC12345")
+        getattr(seeded_window, attr)()
+
+    @pytest.mark.parametrize("attr,mod,cls", [
+        ("_open_coord_converter", "coord_converter_dialog", "CoordConverterDialog"),
+        ("_open_projection", "projection_dialog", "ProjectionDialog"),
+        ("_open_checksum", "checksum_dialog", "ChecksumDialog"),
+        ("_open_midpoint", "midpoint_dialog", "MidpointDialog"),
+        ("_open_dist_bearing", "distance_bearing_dialog", "DistanceBearingDialog"),
+    ])
+    def test_open_coord_tools_no_selection(self, seeded_window, monkeypatch, attr, mod, cls):
+        monkeypatch.setattr(f"opensak.gui.dialogs.{mod}.{cls}", fake_dialog())
+        seeded_window._cache_table.clearSelection()
+        getattr(seeded_window, attr)()
+
+
+class TestTripBlocked:
+    """Every guarded opener short-circuits when the Trip Planner is open."""
+
+    @pytest.fixture
+    def blocked(self, seeded_window):
+        seeded_window._trip_planner_win = SimpleNamespace(
+            isVisible=lambda: True, raise_=lambda: None, activateWindow=lambda: None)
+        return seeded_window
+
+    @pytest.mark.parametrize("method", [
+        "_open_settings", "_open_column_chooser", "_open_gps_export",
+        "_open_kml_export", "_open_found_updater", "_open_update_location",
+        "_open_coord_converter", "_open_projection", "_open_checksum",
+        "_open_midpoint", "_open_dist_bearing",
+    ])
+    def test_blocked(self, blocked, method):
+        getattr(blocked, method)()  # warns, returns without constructing dialog
+
+    def test_file_export_blocked(self, blocked):
+        blocked._open_file_export("gpx")
+
+
+class TestHomeAndCwExtra:
+    def test_on_home_changed_user_and_gc_home(self, seeded_window, iso_settings):
+        from opensak.gui.settings import HomePoint
+        s = iso_settings.appset
+        s.gc_home_location = "N55 40.566 E012 34.098"
+        s.home_points = [HomePoint("Work", 56.0, 10.0)]
+        s._s.sync()
+        seeded_window._reload_home_combo()
+        visited = 0
+        for i in range(seeded_window._home_combo.count()):
+            if seeded_window._home_combo.itemData(i):
+                seeded_window._on_home_changed(i)
+                visited += 1
+        assert visited >= 2  # "★ Home" + "Work"
+
+    def test_next_cw_id_increments(self, seeded_window, monkeypatch):
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.waypoint_dialog.WaypointDialog",
+            fake_dialog(exec_result=1, data=_wp_data("CW001")))
+        seeded_window._add_waypoint()
+        assert seeded_window._next_cw_id() == "CW002"
+
+    def test_edit_waypoint_with_selection(self, seeded_window, monkeypatch):
+        seeded_window._cache_table.select_by_gc_code("GC12345")
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.waypoint_dialog.WaypointDialog",
+            fake_dialog(exec_result=0))
+        seeded_window._edit_waypoint()
+
+
+# ── trip planner ──────────────────────────────────────────────────────────────
+
+class TestTripPlanner:
+    def test_open_trip_planner(self, seeded_window, monkeypatch):
+        class FakeTrip:
+            def __init__(self, *a, **k):
+                self._visible = False
+
+            def show(self):
+                self._visible = True
+
+            def raise_(self):
+                pass
+
+            def activateWindow(self):
+                pass
+
+            def isVisible(self):
+                return self._visible
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.trip_dialog.TripPlannerDialog", FakeTrip)
+        seeded_window._open_trip_planner()
+        assert seeded_window._trip_planner_win is not None
+
+    def test_open_trip_planner_already_open(self, seeded_window, monkeypatch):
+        raised = []
+        seeded_window._trip_planner_win = SimpleNamespace(
+            isVisible=lambda: True,
+            raise_=lambda: raised.append("r"),
+            activateWindow=lambda: None)
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.trip_dialog.TripPlannerDialog",
+            lambda *a, **k: pytest.fail("should not construct"))
+        seeded_window._open_trip_planner()
+        assert raised == ["r"]
+
+    def test_warn_trip_planner_active(self, seeded_window):
+        seeded_window._trip_planner_win = SimpleNamespace(
+            raise_=lambda: None, activateWindow=lambda: None)
+        seeded_window._warn_trip_planner_active()
+
+
+# ── about / updates ───────────────────────────────────────────────────────────
+
+class TestAboutUpdates:
+    def test_show_about(self, seeded_window, mbox_ok):
+        seeded_window._show_about()
+
+    def test_check_update_manual(self, seeded_window, monkeypatch):
+        monkeypatch.setattr("opensak.gui.mainwindow.UpdateCheckWorker", fake_worker())
+        seeded_window._check_update_manual()
+
+    def test_on_manual_check_done_no_update(self, seeded_window, mbox_ok):
+        seeded_window._manual_found_update = False
+        seeded_window._on_manual_check_done()
+
+    def test_on_manual_check_done_found(self, seeded_window):
+        seeded_window._manual_found_update = True
+        seeded_window._on_manual_check_done()  # no dialog
+
+    def test_on_update_available_manual(self, seeded_window, mbox_ok):
+        seeded_window._on_update_available("v9.9.9", "http://x", manual=True)
+
+    def test_on_update_available_auto(self, seeded_window, mbox_ok):
+        seeded_window._on_update_available("v9.9.9", "http://x", manual=False)
+
+    def test_on_update_available_skipped(self, seeded_window, mbox_ok, iso_settings):
+        raw = _RealQSettings(iso_settings.raw_ini, _RealQSettings.Format.IniFormat)
+        raw.setValue("updates/skipped_version", "v1.2.3")
+        raw.sync()
+        seeded_window._on_update_available("v1.2.3", "http://x", manual=False)

--- a/tests/unit-tests/test_app_settings.py
+++ b/tests/unit-tests/test_app_settings.py
@@ -1,0 +1,224 @@
+"""tests/unit-tests/test_app_settings.py — AppSettings / HomePoint (temp-INI)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtCore import QSettings
+
+from opensak.gui.settings import AppSettings, HomePoint
+from opensak.utils.types import CoordFormat
+
+_VALID = "N55 47.250 E012 25.000"
+
+
+@pytest.fixture
+def s(tmp_path, monkeypatch):
+    # Bind AppSettings to an explicit temp INI — full isolation from the real
+    # user settings (a plain attribute swap, no class patching).
+    monkeypatch.setattr(
+        "opensak.db.manager.get_db_manager",
+        lambda: (_ for _ in ()).throw(RuntimeError("no manager")),
+    )
+    obj = AppSettings()
+    obj._s = QSettings(str(tmp_path / "settings.ini"), QSettings.Format.IniFormat)
+    return obj
+
+
+# ── HomePoint ───────────────────────────────────────────────────────────────────
+
+class TestHomePoint:
+    def test_to_from_dict_roundtrip(self):
+        p = HomePoint("Home", 55.0, 12.0)
+        d = p.to_dict()
+        back = HomePoint.from_dict(d)
+        assert (back.name, back.lat, back.lon) == ("Home", 55.0, 12.0)
+
+    def test_repr(self):
+        assert repr(HomePoint("X", 1.0, 2.0)) == "HomePoint('X', 1.0, 2.0)"
+
+
+# ── home lat/lon (global fallback path) ─────────────────────────────────────────
+
+class TestHomeCoords:
+    def test_defaults(self, s):
+        assert s.home_lat == pytest.approx(55.6761)
+        assert s.home_lon == pytest.approx(12.5683)
+
+    def test_set_and_get(self, s):
+        s.home_lat = 1.5
+        s.home_lon = 2.5
+        assert s.home_lat == pytest.approx(1.5)
+        assert s.home_lon == pytest.approx(2.5)
+
+
+# ── per-database key resolution ─────────────────────────────────────────────────
+
+class TestPerDbKeys:
+    def test_per_db_key_used_when_active(self, s, monkeypatch):
+        active = SimpleNamespace(path="/tmp/my.db")
+        monkeypatch.setattr(
+            "opensak.db.manager.get_db_manager",
+            lambda: SimpleNamespace(active=active),
+        )
+        s.home_lat = 10.0
+        # stored under per-db key; a fresh read resolves the same per-db value
+        assert s.home_lat == pytest.approx(10.0)
+
+
+# ── home points list ────────────────────────────────────────────────────────────
+
+class TestHomePoints:
+    def test_empty_by_default(self, s):
+        assert s.home_points == []
+
+    def test_add_update_remove(self, s):
+        s.add_or_update_home_point(HomePoint("Work", 1.0, 2.0))
+        assert [p.name for p in s.home_points] == ["Work"]
+        s.add_or_update_home_point(HomePoint("Work", 3.0, 4.0))  # update
+        assert s.home_points[0].lat == pytest.approx(3.0)
+        s.remove_home_point("Work")
+        assert s.home_points == []
+
+    def test_corrupt_json_ignored(self, s):
+        s._s.setValue("homepoints/list", "{not json")
+        assert s.home_points == []
+
+    def test_gc_home_prepended_as_star(self, s):
+        s.gc_home_location = _VALID
+        names = [p.name for p in s.home_points]
+        assert names and names[0] == "★ Home"
+
+    def test_setter_filters_out_star_home(self, s):
+        s.home_points = [HomePoint("★ Home", 1.0, 2.0), HomePoint("Real", 3.0, 4.0)]
+        raw_names = [p.name for p in s.home_points]
+        assert "Real" in raw_names
+
+    def test_active_home_roundtrip(self, s):
+        p = HomePoint("Spot", 5.0, 6.0)
+        s.add_or_update_home_point(p)
+        s.set_active_home(p)
+        assert s.active_home_name == "Spot"
+        got = s.get_active_home()
+        assert got is not None and got.name == "Spot"
+
+    def test_get_active_home_none(self, s):
+        assert s.get_active_home() is None
+
+    def test_remove_active_clears_active_name(self, s):
+        p = HomePoint("A", 1.0, 2.0)
+        s.add_or_update_home_point(p)
+        s.set_active_home(p)
+        s.remove_home_point("A")
+        assert s.active_home_name == ""
+
+
+# ── geocaching user fields ──────────────────────────────────────────────────────
+
+class TestGcFields:
+    def test_username_stripped(self, s):
+        s.gc_username = "  bob  "
+        assert s.gc_username == "bob"
+
+    def test_finder_id_stripped(self, s):
+        s.gc_finder_id = "  12345  "
+        assert s.gc_finder_id == "12345"
+
+    def test_gc_home_point_valid(self, s):
+        s.gc_home_location = _VALID
+        hp = s.get_gc_home_point()
+        assert hp is not None and hp.name == "★ Home"
+
+    def test_gc_home_point_empty(self, s):
+        s.gc_home_location = ""
+        assert s.get_gc_home_point() is None
+
+    def test_gc_home_point_invalid(self, s):
+        s.gc_home_location = "garbage"
+        assert s.get_gc_home_point() is None
+
+    def test_is_setup_complete(self, s):
+        assert s.is_setup_complete() is False
+        s.gc_username = "bob"
+        s.gc_home_location = _VALID
+        assert s.is_setup_complete() is True
+
+
+# ── display / format / units ────────────────────────────────────────────────────
+
+class TestDisplay:
+    def test_theme_roundtrip(self, s):
+        assert s.theme == "auto"
+        s.theme = "dark"
+        assert s.theme == "dark"
+
+    def test_use_miles(self, s):
+        s.use_miles = True
+        assert s.use_miles is True
+
+    def test_coord_format_roundtrip(self, s):
+        s.coord_format = CoordFormat.DMS
+        assert s.coord_format == CoordFormat.DMS
+
+    def test_coord_format_invalid_defaults_dmm(self, s):
+        s._s.setValue("display/coord_format", "bogus")
+        assert s.coord_format == CoordFormat.DMM
+
+    def test_map_provider_and_url(self, s):
+        assert "google.com" in s.get_maps_url(55.0, 12.0)
+        s.map_provider = "osm"
+        assert "openstreetmap.org" in s.get_maps_url(55.0, 12.0)
+
+    def test_show_flags(self, s):
+        s.show_archived = True
+        s.show_found = False
+        assert s.show_archived is True
+        assert s.show_found is False
+
+
+# ── window state / search / nominatim / paths ───────────────────────────────────
+
+class TestMisc:
+    def test_window_state_roundtrip(self, s):
+        s.window_geometry = b"geo"
+        s.window_state = b"state"
+        s.splitter_state = b"sp"
+        s.bottom_splitter_state = b"bsp"
+        assert s.window_geometry == b"geo"
+        assert s.window_state == b"state"
+        assert s.splitter_state == b"sp"
+        assert s.bottom_splitter_state == b"bsp"
+
+    def test_search_thresholds(self, s):
+        s.search_min_chars = 3
+        s.search_debounce_ms = 250
+        assert s.search_min_chars == 3
+        assert s.search_debounce_ms == 250
+
+    def test_nominatim(self, s):
+        s.nominatim_enabled = True
+        assert s.nominatim_enabled is True
+
+    def test_last_import_dir(self, s):
+        assert s.last_import_dir  # defaults to home
+        s.last_import_dir = "/tmp/x"
+        assert s.last_import_dir == "/tmp/x"
+
+    def test_apply_default_center_for_new_db(self, s):
+        s.gc_home_location = _VALID
+        s.apply_default_center_for_new_db()
+        assert s.active_home_name == "★ Home"
+
+    def test_apply_default_center_no_home(self, s):
+        s.apply_default_center_for_new_db()  # no gc_home -> no-op
+        assert s.active_home_name == ""
+
+    def test_sync_does_not_raise(self, s):
+        s.gc_username = "bob"
+        s.sync()  # flush to disk
+
+    def test_get_settings_is_singleton(self):
+        from opensak.gui.settings import get_settings
+        assert get_settings() is get_settings()

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -1,0 +1,684 @@
+"""tests/unit-tests/test_cache_table.py — cache list model, delegates, view."""
+
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtCore import Qt, QModelIndex
+from PySide6.QtGui import QPixmap, QPainter
+
+from opensak.gui import cache_table as ct
+from opensak.gui.cache_table import (
+    CacheTableModel,
+    CacheTableView,
+    SizeBarDelegate,
+    GcCodeDelegate,
+    _bearing_deg,
+    _bearing_deg_batch,
+    _bearing_compass,
+    _gc_sort_key,
+)
+from opensak.db.models import Cache, UserNote
+from opensak.utils.types import CoordFormat
+
+ALL_COLUMNS = [
+    "gc_code", "name", "cache_type", "difficulty", "terrain", "container",
+    "country", "state", "county", "distance", "found", "placed_by",
+    "hidden_date", "last_log", "log_count", "dnf", "premium_only", "archived",
+    "favorite", "corrected", "latitude", "longitude", "found_date", "dnf_date",
+    "first_to_find", "favorite_points", "user_flag", "bearing", "user_sort",
+    "user_data_1", "user_data_2", "user_data_3", "user_data_4",
+]
+
+
+def _cache(**kw):
+    c = Cache(gc_code=kw.pop("gc_code", "GC1"), name=kw.pop("name", "Name"))
+    # Transient instances do not get DB-level defaults; set sane visible defaults.
+    c.available = kw.pop("available", True)
+    c.archived = kw.pop("archived", False)
+    c.found = kw.pop("found", False)
+    for k, v in kw.items():
+        setattr(c, k, v)
+    return c
+
+
+def _note(lat=56.0, lon=13.0, corrected=True):
+    return UserNote(corrected_lat=lat, corrected_lon=lon, is_corrected=corrected)
+
+
+@pytest.fixture(autouse=True)
+def fake_settings(monkeypatch, qapp):
+    s = SimpleNamespace(
+        home_lat=55.0, home_lon=12.0, use_miles=False,
+        coord_format=CoordFormat.DMM, gc_username="", map_provider="google",
+    )
+    s.get_maps_url = lambda lat, lon: f"https://maps?{lat},{lon}"
+    monkeypatch.setattr(ct, "get_settings", lambda: s)
+    monkeypatch.setattr("opensak.gui.settings.get_settings", lambda: s)
+    monkeypatch.setattr(ct, "get_cache_type_icon", lambda *a, **k: QPixmap(4, 4))
+    monkeypatch.setattr(ct, "get_cache_size_icon", lambda *a, **k: QPixmap(4, 4))
+    return s
+
+
+@pytest.fixture
+def model(monkeypatch):
+    monkeypatch.setattr(ct, "_get_active_columns", lambda: list(ALL_COLUMNS))
+    return CacheTableModel()
+
+
+# ── pure helpers ────────────────────────────────────────────────────────────────
+
+class TestHelpers:
+    def test_bearing_deg_cardinal(self):
+        # due north -> ~0, due east -> ~90
+        assert _bearing_deg(0, 0, 1, 0) == pytest.approx(0, abs=1)
+        assert _bearing_deg(0, 0, 0, 1) == pytest.approx(90, abs=1)
+
+    def test_bearing_compass_format(self):
+        out = _bearing_compass(0)
+        assert "0°" in out
+
+    def test_bearing_batch_numpy(self):
+        out = _bearing_deg_batch(0, 0, [1, 0], [0, 1])
+        assert len(out) == 2
+        assert float(out[0]) == pytest.approx(0, abs=1)
+
+    def test_bearing_batch_fallback_without_numpy(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "numpy", None)
+        out = _bearing_deg_batch(0, 0, [1.0], [0.0])
+        assert isinstance(out, list)
+        assert out[0] == pytest.approx(0, abs=1)
+
+    def test_gc_sort_key_pads(self):
+        assert _gc_sort_key("GC1D") < _gc_sort_key("GC1DCA")
+        assert _gc_sort_key("") == ""
+        assert _gc_sort_key("ABC").startswith("GC")
+
+
+# ── model basics ────────────────────────────────────────────────────────────────
+
+class TestModelBasics:
+    def test_dimensions(self, model):
+        model.load([_cache(gc_code="GC1"), _cache(gc_code="GC2")])
+        assert model.rowCount() == 2
+        assert model.columnCount() == len(ALL_COLUMNS)
+
+    def test_cache_at_bounds(self, model):
+        model.load([_cache()])
+        assert model.cache_at(0) is not None
+        assert model.cache_at(5) is None
+
+    def test_header_display_and_alignment(self, model):
+        name = model.headerData(1, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
+        assert isinstance(name, str) and name
+        align = model.headerData(0, Qt.Orientation.Horizontal, Qt.ItemDataRole.TextAlignmentRole)
+        assert align == Qt.AlignmentFlag.AlignCenter
+        assert model.headerData(0, Qt.Orientation.Vertical) is None
+
+    def test_data_invalid_index(self, model):
+        assert model.data(QModelIndex()) is None
+
+    def test_reload_columns(self, model, monkeypatch):
+        monkeypatch.setattr(ct, "_get_active_columns", lambda: ["gc_code"])
+        model.reload_columns()
+        assert model._columns == ["gc_code"]
+
+
+# ── display values per column ───────────────────────────────────────────────────
+
+class TestDisplayValues:
+    def test_text_columns(self, model):
+        c = _cache(gc_code="GC9", name="Hello", country="DK", state="Z",
+                   county="Cty", placed_by="Owner")
+        dv = model._display_value
+        assert dv(c, "gc_code") == "GC9"
+        assert dv(c, "name") == "Hello"
+        assert dv(c, "country") == "DK"
+        assert dv(c, "state") == "Z"
+        assert dv(c, "county") == "Cty"
+        assert dv(c, "placed_by") == "Owner"
+        assert dv(c, "cache_type") == ""   # icon only
+        assert dv(c, "container") == ""    # icon only
+        assert dv(c, "unknown_col") == ""
+
+    def test_difficulty_terrain(self, model):
+        assert model._display_value(_cache(difficulty=2.5), "difficulty") == "2.5"
+        assert model._display_value(_cache(difficulty=None), "difficulty") == "?"
+        assert model._display_value(_cache(terrain=3.0), "terrain") == "3.0"
+        assert model._display_value(_cache(terrain=None), "terrain") == "?"
+
+    def test_distance_km_and_miles(self, model, fake_settings):
+        c = _cache()
+        c.id = 1
+        model._distances = {1: 10.0}
+        assert model._display_value(c, "distance") == "10.0 km"
+        fake_settings.use_miles = True
+        assert "mi" in model._display_value(c, "distance")
+        assert model._display_value(_cache(), "distance") == "?"  # id not in dist
+
+    def test_bearing(self, model, monkeypatch):
+        monkeypatch.setattr(
+            ct, "tr",
+            lambda key, **kw: "N NE E SE S SW W NW" if key == "bearing_dirs" else key,
+        )
+        c = _cache()
+        c.id = 2
+        model._bearings = {2: 90.0}
+        assert "°" in model._display_value(c, "bearing")
+        assert model._display_value(_cache(), "bearing") == "?"
+
+    def test_boolean_markers(self, model):
+        assert model._display_value(_cache(found=True), "found") == "✓"
+        assert model._display_value(_cache(found=False), "found") == ""
+        assert model._display_value(_cache(dnf=True), "dnf") == "DNF"
+        assert model._display_value(_cache(premium_only=True), "premium_only") == "P"
+        assert model._display_value(_cache(archived=True), "archived") == "✓"
+        assert model._display_value(_cache(favorite_point=True), "favorite") == "★"
+        assert model._display_value(_cache(first_to_find=True), "first_to_find") == "FTF"
+        assert model._display_value(_cache(user_flag=True), "user_flag") == "🚩"
+
+    def test_dates(self, model):
+        d = datetime(2024, 3, 1)
+        assert model._display_value(_cache(hidden_date=d), "hidden_date") == "01.03.2024"
+        assert model._display_value(_cache(last_log_date=d), "last_log") == "01.03.2024"
+        assert model._display_value(_cache(found_date=d), "found_date") == "01.03.2024"
+        assert model._display_value(_cache(dnf_date=d), "dnf_date") == "01.03.2024"
+        assert model._display_value(_cache(), "hidden_date") == ""
+
+    def test_counts_and_user_fields(self, model):
+        assert model._display_value(_cache(log_count=7), "log_count") == "7"
+        assert model._display_value(_cache(favorite_points=12), "favorite_points") == "12"
+        assert model._display_value(_cache(user_sort=3), "user_sort") == "3"
+        assert model._display_value(_cache(user_data_1="x"), "user_data_1") == "x"
+        assert model._display_value(_cache(user_data_4="z"), "user_data_4") == "z"
+
+    def test_corrected_marker(self, model):
+        plain = _cache()
+        plain.user_note = None
+        assert model._display_value(plain, "corrected") == ""
+        corr = _cache()
+        corr.user_note = _note()
+        assert model._display_value(corr, "corrected") == "📍"
+
+    def test_lat_lon_uses_corrected(self, model):
+        c = _cache(latitude=55.0, longitude=12.0)
+        c.user_note = _note(56.0, 13.0)
+        assert model._display_value(c, "latitude") != ""
+        assert model._display_value(c, "longitude") != ""
+        empty = _cache(latitude=None, longitude=None)
+        empty.user_note = None
+        assert model._display_value(empty, "latitude") == ""
+        assert model._display_value(empty, "longitude") == ""
+
+
+# ── data() roles ────────────────────────────────────────────────────────────────
+
+class TestDataRoles:
+    def test_display_role(self, model):
+        model.load([_cache(gc_code="GCABC")])
+        idx = model.index(0, 0)
+        assert model.data(idx, Qt.ItemDataRole.DisplayRole) == "GCABC"
+
+    def test_alignment_role(self, model):
+        model.load([_cache()])
+        center_idx = model.index(0, ALL_COLUMNS.index("difficulty"))
+        assert model.data(center_idx, Qt.ItemDataRole.TextAlignmentRole) == Qt.AlignmentFlag.AlignCenter
+        left_idx = model.index(0, ALL_COLUMNS.index("name"))
+        assert model.data(left_idx, Qt.ItemDataRole.TextAlignmentRole) != Qt.AlignmentFlag.AlignCenter
+
+    def test_font_role_italic_when_found(self, model):
+        model.load([_cache(found=True)])
+        font = model.data(model.index(0, 0), Qt.ItemDataRole.FontRole)
+        assert font is not None and font.italic()
+
+    def test_tooltip_cache_type(self, model):
+        model.load([_cache(cache_type="Unknown Cache")])
+        tip = model.data(model.index(0, ALL_COLUMNS.index("cache_type")),
+                         Qt.ItemDataRole.ToolTipRole)
+        assert "Mystery" in tip
+
+    def test_tooltip_latlon(self, model):
+        c = _cache(latitude=55.0, longitude=12.0)
+        c.user_note = None
+        model.load([c])
+        tip = model.data(model.index(0, ALL_COLUMNS.index("latitude")),
+                         Qt.ItemDataRole.ToolTipRole)
+        assert tip  # original-coords tooltip
+
+    def test_decoration_role_icons(self, model):
+        model.load([_cache(cache_type="Traditional Cache", container="small")])
+        type_idx = model.index(0, ALL_COLUMNS.index("cache_type"))
+        cont_idx = model.index(0, ALL_COLUMNS.index("container"))
+        assert model.data(type_idx, Qt.ItemDataRole.DecorationRole) is not None
+        assert model.data(cont_idx, Qt.ItemDataRole.DecorationRole) is not None
+
+    def test_userrole_returns_cache_and_dict(self, model):
+        model.load([_cache(container="Micro", cache_type="Virtual Cache")])
+        idx = model.index(0, 0)
+        assert isinstance(model.data(idx, Qt.ItemDataRole.UserRole), Cache)
+        d = model.data(idx, Qt.ItemDataRole.UserRole + 10)
+        assert d["size"] == "micro" and d["type"] == "virtual cache"
+
+    def test_unhandled_role_none(self, model):
+        model.load([_cache()])
+        assert model.data(model.index(0, 0), Qt.ItemDataRole.WhatsThisRole) is None
+
+
+# ── icon key mapping ────────────────────────────────────────────────────────────
+
+class TestIconKeys:
+    def test_type_icon_archived_disabled(self):
+        assert CacheTableModel._type_icon_key(_cache(archived=True)) == "archived"
+        assert CacheTableModel._type_icon_key(_cache(archived=False, available=False)) == "disabled"
+
+    def test_type_icon_mapping(self):
+        assert CacheTableModel._type_icon_key(_cache(cache_type="Multi-cache")) == "multi"
+        assert CacheTableModel._type_icon_key(_cache(cache_type="Weird Type")) == "unknown"
+
+    def test_size_icon_mapping(self):
+        assert CacheTableModel._size_icon_key(_cache(container="large")) == "large"
+        assert CacheTableModel._size_icon_key(_cache(container="whatever")) == "other"
+
+
+# ── effective coords ────────────────────────────────────────────────────────────
+
+class TestEffectiveCoords:
+    def test_returns_corrected(self):
+        c = _cache(latitude=1.0, longitude=2.0)
+        c.user_note = _note(9.0, 8.0)
+        assert CacheTableModel._effective_coords(c) == (9.0, 8.0)
+
+    def test_returns_original_when_not_corrected(self):
+        c = _cache(latitude=1.0, longitude=2.0)
+        c.user_note = None
+        assert CacheTableModel._effective_coords(c) == (1.0, 2.0)
+
+
+# ── sort ────────────────────────────────────────────────────────────────────────
+
+class TestSort:
+    def _loaded(self, model, caches):
+        model.load(caches)
+        return model
+
+    def test_sort_out_of_range_noop(self, model):
+        model.load([_cache()])
+        model.sort(999)  # no crash
+
+    def test_sort_by_name(self, model):
+        m = self._loaded(model, [_cache(gc_code="A", name="Beta"), _cache(gc_code="B", name="alpha")])
+        m.sort(ALL_COLUMNS.index("name"), Qt.SortOrder.AscendingOrder)
+        assert m.cache_at(0).name == "alpha"
+
+    def test_sort_by_difficulty_desc(self, model):
+        m = self._loaded(model, [_cache(gc_code="A", difficulty=1.0), _cache(gc_code="B", difficulty=5.0)])
+        m.sort(ALL_COLUMNS.index("difficulty"), Qt.SortOrder.DescendingOrder)
+        assert m.cache_at(0).difficulty == 5.0
+
+    def test_sort_by_gc_code(self, model):
+        m = self._loaded(model, [_cache(gc_code="GC1DCA"), _cache(gc_code="GC1D")])
+        m.sort(ALL_COLUMNS.index("gc_code"), Qt.SortOrder.AscendingOrder)
+        assert m.cache_at(0).gc_code == "GC1D"
+
+    def test_sort_distance_and_bearing(self, model):
+        a, b = _cache(gc_code="A"), _cache(gc_code="B")
+        a.id, b.id = 1, 2
+        m = self._loaded(model, [a, b])
+        m._distances = {1: 50.0, 2: 5.0}
+        m._bearings = {1: 300.0, 2: 10.0}
+        m.sort(ALL_COLUMNS.index("distance"), Qt.SortOrder.AscendingOrder)
+        assert m.cache_at(0).gc_code == "B"
+        m.sort(ALL_COLUMNS.index("bearing"), Qt.SortOrder.AscendingOrder)
+        assert m.cache_at(0).gc_code == "B"
+
+    def test_sort_various_columns_do_not_crash(self, model):
+        d = datetime(2024, 1, 1)
+        caches = [
+            _cache(gc_code="A", terrain=2.0, found=True, log_count=3, favorite_points=1,
+                   user_sort=2, first_to_find=True, user_flag=True, container="micro",
+                   hidden_date=d, last_log_date=d, found_date=d, dnf_date=d,
+                   latitude=55.0, longitude=12.0, country="DK"),
+            _cache(gc_code="B", country="ZZ"),
+        ]
+        caches[1].user_note = None
+        caches[0].user_note = _note(1.0, 2.0)
+        m = self._loaded(model, caches)
+        for col in ("terrain", "found", "corrected", "log_count", "last_log",
+                    "hidden_date", "found_date", "dnf_date", "first_to_find",
+                    "user_flag", "user_sort", "favorite_points", "container",
+                    "latitude", "longitude", "country"):
+            m.sort(ALL_COLUMNS.index(col), Qt.SortOrder.AscendingOrder)
+            m.sort(ALL_COLUMNS.index(col), Qt.SortOrder.DescendingOrder)
+
+    def test_sort_emits_signal(self, model):
+        got = []
+        model.sort_changed.connect(lambda c, a: got.append((c, a)))
+        model.load([_cache()])
+        model.sort(ALL_COLUMNS.index("name"), Qt.SortOrder.AscendingOrder)
+        assert got and got[-1][0] == "name"
+
+
+# ── flags / setData (needs DB) ──────────────────────────────────────────────────
+
+class TestSetData:
+    def test_flags_editable_columns(self, model):
+        model.load([_cache()])
+        uf = model.index(0, ALL_COLUMNS.index("user_flag"))
+        assert model.flags(uf) & Qt.ItemFlag.ItemIsEditable
+        nf = model.index(0, ALL_COLUMNS.index("name"))
+        assert not (model.flags(nf) & Qt.ItemFlag.ItemIsEditable)
+
+    def test_setdata_invalid_or_wrong_column(self, model):
+        model.load([_cache()])
+        assert model.setData(QModelIndex(), None) is False
+        assert model.setData(model.index(0, ALL_COLUMNS.index("name")), None) is False
+
+    def test_setdata_toggles_user_flag(self, model, db_session, make_cache):
+        c = make_cache(gc_code="GCSET")
+        db_session.add(c)
+        db_session.commit()
+        cache = _cache(gc_code="GCSET", user_flag=False)
+        model.load([cache])
+        fired = []
+        model.flags_changed.connect(lambda: fired.append(True))
+        ok = model.setData(model.index(0, ALL_COLUMNS.index("user_flag")), None)
+        assert ok is True
+        assert cache.user_flag is True
+        assert fired == [True]
+
+    def test_setdata_toggles_first_to_find(self, model, db_session, make_cache):
+        c = make_cache(gc_code="GCFTF")
+        db_session.add(c)
+        db_session.commit()
+        cache = _cache(gc_code="GCFTF", first_to_find=False)
+        model.load([cache])
+        ok = model.setData(model.index(0, ALL_COLUMNS.index("first_to_find")), None)
+        assert ok is True
+        assert cache.first_to_find is True
+
+
+# ── delegates ───────────────────────────────────────────────────────────────────
+
+class TestDelegates:
+    def _paint(self, delegate, model, col, *, selected=False):
+        """Paint column ``col`` of row 0 via a real QModelIndex."""
+        from PySide6.QtWidgets import QStyleOptionViewItem, QStyle
+        from PySide6.QtCore import QRect
+        idx = model.index(0, ALL_COLUMNS.index(col))
+        pm = QPixmap(80, 24)
+        painter = QPainter(pm)
+        opt = QStyleOptionViewItem()
+        opt.rect = QRect(0, 0, 80, 24)
+        if selected:
+            opt.state |= QStyle.StateFlag.State_Selected
+        delegate.paint(painter, opt, idx)
+        painter.end()
+
+    def test_size_bar_delegate_paints_physical(self, model):
+        model.load([_cache(container="small", cache_type="traditional cache")])
+        d = SizeBarDelegate()
+        self._paint(d, model, "container")
+        self._paint(d, model, "container", selected=True)
+
+    def test_size_bar_delegate_paints_letter(self, model):
+        model.load([_cache(container="other", cache_type="virtual cache")])
+        self._paint(SizeBarDelegate(), model, "container")
+
+    def test_size_bar_sizehint(self, model):
+        from PySide6.QtWidgets import QStyleOptionViewItem
+        model.load([_cache()])
+        idx = model.index(0, ALL_COLUMNS.index("container"))
+        sh = SizeBarDelegate().sizeHint(QStyleOptionViewItem(), idx)
+        assert sh.height() >= 20
+
+    def test_gc_code_delegate_colors(self, model, fake_settings):
+        d = GcCodeDelegate()
+        model.load([_cache(gc_code="GCARCH", archived=True)])
+        self._paint(d, model, "gc_code")                       # archived bg
+        model.load([_cache(gc_code="GCF", found=True, available=True, archived=False)])
+        self._paint(d, model, "gc_code")                       # found green
+        self._paint(d, model, "gc_code", selected=True)        # selected
+        plain = _cache(gc_code="GCP", found=False, available=True, archived=False)
+        plain.owner_name = None
+        model.load([plain])
+        self._paint(d, model, "gc_code")                       # default path
+
+    def test_gc_code_delegate_disabled_text(self, model):
+        c = _cache(gc_code="GCDIS", found=False, available=False, archived=False)
+        c.owner_name = None
+        model.load([c])
+        self._paint(GcCodeDelegate(), model, "gc_code")
+
+    def test_gc_code_delegate_placed_by_user(self, model, fake_settings):
+        fake_settings.gc_username = "me"
+        c = _cache(gc_code="GCMINE", found=False, available=True, archived=False)
+        c.owner_name = "Me"
+        model.load([c])
+        self._paint(GcCodeDelegate(), model, "gc_code")
+
+    def test_gc_code_bg_none_when_no_cache(self, model):
+        d = GcCodeDelegate()
+
+        class _Idx:
+            def data(self, role):
+                return None
+        assert d._bg_color(_Idx()) is None
+
+
+# ── view ────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def view(monkeypatch, qtbot):
+    monkeypatch.setattr(ct, "_get_active_columns", lambda: list(ALL_COLUMNS))
+    monkeypatch.setattr(ct, "get_column_widths", lambda: {})
+    monkeypatch.setattr(ct, "set_column_widths", lambda w: None)
+    v = CacheTableView()
+    qtbot.addWidget(v)
+    return v
+
+
+class TestView:
+    def test_construction_sets_delegates(self, view):
+        # container + gc_code columns get custom delegates
+        assert isinstance(view.itemDelegateForColumn(ALL_COLUMNS.index("container")),
+                          SizeBarDelegate)
+        assert isinstance(view.itemDelegateForColumn(ALL_COLUMNS.index("gc_code")),
+                          GcCodeDelegate)
+
+    def test_load_and_counts(self, view):
+        view.load_caches([_cache(gc_code="A"), _cache(gc_code="B", user_flag=True)])
+        assert view.row_count() == 2
+        assert len(view.get_all_caches()) == 2
+        assert len(view.get_flagged_caches()) == 1
+
+    def test_select_by_gc_code_emits(self, view):
+        view.load_caches([_cache(gc_code="A"), _cache(gc_code="B")])
+        got = []
+        view.cache_selected.connect(lambda c: got.append(c.gc_code))
+        view.select_by_gc_code("B")
+        assert view.selected_cache().gc_code == "B"
+        assert got and got[-1] == "B"
+
+    def test_select_by_gc_code_missing(self, view):
+        view.load_caches([_cache(gc_code="A")])
+        view.select_by_gc_code("ZZZ")  # no crash, no selection change
+
+    def test_selected_cache_none_when_empty(self, view):
+        view.load_caches([])
+        assert view.selected_cache() is None
+
+    def test_reload_columns(self, view, monkeypatch):
+        monkeypatch.setattr(ct, "_get_active_columns", lambda: ["gc_code", "name"])
+        view.reload_columns()
+        assert view._model.columnCount() == 2
+
+    def test_apply_sort_and_model_sort_changed(self, view):
+        view.load_caches([_cache(gc_code="B", name="b"), _cache(gc_code="A", name="a")])
+        fired = []
+        view.sort_changed.connect(lambda c, a: fired.append((c, a)))
+        view.apply_sort("name", True)
+        assert view._last_sort_col == ALL_COLUMNS.index("name")
+        assert view._last_sort_asc is True
+        # apply_sort blocks signals, so a user sort exercises the relay
+        view._model.sort(ALL_COLUMNS.index("gc_code"), Qt.SortOrder.AscendingOrder)
+        assert fired and fired[-1][0] == "gc_code"
+
+    def test_apply_sort_unknown_column_noop(self, view):
+        view.load_caches([_cache()])
+        view.apply_sort("does_not_exist", True)  # no crash
+
+    def test_double_click_corrected_opens_editor(self, view, monkeypatch):
+        view.load_caches([_cache(gc_code="A")])
+        called = []
+        monkeypatch.setattr(view, "_edit_corrected", lambda c: called.append(c.gc_code))
+        idx = view._model.index(0, ALL_COLUMNS.index("corrected"))
+        view._on_double_clicked(idx)
+        assert called == ["A"]
+
+    def test_double_click_other_column_noop(self, view, monkeypatch):
+        view.load_caches([_cache(gc_code="A")])
+        called = []
+        monkeypatch.setattr(view, "_edit_corrected", lambda c: called.append(c))
+        view._on_double_clicked(view._model.index(0, ALL_COLUMNS.index("name")))
+        assert called == []
+
+    def test_copy_to_clipboard(self, view):
+        view._copy_to_clipboard("hello")
+        from PySide6.QtWidgets import QApplication
+        assert QApplication.clipboard().text() == "hello"
+
+    def test_column_resized_persists(self, view, monkeypatch):
+        saved = {}
+        monkeypatch.setattr(ct, "get_column_widths", lambda: dict(saved))
+        monkeypatch.setattr(ct, "set_column_widths", lambda w: saved.update(w))
+        view._applying_widths = False
+        view._on_column_resized(0, 50, 123)
+        assert saved.get("gc_code") == 123
+
+    def test_column_resized_ignored_while_applying(self, view, monkeypatch):
+        called = []
+        monkeypatch.setattr(ct, "set_column_widths", lambda w: called.append(w))
+        view._applying_widths = True
+        view._on_column_resized(0, 50, 99)
+        assert called == []
+
+    # ── DB-backed operations ─────────────────────────────────────────────────
+
+    def test_toggle_found(self, view, db_session, make_cache):
+        db_session.add(make_cache(gc_code="GCTF"))
+        db_session.commit()
+        cache = _cache(gc_code="GCTF", found=False)
+        view.load_caches([cache])
+        view._toggle_found(cache, True)
+        assert cache.found is True
+
+    def test_save_and_clear_corrected(self, view, db_session, make_cache):
+        db_session.add(make_cache(gc_code="GCCC"))
+        db_session.commit()
+        cache = _cache(gc_code="GCCC", latitude=55.0, longitude=12.0)
+        view.load_caches([cache])
+        view._save_corrected(cache, 56.0, 13.0)
+        refreshed = view._model.cache_at(0)
+        assert refreshed.user_note is not None
+        assert refreshed.user_note.is_corrected is True
+        view._clear_corrected(refreshed)
+        assert view._model.cache_at(0).user_note.is_corrected is False
+
+    def test_save_corrected_missing_cache_noop(self, view, db_session):
+        cache = _cache(gc_code="GCNONE")
+        view.load_caches([cache])
+        view._save_corrected(cache, 1.0, 2.0)  # not in DB -> early return, no crash
+
+    # ── dialog openers (dialogs faked) ───────────────────────────────────────
+
+    def test_edit_corrected_saves_on_accept(self, view, monkeypatch):
+        cache = _cache(gc_code="A", latitude=55.0, longitude=12.0)
+        cache.user_note = None
+
+        class FakeDlg:
+            def __init__(self, **kw):
+                pass
+            def exec(self):
+                return 1
+            def get_coords(self):
+                return 56.0, 13.0
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.corrected_coords_dialog.CorrectedCoordsDialog", FakeDlg
+        )
+        saved = []
+        monkeypatch.setattr(view, "_save_corrected", lambda c, la, lo: saved.append((la, lo)))
+        view._edit_corrected(cache)
+        assert saved == [(56.0, 13.0)]
+
+    def test_edit_corrected_cancelled(self, view, monkeypatch):
+        cache = _cache(gc_code="A", latitude=55.0, longitude=12.0)
+        cache.user_note = None
+
+        class FakeDlg:
+            def __init__(self, **kw):
+                pass
+            def exec(self):
+                return 0
+            def get_coords(self):
+                raise AssertionError("should not be called")
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.corrected_coords_dialog.CorrectedCoordsDialog", FakeDlg
+        )
+        saved = []
+        monkeypatch.setattr(view, "_save_corrected", lambda *a: saved.append(a))
+        view._edit_corrected(cache)
+        assert saved == []
+
+    def test_open_converter(self, view, monkeypatch):
+        opened = []
+
+        class FakeDlg:
+            def __init__(self, *a, **k):
+                opened.append(a)
+            def exec(self):
+                return 0
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.coord_converter_dialog.CoordConverterDialog", FakeDlg
+        )
+        view._open_converter(55.0, 12.0)
+        assert opened
+
+    def test_update_location(self, view, monkeypatch):
+        class FakeDlg:
+            def __init__(self, *a, **k):
+                self.location_updated = SimpleNamespace(connect=lambda *x: None)
+            def exec(self):
+                return 0
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.update_location_dialog.UpdateLocationDialog", FakeDlg
+        )
+        view._update_location("GC123")  # no crash
+
+    # ── context menu ─────────────────────────────────────────────────────────
+
+    def test_context_menu_builds(self, view, qtbot, monkeypatch):
+        # Neutralise the blocking exec via a QMenu subclass.
+        class _Menu(ct.QMenu):
+            def exec(self, *a, **k):
+                return None
+        monkeypatch.setattr(ct, "QMenu", _Menu)
+        monkeypatch.setattr(ct.webbrowser, "open", lambda *a, **k: None)
+        from opensak.utils import flags
+        monkeypatch.setattr(flags, "update_location", True, raising=False)
+
+        c = _cache(gc_code="GCMENU", latitude=55.0, longitude=12.0)
+        c.user_note = _note()  # corrected -> edit/clear branch
+        view.load_caches([c])
+        view.show()
+        qtbot.addWidget(view)
+        pos = view.visualRect(view._model.index(0, 0)).center()
+        view._show_context_menu(pos)  # builds full menu, exec is a no-op
+
+    def test_context_menu_no_cache_noop(self, view):
+        view.load_caches([])
+        from PySide6.QtCore import QPoint
+        view._show_context_menu(QPoint(0, 0))  # indexAt -> invalid -> early return

--- a/tests/unit-tests/test_database_dialog.py
+++ b/tests/unit-tests/test_database_dialog.py
@@ -1,0 +1,306 @@
+"""tests/unit-tests/test_database_dialog.py — database manager + new-database dialogs."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtWidgets import QDialog, QInputDialog
+
+from opensak.gui.dialogs import database_dialog as dd
+from opensak.gui.dialogs.database_dialog import NewDatabaseDialog, DatabaseManagerDialog
+
+
+class _DB:
+    def __init__(self, name, path, exists=True, size_mb=1.5, modified=None):
+        self.name = name
+        self.path = Path(path)
+        self.exists = exists
+        self.size_mb = size_mb
+        self.modified = modified or datetime(2024, 1, 2, 3, 4)
+
+    def __eq__(self, other):
+        return isinstance(other, _DB) and self.path == other.path
+
+    def __hash__(self):
+        return hash(self.path)
+
+
+@pytest.fixture(autouse=True)
+def app_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("opensak.config.get_app_data_dir", lambda: tmp_path)
+    return tmp_path
+
+
+# ── NewDatabaseDialog ───────────────────────────────────────────────────────────
+
+class TestNewDatabaseDialog:
+    def test_path_preview_folder_then_file(self, qtbot, tmp_path):
+        dlg = NewDatabaseDialog()
+        qtbot.addWidget(dlg)
+        assert dlg._path_edit.text() == str(tmp_path)  # no name -> folder
+        dlg._name_edit.setText("MyDB")
+        assert dlg._path_edit.text() == str(tmp_path / "MyDB.db")
+
+    def test_browse_sets_custom_path(self, qtbot, tmp_path, monkeypatch):
+        dlg = NewDatabaseDialog()
+        qtbot.addWidget(dlg)
+        target = tmp_path / "sub"
+        target.mkdir()
+        monkeypatch.setattr(dd.QFileDialog, "getExistingDirectory", lambda *a, **k: str(target))
+        dlg._name_edit.setText("DB")
+        dlg._browse()
+        assert dlg._custom_path == target
+        assert dlg._path_edit.text() == str(target / "DB.db")
+
+    def test_browse_cancel(self, qtbot, monkeypatch):
+        dlg = NewDatabaseDialog()
+        qtbot.addWidget(dlg)
+        monkeypatch.setattr(dd.QFileDialog, "getExistingDirectory", lambda *a, **k: "")
+        dlg._browse()
+        assert dlg._custom_path is None
+
+    def test_validate_requires_name(self, qtbot, monkeypatch):
+        dlg = NewDatabaseDialog()
+        qtbot.addWidget(dlg)
+        warn = MagicMock()
+        monkeypatch.setattr(dd.QMessageBox, "warning", warn)
+        dlg._validate()
+        warn.assert_called_once()
+        assert dlg.result() != QDialog.DialogCode.Accepted
+
+    def test_validate_accepts(self, qtbot):
+        dlg = NewDatabaseDialog()
+        qtbot.addWidget(dlg)
+        dlg._name_edit.setText("Good")
+        dlg._validate()
+        assert dlg.result() == QDialog.DialogCode.Accepted
+        assert dlg.name == "Good"
+
+    def test_custom_path_property(self, qtbot, tmp_path):
+        dlg = NewDatabaseDialog()
+        qtbot.addWidget(dlg)
+        assert dlg.custom_path is None  # no custom folder
+        dlg._custom_path = tmp_path
+        dlg._name_edit.setText("My DB!")        # illegal char sanitised
+        assert dlg.custom_path == tmp_path / "My DB_.db"
+
+    def test_custom_path_no_name(self, qtbot, tmp_path):
+        dlg = NewDatabaseDialog()
+        qtbot.addWidget(dlg)
+        dlg._custom_path = tmp_path
+        assert dlg.custom_path == tmp_path  # falls back to folder when name empty
+
+
+# ── DatabaseManagerDialog ───────────────────────────────────────────────────────
+
+@pytest.fixture
+def manager(monkeypatch):
+    active = _DB("Active", "/data/active.db")
+    other = _DB("Other", "/data/other.db")
+    missing = _DB("Gone", "/data/gone.db", exists=False)
+    mgr = MagicMock()
+    mgr.active = active
+    mgr.databases = [active, other, missing]
+    monkeypatch.setattr(dd, "get_db_manager", lambda: mgr)
+    mgr._dbs = {"active": active, "other": other, "missing": missing}
+    return mgr
+
+
+@pytest.fixture
+def dlg(qtbot, manager):
+    d = DatabaseManagerDialog()
+    qtbot.addWidget(d)
+    return d
+
+
+def _select(dlg, name):
+    for row in range(dlg._list.count()):
+        if dlg._list.item(row).data(dd.Qt.ItemDataRole.UserRole).name == name:
+            dlg._list.setCurrentRow(row)
+            return
+    raise AssertionError(f"{name} not in list")
+
+
+class TestManagerDialog:
+    def test_list_populated_and_active_marked(self, dlg):
+        assert dlg._list.count() == 3
+        # active item carries a check mark
+        texts = [dlg._list.item(i).text() for i in range(3)]
+        assert any("✓" in t for t in texts)
+
+    def test_selection_updates_info_and_buttons(self, dlg, manager):
+        _select(dlg, "Other")
+        assert dlg._info_name.text() == "Other"
+        assert "MB" in dlg._info_size.text()
+        assert dlg._btn_switch.isEnabled() is True   # non-active, exists
+        assert dlg._btn_delete.isEnabled() is True
+
+    def test_active_selection_disables_switch_delete(self, dlg):
+        _select(dlg, "Active")
+        assert dlg._btn_switch.isEnabled() is False
+        assert dlg._btn_delete.isEnabled() is False
+        assert dlg._btn_remove.isEnabled() is False
+
+    def test_missing_db_shows_not_found(self, dlg):
+        _select(dlg, "Gone")
+        assert dlg._info_size.text() != ""
+        assert dlg._btn_switch.isEnabled() is False  # file missing
+        assert dlg._btn_copy.isEnabled() is False
+
+    def test_switch_to_selected(self, dlg, manager, monkeypatch):
+        monkeypatch.setattr(dd.QMessageBox, "information", MagicMock())
+        emitted = []
+        dlg.database_switched.connect(lambda db: emitted.append(db.name))
+        _select(dlg, "Other")
+        dlg._switch_to_selected()
+        manager.switch_to.assert_called_once()
+        assert emitted == ["Other"]
+
+    def test_switch_noop_when_active(self, dlg, manager):
+        _select(dlg, "Active")
+        dlg._switch_to_selected()
+        manager.switch_to.assert_not_called()
+
+    def test_new_database_success(self, dlg, manager, monkeypatch):
+        new_db = _DB("Fresh", "/data/fresh.db")
+        manager.new_database.return_value = new_db
+
+        class FakeNew:
+            def __init__(self, parent=None):
+                pass
+            def exec(self):
+                return 1
+            name = "Fresh"
+            custom_path = None
+        monkeypatch.setattr(dd, "NewDatabaseDialog", FakeNew)
+        monkeypatch.setattr(dd.QMessageBox, "information", MagicMock())
+        monkeypatch.setattr("opensak.gui.settings.get_settings",
+                            lambda: MagicMock())
+        emitted = []
+        dlg.database_switched.connect(lambda db: emitted.append(db.name))
+        dlg._new_database()
+        manager.new_database.assert_called_once()
+        assert emitted == ["Fresh"]
+
+    def test_new_database_value_error(self, dlg, manager, monkeypatch):
+        manager.new_database.side_effect = ValueError("dup")
+
+        class FakeNew:
+            def __init__(self, parent=None):
+                pass
+            def exec(self):
+                return 1
+            name = "X"
+            custom_path = None
+        monkeypatch.setattr(dd, "NewDatabaseDialog", FakeNew)
+        warn = MagicMock()
+        monkeypatch.setattr(dd.QMessageBox, "warning", warn)
+        dlg._new_database()
+        warn.assert_called_once()
+
+    def test_new_database_cancelled(self, dlg, manager, monkeypatch):
+        class FakeNew:
+            def __init__(self, parent=None):
+                pass
+            def exec(self):
+                return 0
+        monkeypatch.setattr(dd, "NewDatabaseDialog", FakeNew)
+        dlg._new_database()
+        manager.new_database.assert_not_called()
+
+    def test_open_database_success(self, dlg, manager, monkeypatch):
+        manager.open_database.return_value = _DB("Opened", "/data/opened.db")
+        monkeypatch.setattr(dd.QFileDialog, "getOpenFileName",
+                            lambda *a, **k: ("/data/opened.db", "f"))
+        monkeypatch.setattr(dd.QMessageBox, "information", MagicMock())
+        dlg._open_database()
+        manager.open_database.assert_called_once()
+
+    def test_open_database_cancel(self, dlg, manager, monkeypatch):
+        monkeypatch.setattr(dd.QFileDialog, "getOpenFileName", lambda *a, **k: ("", ""))
+        dlg._open_database()
+        manager.open_database.assert_not_called()
+
+    def test_open_database_error(self, dlg, manager, monkeypatch):
+        manager.open_database.side_effect = Exception("bad file")
+        monkeypatch.setattr(dd.QFileDialog, "getOpenFileName",
+                            lambda *a, **k: ("/data/x.db", "f"))
+        warn = MagicMock()
+        monkeypatch.setattr(dd.QMessageBox, "warning", warn)
+        dlg._open_database()
+        warn.assert_called_once()
+
+    def test_copy_database(self, dlg, manager, monkeypatch):
+        manager.copy_database.return_value = _DB("Copy", "/data/copy.db")
+        monkeypatch.setattr(dlg, "_simple_input", lambda *a, **k: ("Copy", True))
+        monkeypatch.setattr(dd.QMessageBox, "information", MagicMock())
+        _select(dlg, "Other")
+        dlg._copy_database()
+        manager.copy_database.assert_called_once()
+
+    def test_copy_database_error(self, dlg, manager, monkeypatch):
+        manager.copy_database.side_effect = Exception("no space")
+        monkeypatch.setattr(dlg, "_simple_input", lambda *a, **k: ("Copy", True))
+        warn = MagicMock()
+        monkeypatch.setattr(dd.QMessageBox, "warning", warn)
+        _select(dlg, "Other")
+        dlg._copy_database()
+        warn.assert_called_once()
+
+    def test_rename_database(self, dlg, manager, monkeypatch):
+        monkeypatch.setattr(dlg, "_simple_input", lambda *a, **k: ("Renamed", True))
+        _select(dlg, "Other")
+        dlg._rename_database()
+        manager.rename.assert_called_once()
+
+    def test_rename_database_value_error(self, dlg, manager, monkeypatch):
+        manager.rename.side_effect = ValueError("exists")
+        monkeypatch.setattr(dlg, "_simple_input", lambda *a, **k: ("Renamed", True))
+        warn = MagicMock()
+        monkeypatch.setattr(dd.QMessageBox, "warning", warn)
+        _select(dlg, "Other")
+        dlg._rename_database()
+        warn.assert_called_once()
+
+    def test_remove_from_list(self, dlg, manager, monkeypatch):
+        monkeypatch.setattr(dd.QMessageBox, "question",
+                            lambda *a, **k: dd.QMessageBox.StandardButton.Yes)
+        _select(dlg, "Other")
+        dlg._remove_from_list()
+        manager.remove_from_list.assert_called_once()
+
+    def test_delete_active_guard(self, dlg, manager, monkeypatch):
+        warn = MagicMock()
+        monkeypatch.setattr(dd.QMessageBox, "warning", warn)
+        _select(dlg, "Active")
+        dlg._delete_database()
+        warn.assert_called_once()
+        manager.delete_database.assert_not_called()
+
+    def test_delete_confirmed_with_folder_offer(self, dlg, manager, monkeypatch):
+        manager.delete_database.return_value = Path("/data/emptyfolder")
+        # first warning() = confirm -> Yes; question() = delete folder -> Yes
+        monkeypatch.setattr(dd.QMessageBox, "warning",
+                            lambda *a, **k: dd.QMessageBox.StandardButton.Yes)
+        monkeypatch.setattr(dd.QMessageBox, "question",
+                            lambda *a, **k: dd.QMessageBox.StandardButton.Yes)
+        _select(dlg, "Other")
+        dlg._delete_database()
+        manager.delete_database.assert_called_once()
+        manager.delete_folder.assert_called_once()
+
+    def test_delete_oserror(self, dlg, manager, monkeypatch):
+        manager.delete_database.side_effect = OSError("locked")
+        monkeypatch.setattr(dd.QMessageBox, "warning",
+                            lambda *a, **k: dd.QMessageBox.StandardButton.Yes)
+        _select(dlg, "Other")
+        dlg._delete_database()  # OSError handled, no crash
+
+    def test_simple_input(self, dlg, monkeypatch):
+        monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("  typed  ", True))
+        text, ok = dlg._simple_input("t", "l", "d")
+        assert (text, ok) == ("typed", True)

--- a/tests/unit-tests/test_filter_dialog.py
+++ b/tests/unit-tests/test_filter_dialog.py
@@ -296,6 +296,12 @@ class TestWhereSql:
 # ── profiles ────────────────────────────────────────────────────────────────────
 
 class TestProfiles:
+    @pytest.fixture(autouse=True)
+    def _no_modal(self, monkeypatch):
+        # Never let a profile-combo signal pop a real (blocking) message box.
+        monkeypatch.setattr(fd.QMessageBox, "warning", MagicMock())
+        monkeypatch.setattr(fd.QMessageBox, "information", MagicMock())
+
     def test_save_profile(self, dlg, monkeypatch):
         monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("MyProfile", True))
         saved = {}
@@ -321,10 +327,14 @@ class TestProfiles:
         fs = FilterSet(mode="AND")
         fs.add(NameFilter("loaded"))
         prof = SimpleNamespace(filterset=fs)
+        # Patch load BEFORE touching the combo, and block the combo signal so
+        # setCurrentIndex can't re-enter _on_profile_selected with the real load.
+        monkeypatch.setattr(fd.FilterProfile, "load", classmethod(lambda cls, path: prof))
         p = tmp_path / "p.json"
+        dlg._profile_combo.blockSignals(True)
         dlg._profile_combo.addItem("P", p)
         dlg._profile_combo.setCurrentIndex(dlg._profile_combo.count() - 1)
-        monkeypatch.setattr(fd.FilterProfile, "load", classmethod(lambda cls, path: prof))
+        dlg._profile_combo.blockSignals(False)
         dlg._on_profile_selected(dlg._profile_combo.currentIndex())
         assert dlg._name_filter.text() == "loaded"
         assert dlg._del_btn.isEnabled() is True
@@ -332,8 +342,10 @@ class TestProfiles:
     def test_delete_profile(self, dlg, monkeypatch, tmp_path):
         p = tmp_path / "del.json"
         p.write_text("{}")
+        dlg._profile_combo.blockSignals(True)
         dlg._profile_combo.addItem("Del", p)
         dlg._profile_combo.setCurrentIndex(dlg._profile_combo.count() - 1)
+        dlg._profile_combo.blockSignals(False)
         monkeypatch.setattr(fd.QMessageBox, "question",
                             lambda *a, **k: fd.QMessageBox.StandardButton.Yes)
         dlg._delete_profile()

--- a/tests/unit-tests/test_filter_dialog.py
+++ b/tests/unit-tests/test_filter_dialog.py
@@ -1,0 +1,360 @@
+"""tests/unit-tests/test_filter_dialog.py — complete filter dialog (build/load/profiles)."""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtWidgets import QInputDialog
+from PySide6.QtCore import QDate
+
+from opensak.gui.dialogs import filter_dialog as fd
+from opensak.gui.dialogs.filter_dialog import FilterDialog, TriStateBox, DTSpinBox
+from opensak.filters.engine import (
+    FilterSet, NameFilter, GcCodeFilter, PlacedByFilter, OwnerFilter,
+    CacheTypeFilter, ContainerFilter, DifficultyFilter, TerrainFilter,
+    FoundFilter, NotFoundFilter, AvailabilityFilter, DistanceFilter,
+    PremiumFilter, NonPremiumFilter, HasTrackableFilter, HasCorrectedFilter,
+    CountryFilter, StateFilter, CountyFilter, UserFlagFilter, DnfFilter,
+    FtfFilter, FavoritePointsFilter, AttributeFilter, WhereClauseFilter,
+    FoundByMeDateFilter, DnfDateFilter, LastLogDateFilter, FilterProfile,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate(monkeypatch):
+    # No real profiles on disk; deterministic home for DistanceFilter.
+    monkeypatch.setattr(fd.FilterProfile, "list_profiles", staticmethod(lambda: []))
+    monkeypatch.setattr("opensak.gui.settings.get_settings",
+                        lambda: SimpleNamespace(home_lat=55.0, home_lon=12.0))
+
+
+@pytest.fixture
+def dlg(qtbot):
+    d = FilterDialog()
+    qtbot.addWidget(d)
+    return d
+
+
+# ── helper widgets ──────────────────────────────────────────────────────────────
+
+class TestHelperWidgets:
+    def test_tristate(self, qtbot):
+        box = TriStateBox()
+        qtbot.addWidget(box)
+        assert box.state is None
+        box._ja.setChecked(True)
+        assert box.state is True
+        box._ja.setChecked(False)
+        box._nej.setChecked(True)
+        assert box.state is False
+        box.reset()
+        assert box.state is None
+
+    def test_dtspinbox(self, qtbot):
+        sb = DTSpinBox()
+        qtbot.addWidget(sb)
+        assert sb.minimum() == 1.0 and sb.maximum() == 5.0
+        assert sb.singleStep() == 0.5
+
+
+# ── construction ────────────────────────────────────────────────────────────────
+
+class TestConstruction:
+    def test_five_tabs(self, dlg):
+        assert dlg._tabs.count() == 5
+
+    def test_init_with_filterset(self, qtbot):
+        fs = FilterSet(mode="AND")
+        fs.add(NameFilter("hello"))
+        d = FilterDialog(current_filterset=fs)
+        qtbot.addWidget(d)
+        assert d._name_filter.text() == "hello"
+
+
+# ── build_filterset ─────────────────────────────────────────────────────────────
+
+def _types(fs):
+    return [getattr(f, "filter_type", None) for f in fs._filters]
+
+
+class TestBuildFilterset:
+    def test_empty_is_empty(self, dlg):
+        dlg._archived_cb.setChecked(True)  # all three statuses -> no availability filter
+        fs = dlg._build_filterset()
+        assert fs._filters == []
+
+    def test_text_filters(self, dlg):
+        dlg._name_filter.setText("n")
+        dlg._gc_filter.setText("GC1")
+        dlg._placed_filter.setText("p")
+        dlg._owner_filter.setText("o")
+        types = _types(dlg._build_filterset())
+        assert {"name", "gc_code", "placed_by", "owner_name"} <= set(types)
+
+    def test_type_and_container_subset(self, dlg):
+        # uncheck one type and one container -> filters added
+        first_type = next(iter(dlg._type_checks.values()))
+        first_type.setChecked(False)
+        first_cont = next(iter(dlg._cont_checks.values()))
+        first_cont.setChecked(False)
+        types = _types(dlg._build_filterset())
+        assert "cache_type" in types and "container" in types
+
+    def test_dt_filters(self, dlg):
+        dlg._diff_min.setValue(2.0)
+        dlg._terr_max.setValue(4.0)
+        types = _types(dlg._build_filterset())
+        assert "difficulty" in types and "terrain" in types
+
+    def test_found_only_and_notfound_only(self, dlg):
+        dlg._notfound_cb.setChecked(False)
+        assert "found" in _types(dlg._build_filterset())
+        dlg._notfound_cb.setChecked(True)
+        dlg._found_cb.setChecked(False)
+        assert "not_found" in _types(dlg._build_filterset())
+
+    def test_availability_filter(self, dlg):
+        dlg._unavail_cb.setChecked(False)  # not all three selected
+        assert "availability" in _types(dlg._build_filterset())
+
+    def test_distance_filter(self, dlg):
+        dlg._dist_enabled.setChecked(True)
+        assert "distance" in _types(dlg._build_filterset())
+
+    def test_premium_and_trackable_and_corrected(self, dlg):
+        dlg._prem_no.setChecked(False)
+        dlg._tb_no.setChecked(False)
+        dlg._cc_no.setChecked(False)
+        types = _types(dlg._build_filterset())
+        assert "premium" in types and "has_trackable" in types and "has_corrected" in types
+        dlg._prem_yes.setChecked(False)
+        dlg._prem_no.setChecked(True)
+        assert "non_premium" in _types(dlg._build_filterset())
+
+    def test_misc_filters(self, dlg):
+        dlg._country_filter.setText("DK")
+        dlg._state_filter.setText("Z")
+        dlg._county_filter.setText("C")
+        dlg._flag_no.setChecked(False)   # flag yes only
+        dlg._dnf_no.setChecked(False)
+        dlg._ftf_no.setChecked(False)
+        dlg._fav_enabled.setChecked(True)
+        types = _types(dlg._build_filterset())
+        assert {"country", "state", "county", "user_flag", "dnf", "ftf",
+                "favorite_points"} <= set(types)
+
+    def test_date_filters(self, dlg):
+        dlg._hidden_from_enabled.setChecked(True)
+        dlg._found_from_enabled.setChecked(True)
+        dlg._dnf_date_from_enabled.setChecked(True)
+        dlg._log_from_enabled.setChecked(True)
+        types = _types(dlg._build_filterset())
+        assert "found_by_me_date" in types
+        assert "dnf_date" in types
+        assert "last_log_date" in types
+        assert "hidden_date_range" in types
+
+    def test_attributes_and_mode(self, dlg):
+        attr_id = next(iter(dlg._attr_boxes))
+        ja, nej, ingen = dlg._attr_boxes[attr_id]
+        ja.setChecked(True)
+        fs = dlg._build_filterset()
+        assert any(getattr(f, "filter_type", None) == "attribute" for f in fs._filters)
+
+    def test_attributes_or_mode(self, dlg):
+        dlg._attr_mode_all.setChecked(False)  # ANY/OR mode
+        ids = list(dlg._attr_boxes)[:2]
+        for aid in ids:
+            dlg._attr_boxes[aid][0].setChecked(True)
+        fs = dlg._build_filterset()
+        # nested OR FilterSet present
+        assert any(isinstance(f, FilterSet) and f.mode == "OR" for f in fs._filters)
+
+    def test_where_clause(self, dlg):
+        dlg._where_sql_general.setPlainText("found = 0")
+        assert "where_clause" in _types(dlg._build_filterset())
+
+
+# ── load_filterset roundtrip ────────────────────────────────────────────────────
+
+class TestLoadFilterset:
+    def test_loads_many_filters(self, dlg):
+        fs = FilterSet(mode="AND")
+        fs.add(NameFilter("nm"))
+        fs.add(GcCodeFilter("GC9"))
+        fs.add(PlacedByFilter("pb"))
+        fs.add(OwnerFilter("ow"))
+        fs.add(DifficultyFilter(2.0, 4.0))
+        fs.add(TerrainFilter(1.5, 3.5))
+        fs.add(NotFoundFilter())
+        fs.add(AvailabilityFilter(show_avail=True, show_unavail=False, show_archived=True))
+        fs.add(DistanceFilter(55.0, 12.0, 25.0))
+        fs.add(PremiumFilter())
+        fs.add(HasTrackableFilter())
+        fs.add(HasCorrectedFilter())
+        fs.add(CountryFilter("DK"))
+        fs.add(StateFilter("Z"))
+        fs.add(CountyFilter("Cty"))
+        fs.add(UserFlagFilter(flagged=True))
+        fs.add(DnfFilter(has_dnf=False))
+        fs.add(FtfFilter(has_ftf=True))
+        fs.add(FavoritePointsFilter(min_pts=10, max_pts=200))
+        fs.add(WhereClauseFilter("found = 0"))
+        dlg._load_filterset(fs)
+        assert dlg._name_filter.text() == "nm"
+        assert dlg._gc_filter.text() == "GC9"
+        assert dlg._diff_min.value() == 2.0
+        assert dlg._notfound_cb.isChecked() and not dlg._found_cb.isChecked()
+        assert dlg._dist_enabled.isChecked()
+        assert dlg._country_filter.text() == "DK"
+        assert dlg._fav_enabled.isChecked()
+        assert dlg._where_sql_general.toPlainText() == "found = 0"
+
+    def test_loads_types_and_container(self, dlg):
+        from opensak.utils.constants import CACHE_TYPES, CONTAINER_SIZES
+        fs = FilterSet(mode="AND")
+        fs.add(CacheTypeFilter([CACHE_TYPES[0]]))
+        fs.add(ContainerFilter([CONTAINER_SIZES[0]]))
+        dlg._load_filterset(fs)
+        assert dlg._type_checks[CACHE_TYPES[0]].isChecked()
+        assert not dlg._type_checks[CACHE_TYPES[1]].isChecked()
+
+    def test_loads_date_filters(self, dlg):
+        fs = FilterSet(mode="AND")
+        fs.add(FoundByMeDateFilter(from_date=datetime(2020, 1, 1),
+                                   to_date=datetime(2021, 1, 1)))
+        fs.add(DnfDateFilter(from_date=datetime(2020, 2, 2), to_date=None))
+        fs.add(LastLogDateFilter(from_date=None, to_date=datetime(2022, 3, 3)))
+        dlg._load_filterset(fs)
+        assert dlg._found_from_enabled.isChecked()
+        assert dlg._dnf_date_from_enabled.isChecked()
+        assert dlg._log_to_enabled.isChecked()
+
+    def test_loads_attribute_or_group_sets_any_mode(self, dlg):
+        attr_id = next(iter(dlg._attr_boxes))
+        inner = FilterSet(mode="OR")
+        inner.add(AttributeFilter(attr_id, True))
+        fs = FilterSet(mode="AND")
+        fs.add(inner)
+        dlg._load_filterset(fs)        # exercises the fixed _attr_mode_all toggle
+        assert dlg._attr_mode_all.isChecked() is False
+        assert dlg._attr_boxes[attr_id][0].isChecked() is True
+
+
+# ── reset ───────────────────────────────────────────────────────────────────────
+
+class TestReset:
+    def test_reset_all(self, dlg):
+        dlg._name_filter.setText("x")
+        dlg._country_filter.setText("y")
+        dlg._where_sql_general.setPlainText("found = 0")
+        dlg._reset_all()
+        assert dlg._name_filter.text() == ""
+        assert dlg._country_filter.text() == ""
+        assert dlg._where_sql_general.toPlainText() == ""
+
+    def test_reset_current_tab_each(self, dlg):
+        for i in range(dlg._tabs.count()):
+            dlg._tabs.setCurrentIndex(i)
+            dlg._reset_current_tab()  # no crash for any tab
+
+    def test_enable_disable_all_types(self, dlg):
+        dlg._disable_all_types()
+        assert all(not cb.isChecked() for cb in dlg._type_checks.values())
+        dlg._enable_all_types()
+        assert all(cb.isChecked() for cb in dlg._type_checks.values())
+
+    def test_toggles(self, dlg):
+        dlg._on_dist_toggled(True)
+        assert dlg._dist_max.isEnabled()
+        dlg._on_fav_toggled(True)
+        assert dlg._fav_min.isEnabled() and dlg._fav_max.isEnabled()
+
+
+# ── where SQL validation ────────────────────────────────────────────────────────
+
+class TestWhereSql:
+    def test_validate_valid(self, dlg, db_session):
+        assert dlg._validate_where_sql("found = 0") is None
+
+    def test_validate_invalid(self, dlg, db_session):
+        err = dlg._validate_where_sql("no_such_column = 1")
+        assert err is not None
+
+    def test_show_where_info(self, dlg, monkeypatch):
+        class _NoExec(fd.QDialog):
+            def exec(self):
+                return 0
+        monkeypatch.setattr(fd, "QDialog", _NoExec)
+        dlg._show_where_info()  # builds + (fake) exec, no block
+
+
+# ── profiles ────────────────────────────────────────────────────────────────────
+
+class TestProfiles:
+    def test_save_profile(self, dlg, monkeypatch):
+        monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("MyProfile", True))
+        saved = {}
+        monkeypatch.setattr(fd.FilterProfile, "save",
+                            lambda self, *a, **k: saved.update(name=self.name))
+        monkeypatch.setattr(fd.QMessageBox, "information", MagicMock())
+        dlg._name_filter.setText("foo")
+        dlg._save_profile()
+        assert saved.get("name") == "MyProfile"
+
+    def test_save_profile_cancelled(self, dlg, monkeypatch):
+        monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("", False))
+        called = []
+        monkeypatch.setattr(fd.FilterProfile, "save", lambda self, *a, **k: called.append(True))
+        dlg._save_profile()
+        assert called == []
+
+    def test_on_profile_selected_none(self, dlg):
+        dlg._on_profile_selected(0)  # "none" entry -> del btn disabled
+        assert dlg._del_btn.isEnabled() is False
+
+    def test_on_profile_selected_loads(self, dlg, monkeypatch, tmp_path):
+        fs = FilterSet(mode="AND")
+        fs.add(NameFilter("loaded"))
+        prof = SimpleNamespace(filterset=fs)
+        p = tmp_path / "p.json"
+        dlg._profile_combo.addItem("P", p)
+        dlg._profile_combo.setCurrentIndex(dlg._profile_combo.count() - 1)
+        monkeypatch.setattr(fd.FilterProfile, "load", classmethod(lambda cls, path: prof))
+        dlg._on_profile_selected(dlg._profile_combo.currentIndex())
+        assert dlg._name_filter.text() == "loaded"
+        assert dlg._del_btn.isEnabled() is True
+
+    def test_delete_profile(self, dlg, monkeypatch, tmp_path):
+        p = tmp_path / "del.json"
+        p.write_text("{}")
+        dlg._profile_combo.addItem("Del", p)
+        dlg._profile_combo.setCurrentIndex(dlg._profile_combo.count() - 1)
+        monkeypatch.setattr(fd.QMessageBox, "question",
+                            lambda *a, **k: fd.QMessageBox.StandardButton.Yes)
+        dlg._delete_profile()
+        assert not p.exists()
+
+
+# ── apply ───────────────────────────────────────────────────────────────────────
+
+class TestApply:
+    def test_apply_emits(self, dlg, db_session):
+        captured = []
+        dlg.filter_applied.connect(lambda fs, sort, name: captured.append((fs, name)))
+        dlg._name_filter.setText("hello")
+        dlg._apply()
+        assert captured and captured[0][1] == ""
+
+    def test_apply_blocks_on_bad_where(self, dlg, db_session):
+        captured = []
+        dlg.filter_applied.connect(lambda *a: captured.append(a))
+        dlg._where_sql_general.setPlainText("no_such_column = 1")
+        dlg._apply()
+        assert captured == []                       # not emitted
+        assert dlg._where_error_label.toPlainText() != ""
+        assert not dlg._where_error_label.isHidden()

--- a/tests/unit-tests/test_gps_dialog.py
+++ b/tests/unit-tests/test_gps_dialog.py
@@ -1,0 +1,226 @@
+"""tests/unit-tests/test_gps_dialog.py — GPS/Garmin export dialog + workers."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from opensak.gui.dialogs import gps_dialog as gd
+from opensak.gui.dialogs.gps_dialog import DeleteWorker, ExportWorker, GpsExportDialog
+
+
+# ── DeleteWorker ────────────────────────────────────────────────────────────────
+
+class TestDeleteWorker:
+    def test_run_success(self, monkeypatch):
+        monkeypatch.setattr("opensak.gps.garmin.delete_gpx_files", lambda p: "deleted 3")
+        w = DeleteWorker(Path("/dev"))
+        got = []
+        w.finished.connect(got.append)
+        w.run()
+        assert got == ["deleted 3"]
+
+    def test_run_error(self, monkeypatch):
+        monkeypatch.setattr("opensak.gps.garmin.delete_gpx_files",
+                            lambda p: (_ for _ in ()).throw(RuntimeError("perm denied")))
+        w = DeleteWorker(Path("/dev"))
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs and "perm denied" in errs[0]
+
+
+# ── ExportWorker ────────────────────────────────────────────────────────────────
+
+class TestExportWorker:
+    def test_run_to_device(self, monkeypatch, tmp_path):
+        (tmp_path / "Garmin").mkdir()
+        monkeypatch.setattr("opensak.gps.garmin.export_to_device",
+                            lambda c, d, f: "to device")
+        monkeypatch.setattr("opensak.gps.garmin.export_to_file",
+                            lambda c, p: "to file")
+        w = ExportWorker(["c1", "c2", "c3"], tmp_path, "out", max_caches=2)
+        got = []
+        w.finished.connect(got.append)
+        w.run()
+        assert got == ["to device"]
+
+    def test_run_to_file(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("opensak.gps.garmin.export_to_file", lambda c, p: "to file")
+        w = ExportWorker(["c1"], tmp_path, "out", max_caches=0)  # 0 = all
+        got = []
+        w.finished.connect(got.append)
+        w.run()
+        assert got == ["to file"]
+
+    def test_run_error(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("opensak.gps.garmin.export_to_file",
+                            lambda c, p: (_ for _ in ()).throw(RuntimeError("disk full")))
+        w = ExportWorker(["c1"], tmp_path, "out", max_caches=0)
+        errs = []
+        w.error.connect(errs.append)
+        w.run()
+        assert errs and "disk full" in errs[0]
+
+
+# ── GpsExportDialog ─────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def no_devices(monkeypatch):
+    monkeypatch.setattr("opensak.gps.garmin.find_garmin_devices", lambda: [])
+
+
+@pytest.fixture
+def with_device(monkeypatch, tmp_path):
+    dev = tmp_path / "GARMIN"
+    dev.mkdir()
+    monkeypatch.setattr("opensak.gps.garmin.find_garmin_devices", lambda: [dev])
+    return dev
+
+
+class TestDialogScan:
+    def test_no_devices_selects_file_mode(self, qtbot, no_devices):
+        dlg = GpsExportDialog(caches=["c1", "c2"])
+        qtbot.addWidget(dlg)
+        assert dlg._rb_file.isChecked() is True
+        assert dlg._device_combo.count() == 1  # the "no device" placeholder
+
+    def test_devices_found_enables_export(self, qtbot, with_device):
+        dlg = GpsExportDialog(caches=["c1"])
+        qtbot.addWidget(dlg)
+        assert dlg._device_combo.count() == 1
+        assert dlg._export_btn.isEnabled() is True
+        assert dlg._rb_device.isChecked() is True
+
+
+class TestDialogInteraction:
+    @pytest.fixture
+    def dlg(self, qtbot, with_device):
+        d = GpsExportDialog(caches=["c1", "c2"])
+        qtbot.addWidget(d)
+        return d
+
+    def test_mode_changed_to_file(self, dlg):
+        dlg._rb_file.setChecked(True)
+        dlg._on_mode_changed(False)
+        assert dlg._device_combo.isEnabled() is False
+        assert dlg._cb_delete_gpx.isEnabled() is False
+        assert dlg._cb_delete_gpx.isChecked() is False
+
+    def test_browse_file(self, dlg, monkeypatch, tmp_path):
+        target = tmp_path / "export.gpx"
+        monkeypatch.setattr(gd.QFileDialog, "getSaveFileName",
+                            lambda *a, **k: (str(target), "f"))
+        dlg._browse_file()
+        assert dlg._selected_file_path == tmp_path
+        assert dlg._filename.text() == "export"
+        assert dlg._rb_file.isChecked() is True
+
+    def test_browse_cancel(self, dlg, monkeypatch):
+        monkeypatch.setattr(gd.QFileDialog, "getSaveFileName", lambda *a, **k: ("", ""))
+        dlg._browse_file()
+        assert dlg._selected_file_path is None
+
+    def test_get_destination_device(self, dlg, with_device):
+        assert dlg._get_destination() == Path(with_device)
+
+    def test_get_destination_file_selected(self, dlg, tmp_path):
+        dlg._rb_file.setChecked(True)
+        dlg._selected_file_path = tmp_path
+        assert dlg._get_destination() == tmp_path
+
+    def test_get_destination_file_default_home(self, dlg):
+        dlg._rb_file.setChecked(True)
+        dlg._selected_file_path = None
+        assert dlg._get_destination() == Path.home()
+
+    def test_start_export_no_destination(self, dlg, monkeypatch):
+        monkeypatch.setattr(dlg, "_get_destination", lambda: None)
+        dlg._start_export()
+        assert dlg._log.toPlainText() != ""
+
+    def test_start_export_runs_export(self, dlg, monkeypatch):
+        launched = []
+
+        class FakeExport:
+            def __init__(self, *a, **k):
+                self.finished = MagicMock()
+                self.error = MagicMock()
+            def start(self):
+                launched.append(True)
+            def isRunning(self):
+                return False
+            def wait(self):
+                pass
+        monkeypatch.setattr(gd, "ExportWorker", FakeExport)
+        dlg._cb_delete_gpx.setChecked(False)
+        dlg._start_export()
+        assert launched == [True]
+        assert dlg._export_btn.isEnabled() is False
+
+    def test_start_export_with_delete_confirmed(self, dlg, monkeypatch, tmp_path):
+        gpx_dir = tmp_path / "gpxdir"
+        gpx_dir.mkdir()
+        (gpx_dir / "old.gpx").write_text("x")
+        monkeypatch.setattr("opensak.gps.garmin.get_garmin_gpx_path", lambda dest: gpx_dir)
+        monkeypatch.setattr(gd.QMessageBox, "exec",
+                            lambda self: gd.QMessageBox.StandardButton.Ok)
+        launched = []
+
+        class FakeDelete:
+            def __init__(self, dest):
+                self.finished = MagicMock()
+                self.error = MagicMock()
+            def start(self):
+                launched.append(True)
+            def isRunning(self):
+                return False
+            def wait(self):
+                pass
+        monkeypatch.setattr(gd, "DeleteWorker", FakeDelete)
+        dlg._cb_delete_gpx.setChecked(True)
+        dlg._rb_device.setChecked(True)
+        dlg._start_export()
+        assert launched == [True]
+
+    def test_start_export_delete_cancelled(self, dlg, monkeypatch, tmp_path):
+        gpx_dir = tmp_path / "gpxdir2"
+        gpx_dir.mkdir()
+        monkeypatch.setattr("opensak.gps.garmin.get_garmin_gpx_path", lambda dest: gpx_dir)
+        monkeypatch.setattr(gd.QMessageBox, "exec",
+                            lambda self: gd.QMessageBox.StandardButton.Cancel)
+        launched = []
+        monkeypatch.setattr(gd, "DeleteWorker",
+                            lambda *a, **k: launched.append(True))
+        dlg._cb_delete_gpx.setChecked(True)
+        dlg._rb_device.setChecked(True)
+        dlg._start_export()
+        assert launched == []  # cancelled before launching
+
+    def test_on_delete_finished_runs_export(self, dlg, monkeypatch, tmp_path):
+        launched = []
+
+        class FakeExport:
+            def __init__(self, *a, **k):
+                self.finished = MagicMock()
+                self.error = MagicMock()
+            def start(self):
+                launched.append(True)
+            def isRunning(self):
+                return False
+            def wait(self):
+                pass
+        monkeypatch.setattr(gd, "ExportWorker", FakeExport)
+        dlg._on_delete_finished("removed 2", tmp_path, "out", 100)
+        assert launched == [True]
+        assert "out" not in dlg._log.toPlainText() or dlg._log.toPlainText()
+
+    def test_on_finished_and_error(self, dlg):
+        dlg._on_finished("export ok")
+        assert "export ok" in dlg._log.toPlainText()
+        assert dlg._export_btn.isEnabled() is True
+        dlg._on_error("boom")
+        assert "boom" in dlg._log.toPlainText()

--- a/tests/unit-tests/test_icon.py
+++ b/tests/unit-tests/test_icon.py
@@ -1,0 +1,124 @@
+"""tests/unit-tests/test_icon.py — app icon loader + OpenSAKMessageBox."""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import QMessageBox
+
+from opensak.gui import icon as ic
+
+ASSETS = Path(__file__).resolve().parents[2] / "assets" / "icons"
+
+
+# ── _icon_dir ─────────────────────────────────────────────────────────────────
+
+class TestIconDir:
+    def test_pyinstaller_bundle(self, monkeypatch):
+        monkeypatch.setattr(ic.sys, "_MEIPASS", "/fake/bundle", raising=False)
+        assert ic._icon_dir() == Path("/fake/bundle") / "assets" / "icons"
+
+    def test_source_repo(self, monkeypatch):
+        monkeypatch.delattr(ic.sys, "_MEIPASS", raising=False)
+        assert ic._icon_dir() == ASSETS
+
+    def test_fallback_to_module_dir(self, monkeypatch):
+        monkeypatch.delattr(ic.sys, "_MEIPASS", raising=False)
+        monkeypatch.setattr(ic.Path, "exists", lambda self: False)
+        got = ic._icon_dir()
+        assert got == Path(ic.__file__).resolve().parent
+
+
+# ── get_app_icon ──────────────────────────────────────────────────────────────
+
+class TestGetAppIcon:
+    def test_loads_pngs_from_assets(self, qapp):
+        result = ic.get_app_icon()
+        assert isinstance(result, QIcon)
+        assert not result.isNull()
+
+    def test_win32_ico_branch(self, qapp, monkeypatch, tmp_path):
+        shutil.copy(ASSETS / "opensak.png", tmp_path / "opensak.ico")
+        monkeypatch.setattr(ic, "_icon_dir", lambda: tmp_path)
+        monkeypatch.setattr(ic.sys, "platform", "win32")
+        assert not ic.get_app_icon().isNull()
+
+    def test_darwin_icns_branch(self, qapp, monkeypatch, tmp_path):
+        shutil.copy(ASSETS / "opensak.png", tmp_path / "opensak.icns")
+        monkeypatch.setattr(ic, "_icon_dir", lambda: tmp_path)
+        monkeypatch.setattr(ic.sys, "platform", "darwin")
+        assert not ic.get_app_icon().isNull()
+
+    def test_named_png_loop_adds_pixmaps(self, qapp, monkeypatch, tmp_path):
+        shutil.copy(ASSETS / "opensak_16.png", tmp_path / "opensak_16.png")
+        shutil.copy(ASSETS / "opensak.png", tmp_path / "opensak.png")
+        monkeypatch.setattr(ic, "_icon_dir", lambda: tmp_path)
+        monkeypatch.setattr(ic.sys, "platform", "linux")
+        assert not ic.get_app_icon().isNull()
+
+    def test_fallback_glob_branch(self, qapp, monkeypatch, tmp_path):
+        shutil.copy(ASSETS / "opensak.png", tmp_path / "opensak_weird.png")
+        monkeypatch.setattr(ic, "_icon_dir", lambda: tmp_path)
+        monkeypatch.setattr(ic.sys, "platform", "linux")
+        assert not ic.get_app_icon().isNull()
+
+    def test_no_icons_returns_empty(self, qapp, monkeypatch, tmp_path):
+        monkeypatch.setattr(ic, "_icon_dir", lambda: tmp_path)
+        monkeypatch.setattr(ic.sys, "platform", "linux")
+        assert ic.get_app_icon().isNull()
+
+
+# ── set_taskbar_icon ──────────────────────────────────────────────────────────
+
+def test_set_taskbar_icon(qapp):
+    captured = []
+
+    class FakeWin:
+        def setWindowIcon(self, i):
+            captured.append(i)
+
+    ic.set_taskbar_icon(FakeWin())
+    assert len(captured) == 1
+    assert isinstance(captured[0], QIcon)
+
+
+# ── OpenSAKMessageBox ─────────────────────────────────────────────────────────
+
+class TestMessageBox:
+    @pytest.fixture(autouse=True)
+    def _no_exec(self, monkeypatch):
+        monkeypatch.setattr(ic.QMessageBox, "exec",
+                            lambda self: QMessageBox.StandardButton.Ok)
+
+    def test_init_sets_window_icon(self, qapp):
+        box = ic.OpenSAKMessageBox()
+        assert not box.windowIcon().isNull()
+
+    def test_information(self, qapp):
+        assert ic.OpenSAKMessageBox.information(None, "T", "msg") == \
+            QMessageBox.StandardButton.Ok
+
+    def test_warning(self, qapp):
+        assert ic.OpenSAKMessageBox.warning(None, "T", "msg") == \
+            QMessageBox.StandardButton.Ok
+
+    def test_critical(self, qapp):
+        assert ic.OpenSAKMessageBox.critical(None, "T", "msg") == \
+            QMessageBox.StandardButton.Ok
+
+    def test_question(self, qapp):
+        assert ic.OpenSAKMessageBox.question(None, "T", "msg") == \
+            QMessageBox.StandardButton.Ok
+
+    def test_about(self, qapp):
+        ic.OpenSAKMessageBox.about(None, "T", "msg")  # returns None, no crash
+
+    def test_default_button_set(self, qapp):
+        ic.OpenSAKMessageBox.information(
+            None, "T", "msg",
+            default_button=QMessageBox.StandardButton.Ok)

--- a/tests/unit-tests/test_icon_provider.py
+++ b/tests/unit-tests/test_icon_provider.py
@@ -1,0 +1,128 @@
+"""tests/unit-tests/test_icon_provider.py — cache icon/pixmap/pin provider."""
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtGui import QIcon, QPixmap
+
+from opensak.gui import icon_provider as ip
+
+
+@pytest.fixture(autouse=True)
+def _app(qapp):
+    """QPainter/QPixmap need a QApplication."""
+    yield
+
+
+# ── disk SVG reading ──────────────────────────────────────────────────────────
+
+class TestReadSvg:
+    def test_reads_existing(self, tmp_path):
+        f = tmp_path / "x.svg"
+        f.write_text("<svg/>", encoding="utf-8")
+        assert ip._read_svg_file(f) == "<svg/>"
+
+    def test_missing_returns_none(self, tmp_path):
+        assert ip._read_svg_file(tmp_path / "nope.svg") is None
+
+    def test_get_type_svg_known(self):
+        assert ip._get_type_svg("traditional") is not None
+
+    def test_get_type_svg_unknown_key(self):
+        assert ip._get_type_svg("found") is None  # status, not in type map
+
+    def test_get_found_svg_known(self):
+        assert ip._get_found_svg("traditional") is not None
+
+    def test_get_found_svg_unknown_uses_green(self):
+        # unknown key → default color "green" file exists
+        assert ip._get_found_svg("totally_unknown") is not None
+
+
+# ── key normalization / db mapping ────────────────────────────────────────────
+
+class TestKeys:
+    def test_normalize_spaces_and_dashes(self):
+        assert ip._normalize_key("Multi-Cache Thing") == "multi_cache_thing"
+
+    def test_normalize_none(self):
+        assert ip._normalize_key(None) == ""
+
+    def test_db_type_known(self):
+        assert ip._db_type_to_key("Traditional Cache") == "traditional"
+
+    def test_db_type_unknown_falls_back_to_normalize(self):
+        assert ip._db_type_to_key("Some New Type") == "some_new_type"
+
+    def test_get_all_type_keys_sorted_unique(self):
+        keys = ip.get_all_type_keys()
+        assert keys == sorted(set(keys))
+        assert "traditional" in keys
+
+    def test_get_all_size_keys(self):
+        keys = ip.get_all_size_keys()
+        assert "micro" in keys and "regular" in keys
+
+
+# ── svg-for-key resolution (file vs fallback) ─────────────────────────────────
+
+class TestSvgForKey:
+    def test_uses_file_when_present(self):
+        assert ip._get_svg_for_key("traditional") == ip._get_type_svg("traditional")
+
+    def test_falls_back_for_status_key(self):
+        # "found" has no type file → fallback dict entry
+        assert ip._get_svg_for_key("found") == ip._FALLBACK_SVGS["found"]
+
+    def test_falls_back_to_unknown_for_garbage(self):
+        assert ip._get_svg_for_key("zzz") == ip._FALLBACK_SVGS["unknown"]
+
+    def test_found_for_key_uses_file(self):
+        assert ip._get_found_svg_for_key("traditional") == ip._get_found_svg("traditional")
+
+    def test_found_for_key_fallback(self, monkeypatch):
+        monkeypatch.setattr(ip, "_get_found_svg", lambda key: None)
+        assert ip._get_found_svg_for_key("traditional") == ip._FALLBACK_SVGS["found"]
+
+
+# ── rendering ─────────────────────────────────────────────────────────────────
+
+class TestRendering:
+    def test_svg_to_pixmap(self):
+        px = ip._svg_to_pixmap(ip._FALLBACK_SVGS["traditional"], 32)
+        assert isinstance(px, QPixmap)
+        assert px.width() == 32 and px.height() == 32
+
+    def test_cache_type_icon(self):
+        assert isinstance(ip.get_cache_type_icon("Traditional Cache"), QIcon)
+
+    def test_cache_type_icon_found(self):
+        assert isinstance(ip.get_cache_type_icon("Traditional Cache", found=True), QIcon)
+
+    def test_cache_size_icon_known(self):
+        assert isinstance(ip.get_cache_size_icon("micro"), QIcon)
+
+    def test_cache_size_icon_unknown_uses_other(self):
+        assert isinstance(ip.get_cache_size_icon("ginormous"), QIcon)
+
+    def test_cache_type_pixmap(self):
+        assert isinstance(ip.get_cache_type_pixmap("Multi-cache"), QPixmap)
+
+    def test_cache_type_pixmap_found(self):
+        assert isinstance(ip.get_cache_type_pixmap("Multi-cache", found=True), QPixmap)
+
+
+# ── map pin HTML ──────────────────────────────────────────────────────────────
+
+class TestMapPin:
+    def test_not_found_has_base_img_no_overlay(self):
+        html = ip.get_map_pin_html("Traditional Cache")
+        assert "data:image/svg+xml;base64," in html
+        assert html.count("<img") == 1
+        assert "position:relative" in html
+
+    def test_found_has_overlay(self):
+        html = ip.get_map_pin_html("Traditional Cache", found=True)
+        assert html.count("<img") == 2
+        assert "drop-shadow" in html

--- a/tests/unit-tests/test_import_dialog.py
+++ b/tests/unit-tests/test_import_dialog.py
@@ -1,0 +1,263 @@
+"""tests/unit-tests/test_import_dialog.py — GPX/PQ import worker + dialog."""
+
+import contextlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from opensak.gui.dialogs import import_dialog as idlg
+from opensak.gui.dialogs.import_dialog import ImportWorker, ImportDialog
+
+
+def _result(created=1, updated=0, waypoints=0, skipped=0, errors=None):
+    return SimpleNamespace(created=created, updated=updated, waypoints=waypoints,
+                           skipped=skipped, errors=errors or [])
+
+
+@contextlib.contextmanager
+def _fake_session():
+    yield MagicMock()
+
+
+# ── ImportWorker.run ────────────────────────────────────────────────────────────
+
+class TestImportWorker:
+    def _patch_common(self, monkeypatch, active_path=Path("/active.db")):
+        monkeypatch.setattr("opensak.db.manager.get_db_manager",
+                            lambda: SimpleNamespace(active_path=active_path))
+        monkeypatch.setattr("opensak.db.database.get_session", _fake_session)
+        monkeypatch.setattr("opensak.importer.import_gpx",
+                            lambda p, s, progress_cb=None: _result())
+        monkeypatch.setattr("opensak.importer.import_zip",
+                            lambda p, s, progress_cb=None: _result(created=5))
+        from opensak.utils.utils import ImportType
+        return ImportType
+
+    def test_run_gpx_success(self, monkeypatch):
+        ImportType = self._patch_common(monkeypatch)
+        monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
+        w = ImportWorker([Path("/a.gpx")])
+        got = []
+        w.file_finished.connect(lambda i, r: got.append(r))
+        w.run()
+        assert len(got) == 1 and got[0].created == 1
+
+    def test_run_zip_success(self, monkeypatch):
+        ImportType = self._patch_common(monkeypatch)
+        monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.ZIP)
+        w = ImportWorker([Path("/a.zip")])
+        got = []
+        w.file_finished.connect(lambda i, r: got.append(r))
+        w.run()
+        assert got[0].created == 5
+
+    def test_run_value_error(self, monkeypatch):
+        ImportType = self._patch_common(monkeypatch)
+        monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
+        monkeypatch.setattr("opensak.importer.import_gpx",
+                            lambda *a, **k: (_ for _ in ()).throw(ValueError("bad gpx")))
+        w = ImportWorker([Path("/a.gpx")])
+        errs = []
+        w.file_error.connect(lambda i, m: errs.append(m))
+        w.run()
+        assert errs and "bad gpx" in errs[0]
+
+    def test_run_generic_exception_traceback(self, monkeypatch):
+        ImportType = self._patch_common(monkeypatch)
+        monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
+        monkeypatch.setattr("opensak.importer.import_gpx",
+                            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        w = ImportWorker([Path("/a.gpx")])
+        errs = []
+        w.file_error.connect(lambda i, m: errs.append(m))
+        w.run()
+        assert errs and "boom" in errs[0]
+
+    def test_run_switches_and_restores_db(self, monkeypatch):
+        ImportType = self._patch_common(monkeypatch, active_path=Path("/active.db"))
+        monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
+        inits = []
+        monkeypatch.setattr("opensak.db.database.init_db", lambda **k: inits.append(k.get("db_path")))
+        w = ImportWorker([Path("/a.gpx")], target_db_path=Path("/other.db"))
+        w.run()
+        # switched to target, then restored original
+        assert inits == [Path("/other.db"), Path("/active.db")]
+
+
+# ── ImportDialog ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def manager(monkeypatch):
+    a = SimpleNamespace(name="Active", path=Path("/active.db"))
+    b = SimpleNamespace(name="Other", path=Path("/other.db"))
+    mgr = SimpleNamespace(active_path=Path("/active.db"), databases=[a, b])
+    monkeypatch.setattr("opensak.db.manager.get_db_manager", lambda: mgr)
+    return mgr
+
+
+@pytest.fixture
+def dlg(qtbot, manager):
+    d = ImportDialog()
+    qtbot.addWidget(d)
+    return d
+
+
+class TestImportDialog:
+    def test_db_combo_populated_active_selected(self, dlg):
+        assert dlg._db_combo.count() == 2
+        assert "active" in dlg._db_combo.itemText(0).lower() or dlg._db_combo.currentIndex() == 0
+
+    def test_add_files_dedupes(self, dlg):
+        dlg.add_files([Path("/x/a.gpx"), Path("/y/a.gpx"), Path("/x/b.gpx")])
+        assert len(dlg._selected_paths) == 2  # a.gpx deduped by name
+        assert dlg._import_btn.isEnabled() is True
+
+    def test_browse_adds_files(self, dlg, monkeypatch):
+        monkeypatch.setattr(idlg.QFileDialog, "getOpenFileNames",
+                            lambda *a, **k: (["/d/one.gpx", "/d/two.zip"], "f"))
+        dlg._browse()
+        assert len(dlg._selected_paths) == 2
+        assert dlg._import_btn.isEnabled() is True
+
+    def test_browse_cancel(self, dlg, monkeypatch):
+        monkeypatch.setattr(idlg.QFileDialog, "getOpenFileNames", lambda *a, **k: ([], ""))
+        dlg._browse()
+        assert dlg._selected_paths == []
+
+    def test_remove_selected(self, dlg):
+        dlg.add_files([Path("/a.gpx"), Path("/b.gpx")])
+        dlg._file_list.item(0).setSelected(True)
+        dlg._remove_selected()
+        assert [p.name for p in dlg._selected_paths] == ["b.gpx"]
+
+    def test_selection_toggles_remove_btn(self, dlg):
+        dlg.add_files([Path("/a.gpx")])
+        dlg._file_list.item(0).setSelected(True)
+        dlg._on_selection_changed()
+        assert dlg._remove_btn.isEnabled() is True
+
+    def test_start_import_launches_worker(self, dlg, monkeypatch):
+        dlg.add_files([Path("/a.gpx")])
+        started = []
+
+        class FakeWorker:
+            def __init__(self, paths, target_db_path=None):
+                self.file_started = MagicMock()
+                self.file_finished = MagicMock()
+                self.file_error = MagicMock()
+                self.progress = MagicMock()
+                self.finished = MagicMock()
+                self.deleteLater = MagicMock()
+                self.isRunning = MagicMock(return_value=False)
+                self.wait = MagicMock()
+            def start(self):
+                started.append(True)
+        monkeypatch.setattr(idlg, "ImportWorker", FakeWorker)
+        dlg._start_import()
+        assert started == [True]
+        assert dlg._import_btn.isEnabled() is False
+        assert dlg._worker is not None
+
+    def test_start_import_no_paths_noop(self, dlg):
+        dlg._start_import()  # nothing selected -> early return
+        assert dlg._progress.isVisible() is False
+
+    def test_on_file_started_and_progress(self, dlg):
+        dlg.add_files([Path("/a.gpx")])
+        dlg._on_file_started(0, "a.gpx")
+        assert "🔄" in dlg._file_list.item(0).text()
+        dlg._on_progress(-1)            # saving
+        dlg._on_progress(100)           # progress line
+        dlg._on_progress(50)            # ignored (not multiple of 100)
+        assert dlg._log.toPlainText() != ""
+
+    def test_on_file_finished_marks_success(self, dlg):
+        dlg.add_files([Path("/a.gpx")])
+        dlg._on_file_finished(0, _result(created=2, errors=["e1", "e2"]))
+        assert "✅" in dlg._file_list.item(0).text()
+        assert dlg._any_success is True
+        assert "e1" in dlg._log.toPlainText()
+
+    def test_on_file_error_marks_failure(self, dlg):
+        dlg.add_files([Path("/a.gpx")])
+        dlg._on_file_error(0, "kaboom")
+        assert "❌" in dlg._file_list.item(0).text()
+        assert "kaboom" in dlg._log.toPlainText()
+
+    def test_on_all_done_emits_completed(self, dlg, monkeypatch):
+        from opensak.utils import flags
+        monkeypatch.setattr(flags, "update_location", False, raising=False)
+        dlg.add_files([Path("/a.gpx")])
+        dlg._any_success = True
+        fired = []
+        dlg.import_completed.connect(lambda: fired.append(True))
+        dlg._on_all_done()
+        assert fired == [True]
+        assert dlg._import_btn.isEnabled() is True
+
+    def test_on_all_done_triggers_geocoding(self, dlg, monkeypatch):
+        from opensak.utils import flags
+        monkeypatch.setattr(flags, "update_location", True, raising=False)
+        called = []
+        monkeypatch.setattr(dlg, "_start_geocoding", lambda: called.append(True))
+        dlg._any_success = True
+        dlg._on_all_done()
+        assert called == [True]
+
+    def test_start_geocoding_no_rows_finishes(self, dlg, db_session, monkeypatch):
+        # empty DB -> no rows -> _finish_geocoding
+        finished = []
+        monkeypatch.setattr(dlg, "_finish_geocoding", lambda: finished.append(True))
+        dlg._start_geocoding()
+        assert finished == [True]
+
+    def test_start_geocoding_launches_worker(self, dlg, db_session, make_cache, monkeypatch):
+        c = make_cache(gc_code="GCGEO", country=None, latitude=55.0, longitude=12.0)
+        db_session.add(c)
+        db_session.commit()
+        started = []
+
+        class FakeGeo:
+            def __init__(self, rows):
+                self.all_done = MagicMock()
+                self.cancelled = MagicMock()
+                self.finished = MagicMock()
+                self.deleteLater = MagicMock()
+                self.isRunning = MagicMock(return_value=False)
+                self.wait = MagicMock()
+                self.request_cancel = MagicMock()
+            def start(self):
+                started.append(True)
+        monkeypatch.setattr(
+            "opensak.gui.dialogs.update_location_dialog.ReverseGeocodeWorker", FakeGeo
+        )
+        dlg._start_geocoding()
+        assert started == [True]
+
+    def test_on_geocode_done(self, dlg):
+        fired = []
+        dlg.import_completed.connect(lambda: fired.append(True))
+        dlg._on_geocode_done(SimpleNamespace(updated=3, skipped=1, errors=0))
+        assert fired == [True]
+        assert dlg._import_btn.isEnabled() is True
+
+    def test_close_event_waits_for_workers(self, dlg):
+        dlg._worker = SimpleNamespace(isRunning=lambda: True, wait=MagicMock())
+        dlg._geo_worker = SimpleNamespace(
+            isRunning=lambda: True, request_cancel=MagicMock(), wait=MagicMock()
+        )
+        dlg.close()
+        assert dlg._worker is None
+        assert dlg._geo_worker is None
+
+    def test_log_helpers(self, dlg):
+        dlg._append_log("first")
+        dlg._append_log("second")
+        assert "first" in dlg._log.toPlainText()
+        assert "second" in dlg._log.toPlainText()
+        dlg._replace_last_log_line("replaced")
+        assert "replaced" in dlg._log.toPlainText()

--- a/tests/unit-tests/test_map_widget.py
+++ b/tests/unit-tests/test_map_widget.py
@@ -1,0 +1,337 @@
+"""tests/unit-tests/test_map_widget.py — Leaflet map widget (headless mode)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from opensak.gui import map_widget as mw_mod
+from opensak.gui.map_widget import MapBridge, MapWidget, TileInterceptor, _cache_pin_html
+
+
+# ── fakes / helpers ───────────────────────────────────────────────────────────
+
+class FakePage:
+    """Records runJavaScript / setHtml; fires JS callbacks as if Leaflet is up."""
+
+    def __init__(self):
+        self.js = []
+        self.html = None
+
+    def runJavaScript(self, js, cb=None):
+        self.js.append(js)
+        if cb is not None:
+            cb(True)
+
+    def setHtml(self, html, url=None):
+        self.html = html
+
+
+def _note(corrected=False):
+    return SimpleNamespace(is_corrected=corrected, corrected_lat=55.1, corrected_lon=12.1)
+
+
+def _cache(**kw):
+    d = dict(gc_code="GC1", name="Name", cache_type="Traditional Cache",
+             difficulty=1.5, terrain=2.0, latitude=55.0, longitude=12.0,
+             found=False, user_note=None)
+    d.update(kw)
+    return SimpleNamespace(**d)
+
+
+@pytest.fixture
+def fake_settings(monkeypatch):
+    s = SimpleNamespace(home_lat=55.0, home_lon=12.0, active_home_name="Home")
+    monkeypatch.setattr("opensak.gui.settings.get_settings", lambda: s)
+    return s
+
+
+# ── TileInterceptor ───────────────────────────────────────────────────────────
+
+class TestTileInterceptor:
+    def test_sets_referer_for_osm(self):
+        captured = []
+
+        class Info:
+            def requestUrl(self):
+                return SimpleNamespace(
+                    toString=lambda: "https://tile.openstreetmap.org/1/2/3.png")
+
+            def setHttpHeader(self, k, v):
+                captured.append((k, v))
+
+        TileInterceptor().interceptRequest(Info())
+        assert captured == [(b"Referer", b"https://www.openstreetmap.org/")]
+
+    def test_ignores_other_urls(self):
+        captured = []
+
+        class Info:
+            def requestUrl(self):
+                return SimpleNamespace(toString=lambda: "https://example.com/x.png")
+
+            def setHttpHeader(self, k, v):
+                captured.append((k, v))
+
+        TileInterceptor().interceptRequest(Info())
+        assert captured == []
+
+
+# ── module helpers ────────────────────────────────────────────────────────────
+
+def test_cache_pin_html():
+    html = _cache_pin_html("Traditional Cache", False)
+    assert "data:image/svg+xml;base64," in html
+
+
+# ── MapBridge ─────────────────────────────────────────────────────────────────
+
+def test_bridge_emits(qapp):
+    bridge = MapBridge()
+    got = []
+    bridge.cache_clicked.connect(got.append)
+    bridge.on_cache_clicked("GC123")
+    assert got == ["GC123"]
+
+
+# ── MapWidget headless construction ───────────────────────────────────────────
+
+class TestConstruction:
+    def test_headless_no_webengine(self, qtbot):
+        w = MapWidget()
+        qtbot.addWidget(w)
+        assert w._page is None
+        assert w.is_ready() is False
+
+    def test_bridge_wired_to_signal(self, qtbot):
+        w = MapWidget()
+        qtbot.addWidget(w)
+        got = []
+        w.cache_selected.connect(got.append)
+        w._bridge.on_cache_clicked("GC9")
+        assert got == ["GC9"]
+
+    def test_run_js_noop_when_headless(self, qtbot):
+        w = MapWidget()
+        qtbot.addWidget(w)
+        w._run_js("doStuff()")  # no page → no crash
+
+
+# ── load_caches / _do_load_caches ─────────────────────────────────────────────
+
+class TestLoadCaches:
+    @pytest.fixture
+    def w(self, qtbot):
+        widget = MapWidget()
+        qtbot.addWidget(widget)
+        return widget
+
+    def test_not_ready_defers(self, w):
+        caches = [_cache()]
+        w.load_caches(caches)
+        assert w._pending_caches == caches
+        assert w._caches == caches
+
+    def test_ready_loads_immediately(self, w):
+        w._ready = True
+        w._page = FakePage()
+        w.load_caches([_cache()])
+        assert w._pending_caches is None
+        assert any("loadCaches" in js for js in w._page.js)
+
+    def test_do_load_skips_missing_coords_and_handles_corrected(self, w):
+        w._page = FakePage()
+        caches = [
+            _cache(gc_code="GC_NONE", latitude=None),
+            _cache(gc_code="GC_OK", found=True, user_note=_note(corrected=True)),
+        ]
+        w._do_load_caches(caches)
+        assert any("GC_OK" in js for js in w._page.js)
+        assert all("GC_NONE" not in js for js in w._page.js)
+
+
+# ── ready-guarded JS methods ──────────────────────────────────────────────────
+
+class TestJsMethods:
+    @pytest.fixture
+    def w(self, qtbot, fake_settings):
+        widget = MapWidget()
+        qtbot.addWidget(widget)
+        widget._ready = True
+        widget._page = FakePage()
+        return widget
+
+    def test_pan_to_cache(self, w):
+        w.pan_to_cache("GC'1")
+        assert any("panToCache" in js for js in w._page.js)
+
+    def test_fit_all(self, w):
+        w.fit_all()
+        assert w._page.js == ["fitAllMarkers()"]
+
+    def test_update_cache(self, w):
+        w.update_cache(_cache(user_note=_note(corrected=True)))
+        assert any("updateCacheMarker" in js for js in w._page.js)
+
+    def test_pan_to_location(self, w):
+        w.pan_to_location(1.0, 2.0, "Spot")
+        assert any("setHomeLocation" in js for js in w._page.js)
+        assert any("panToHome" in js for js in w._page.js)
+
+    def test_pan_to_home(self, w):
+        w.pan_to_home()
+        assert w._page.js == ["panToHome()"]
+
+    def test_update_home(self, w):
+        w.update_home()
+        assert any("setHomeLocation" in js for js in w._page.js)
+
+    def test_methods_noop_when_not_ready(self, qtbot):
+        widget = MapWidget()
+        qtbot.addWidget(widget)
+        widget._page = FakePage()  # but _ready stays False
+        widget.pan_to_cache("GC1")
+        widget.fit_all()
+        widget.update_cache(_cache())
+        widget.pan_to_home()
+        assert widget._page.js == []
+
+
+# ── lifecycle: load finished / leaflet ready / reload / cleanup ────────────────
+
+class TestLifecycle:
+    @pytest.fixture
+    def w(self, qtbot, fake_settings):
+        widget = MapWidget()
+        qtbot.addWidget(widget)
+        return widget
+
+    def test_on_load_finished_not_ok(self, w):
+        w._page = FakePage()
+        w._on_load_finished(False)
+        assert w._page.js == []
+
+    def test_on_load_finished_drives_ready(self, w):
+        w._page = FakePage()
+        pending = []
+        w._pending_caches = [_cache()]
+        w._pending_refresh = lambda: pending.append("refreshed")
+        w._on_load_finished(True)
+        assert w._ready is True
+        assert pending == ["refreshed"]
+        assert w._pending_caches is None
+
+    def test_on_leaflet_ready_false(self, w):
+        w._page = FakePage()
+        w._on_leaflet_ready(False)
+        assert w._ready is False
+
+    def test_on_leaflet_ready_already_ready(self, w):
+        w._page = FakePage()
+        w._ready = True
+        w._on_leaflet_ready(True)  # returns early, no crash
+
+    def test_reload_map_headless_returns(self, w):
+        cb = lambda: None
+        w.reload_map(cb)  # page is None
+        assert w._pending_refresh is cb
+
+    def test_reload_map_with_page(self, w):
+        w._page = FakePage()
+        w._ready = True
+        w.reload_map()
+        assert w._ready is False
+        assert w._page.html is not None
+
+    def test_set_pending_refresh(self, w):
+        cb = lambda: None
+        w.set_pending_refresh(cb)
+        assert w._pending_refresh is cb
+
+
+class TestProductionSetup:
+    """Cover the real-WebEngine wiring without spawning Chromium."""
+
+    def test_setup_with_fake_webengine(self, qtbot, fake_settings, monkeypatch):
+        from PySide6.QtWidgets import QWidget
+
+        class FakeView(QWidget):
+            def setPage(self, p):
+                self._p = p
+
+        class FakeProfile:
+            def setUrlRequestInterceptor(self, i):
+                self.i = i
+
+        class FakeProdPage:
+            def __init__(self, profile=None):
+                self.loadFinished = SimpleNamespace(connect=lambda cb: None)
+                self.html = None
+
+            def setWebChannel(self, c):
+                self.channel = c
+
+            def setHtml(self, html, url=None):
+                self.html = html
+
+            def runJavaScript(self, *a, **k):
+                pass
+
+        class FakeChannel:
+            def registerObject(self, name, obj):
+                self.obj = obj
+
+        monkeypatch.setattr("opensak.gui._headless.webengine_disabled", lambda: False)
+        monkeypatch.setattr(mw_mod, "QWebEngineProfile", FakeProfile)
+        monkeypatch.setattr(mw_mod, "QWebEnginePage", FakeProdPage)
+        monkeypatch.setattr(mw_mod, "QWebEngineView", FakeView)
+        monkeypatch.setattr(mw_mod, "QWebChannel", FakeChannel)
+
+        w = MapWidget()
+        qtbot.addWidget(w)
+        assert w._page is not None
+        assert isinstance(w._view, FakeView)
+        assert w._page.html is not None  # setHtml was called
+
+
+class TestCleanup:
+    def test_cleanup_headless_noop(self, qtbot):
+        w = MapWidget()
+        qtbot.addWidget(w)
+        w._cleanup_webengine()  # page None → early return
+        assert w._cleaned is False
+
+    def test_cleanup_deletes_page_then_profile(self, qtbot):
+        w = MapWidget()
+        qtbot.addWidget(w)
+        order = []
+        w._page = SimpleNamespace(deleteLater=lambda: order.append("page"))
+        w._profile = SimpleNamespace(deleteLater=lambda: order.append("profile"))
+        w._view = SimpleNamespace(setPage=lambda p: order.append(("setPage", p)))
+        w._cleanup_webengine()
+        assert w._cleaned is True
+        assert order == [("setPage", None), "page", "profile"]
+
+    def test_cleanup_idempotent(self, qtbot):
+        w = MapWidget()
+        qtbot.addWidget(w)
+        w._page = SimpleNamespace(deleteLater=lambda: None)
+        w._profile = SimpleNamespace(deleteLater=lambda: None)
+        w._view = SimpleNamespace(setPage=lambda p: None)
+        w._cleanup_webengine()
+        w._cleanup_webengine()  # second call short-circuits
+        assert w._cleaned is True
+
+    def test_cleanup_swallows_runtime_error(self, qtbot):
+        w = MapWidget()
+        qtbot.addWidget(w)
+
+        def boom(p):
+            raise RuntimeError("deleted")
+
+        w._page = SimpleNamespace(deleteLater=lambda: None)
+        w._profile = SimpleNamespace(deleteLater=lambda: None)
+        w._view = SimpleNamespace(setPage=boom)
+        w._cleanup_webengine()  # RuntimeError caught
+        assert w._cleaned is True

--- a/tests/unit-tests/test_settings_dialog.py
+++ b/tests/unit-tests/test_settings_dialog.py
@@ -27,6 +27,9 @@ def settings(tmp_path, monkeypatch):
     QSettings.setDefaultFormat(QSettings.Format.IniFormat)
     QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(tmp_path))
     s = AppSettings()
+    # setPath alone does not reliably redirect the 2-arg QSettings on macOS, so
+    # bind AppSettings to an explicit temp INI — keeps the real user settings clean.
+    s._s = QSettings(str(tmp_path / "settings.ini"), QSettings.Format.IniFormat)
     monkeypatch.setattr(sd, "get_settings", lambda: s)
     monkeypatch.setattr("opensak.gui.settings.get_settings", lambda: s)
 

--- a/tests/unit-tests/test_settings_dialog.py
+++ b/tests/unit-tests/test_settings_dialog.py
@@ -219,6 +219,15 @@ class TestHomePoints:
         dlg._save_home_location()
         assert settings.gc_home_location == ""
 
+    def test_save_home_location_invalid_warns_and_keeps(self, dlg, settings, monkeypatch):
+        settings.gc_home_location = _VALID
+        warn = MagicMock()
+        monkeypatch.setattr("opensak.gui.icon.OpenSAKMessageBox.warning", warn)
+        dlg._gc_home_location.setText("garbage")
+        dlg._save_home_location()
+        warn.assert_called_once()
+        assert settings.gc_home_location == _VALID  # unchanged
+
 
 # ── theme ─────────────────────────────────────────────────────────────────────
 
@@ -302,3 +311,15 @@ class TestSave:
         assert settings.gc_username == "tester"
         assert settings.use_miles is True
         assert dlg.result() == QDialog.DialogCode.Accepted
+
+    def test_save_keeps_existing_home_when_invalid(self, dlg, settings):
+        settings.gc_home_location = _VALID
+        dlg._gc_home_location.setText("garbage")
+        dlg._save()
+        assert settings.gc_home_location == _VALID  # invalid ignored
+
+    def test_save_clears_home_when_empty(self, dlg, settings):
+        settings.gc_home_location = _VALID
+        dlg._gc_home_location.setText("")
+        dlg._save()
+        assert settings.gc_home_location == ""

--- a/tests/unit-tests/test_theme.py
+++ b/tests/unit-tests/test_theme.py
@@ -1,0 +1,161 @@
+"""tests/unit-tests/test_theme.py — cross-platform theme management."""
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtGui import QPalette
+from PySide6.QtWidgets import QApplication
+
+from opensak.gui import theme
+
+
+# ── palettes ───────────────────────────────────────────────────────────────────
+
+def test_light_palette_window_is_light():
+    p = theme._light_palette()
+    assert isinstance(p, QPalette)
+    assert p.color(QPalette.ColorRole.Window).lightness() > 200
+
+
+def test_dark_palette_window_is_dark():
+    p = theme._dark_palette()
+    assert isinstance(p, QPalette)
+    assert p.color(QPalette.ColorRole.Window).lightness() < 100
+
+
+# ── system dark detection ───────────────────────────────────────────────────────
+
+class TestSystemIsDark:
+    def test_macos_dark(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Darwin")
+        import subprocess
+        from types import SimpleNamespace
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: SimpleNamespace(stdout="Dark\n")
+        )
+        assert theme._system_is_dark() is True
+
+    def test_macos_light(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Darwin")
+        import subprocess
+        from types import SimpleNamespace
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: SimpleNamespace(stdout="")
+        )
+        assert theme._system_is_dark() is False
+
+    def test_macos_subprocess_failure(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Darwin")
+        import subprocess
+        def boom(*a, **k):
+            raise OSError("no defaults")
+        monkeypatch.setattr(subprocess, "run", boom)
+        assert theme._system_is_dark() is False
+
+    def test_linux_gtk_theme_dark(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Linux")
+        monkeypatch.setenv("GTK_THEME", "Adwaita-dark")
+        assert theme._system_is_dark() is True
+
+    def test_linux_portal_dark(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Linux")
+        monkeypatch.delenv("GTK_THEME", raising=False)
+        monkeypatch.delenv("DESKTOP_SESSION", raising=False)
+        import subprocess
+        from types import SimpleNamespace
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **k: SimpleNamespace(stdout="(<<uint32 1>>,)"),
+        )
+        assert theme._system_is_dark() is True
+
+    def test_linux_default_light(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Linux")
+        monkeypatch.delenv("GTK_THEME", raising=False)
+        monkeypatch.delenv("DESKTOP_SESSION", raising=False)
+        import subprocess
+        def boom(*a, **k):
+            raise OSError("no gdbus")
+        monkeypatch.setattr(subprocess, "run", boom)
+        assert theme._system_is_dark() is False
+
+
+# ── default font ────────────────────────────────────────────────────────────────
+
+class TestDefaultFont:
+    def test_macos(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Darwin")
+        assert theme._default_font().family() == "SF Pro Text"
+
+    def test_windows(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Windows")
+        assert theme._default_font().family() == "Segoe UI"
+
+    def test_linux(self, monkeypatch):
+        monkeypatch.setattr(theme.platform, "system", lambda: "Linux")
+        assert theme._default_font().family() == "Ubuntu"
+
+
+# ── apply_theme ─────────────────────────────────────────────────────────────────
+
+class TestApplyTheme:
+    def test_light(self, qapp):
+        theme.apply_theme(qapp, "light")
+        assert qapp.style().objectName().lower() == "fusion"
+        assert qapp.palette().color(QPalette.ColorRole.Window).lightness() > 200
+
+    def test_dark(self, qapp):
+        theme.apply_theme(qapp, "dark")
+        assert qapp.palette().color(QPalette.ColorRole.Window).lightness() < 100
+
+    def test_auto_uses_system(self, qapp, monkeypatch):
+        monkeypatch.setattr(theme, "_system_is_dark", lambda: True)
+        theme.apply_theme(qapp, "auto")
+        assert qapp.palette().color(QPalette.ColorRole.Window).lightness() < 100
+
+    def test_none_reads_settings(self, qapp, monkeypatch):
+        from types import SimpleNamespace
+        monkeypatch.setattr(
+            "opensak.gui.settings.get_settings",
+            lambda: SimpleNamespace(theme="light"),
+        )
+        theme.apply_theme(qapp, None)
+        assert qapp.palette().color(QPalette.ColorRole.Window).lightness() > 200
+
+    def test_none_settings_failure_falls_back_auto(self, qapp, monkeypatch):
+        def boom():
+            raise RuntimeError("no settings")
+        monkeypatch.setattr("opensak.gui.settings.get_settings", boom)
+        monkeypatch.setattr(theme, "_system_is_dark", lambda: False)
+        theme.apply_theme(qapp, None)  # should not raise
+        assert qapp.palette().color(QPalette.ColorRole.Window).lightness() > 200
+
+    def test_repaints_existing_top_level_widgets(self, qtbot, qapp):
+        from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel
+        w = QWidget()
+        QVBoxLayout(w).addWidget(QLabel("child"))
+        qtbot.addWidget(w)
+        theme.apply_theme(qapp, "dark")
+        assert w.palette().color(QPalette.ColorRole.Window).lightness() < 100
+
+
+# ── effective_theme ─────────────────────────────────────────────────────────────
+
+class TestEffectiveTheme:
+    def test_explicit_light(self):
+        assert theme.effective_theme("light") == "light"
+
+    def test_explicit_dark(self):
+        assert theme.effective_theme("dark") == "dark"
+
+    def test_invalid_defaults_light(self):
+        assert theme.effective_theme("weird") == "light"
+
+    def test_auto_dark(self, monkeypatch):
+        monkeypatch.setattr(theme, "_system_is_dark", lambda: True)
+        assert theme.effective_theme("auto") == "dark"
+
+    def test_auto_light(self, monkeypatch):
+        monkeypatch.setattr(theme, "_system_is_dark", lambda: False)
+        assert theme.effective_theme("auto") == "light"

--- a/tests/unit-tests/test_trip_dialog.py
+++ b/tests/unit-tests/test_trip_dialog.py
@@ -1,0 +1,331 @@
+"""tests/unit-tests/test_trip_dialog.py — trip planner geometry, dialog, map preview."""
+
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtWidgets import QInputDialog, QFileDialog
+
+from opensak.gui.dialogs import trip_dialog as td
+from opensak.gui.dialogs.trip_dialog import (
+    TripPlannerDialog,
+    TripMapPreviewDialog,
+    _dist_to_segment_km,
+    _dist_to_route_km,
+    _position_along_route,
+)
+from opensak.db.models import Cache
+from opensak.utils.types import CoordFormat
+
+_VALID = "N55 47.250 E012 25.000"
+
+
+def _c(gc="GC1", lat=55.01, lon=12.01, found=False, available=True,
+       archived=False, diff=2.0, terr=3.0, name="N", ctype="Traditional Cache",
+       hidden=None):
+    return SimpleNamespace(
+        gc_code=gc, name=name, cache_type=ctype, latitude=lat, longitude=lon,
+        found=found, available=available, archived=archived,
+        difficulty=diff, terrain=terr, hidden_date=hidden,
+    )
+
+
+# ── geometry helpers ────────────────────────────────────────────────────────────
+
+class TestGeometry:
+    def test_dist_to_segment_endpoint(self):
+        # P == A -> distance 0
+        assert _dist_to_segment_km(55, 12, 55, 12, 56, 13) == pytest.approx(0, abs=0.5)
+
+    def test_dist_to_segment_off_line(self):
+        d = _dist_to_segment_km(55.1, 12.0, 55.0, 12.0, 55.0, 13.0)
+        assert d > 1.0
+
+    def test_dist_to_segment_degenerate(self):
+        # A == B -> falls back to point distance
+        d = _dist_to_segment_km(55.0, 12.0, 55.0, 12.0, 55.0, 12.0)
+        assert d == pytest.approx(0, abs=0.01)
+
+    def test_dist_to_route_single_waypoint(self):
+        d = _dist_to_route_km(55.0, 12.0, [(55.0, 12.0)])
+        assert d == pytest.approx(0, abs=0.01)
+
+    def test_dist_to_route_multi(self):
+        d = _dist_to_route_km(55.05, 12.0, [(55.0, 12.0), (55.0, 13.0)])
+        assert d > 0
+
+    def test_position_along_route_single(self):
+        assert _position_along_route(55.0, 12.0, [(55.0, 12.0)]) == 0.0
+
+    def test_position_along_route_multi(self):
+        pos = _position_along_route(55.0, 12.5, [(55.0, 12.0), (55.0, 13.0)])
+        assert pos > 0
+
+
+# ── dialog ──────────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _clean_trip_win():
+    # _open_map_preview stores the preview window on the global QApplication;
+    # drop it between tests so a leaked stub can't break the next _update_preview.
+    yield
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is not None and hasattr(app, "_trip_map_win"):
+        del app._trip_map_win
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    s = SimpleNamespace(home_lat=55.0, home_lon=12.0, use_miles=False,
+                        coord_format=CoordFormat.DMM, home_points=[])
+    monkeypatch.setattr(td, "get_settings", lambda: s)
+    return s
+
+
+@pytest.fixture
+def warn(monkeypatch):
+    m = MagicMock()
+    monkeypatch.setattr(td.QMessageBox, "warning", m)
+    return m
+
+
+@pytest.fixture
+def dlg(qtbot, settings):
+    d = TripPlannerDialog(caches=[_c("GCA"), _c("GCB", lat=55.5, lon=12.5)])
+    qtbot.addWidget(d)
+    return d
+
+
+class TestConstruction:
+    def test_two_tabs_and_preview(self, dlg):
+        assert dlg._tabs.count() == 2
+        # radius tab default radius=0 -> all caches in preview
+        assert dlg._table.rowCount() == 2
+
+
+class TestRadiusCompute:
+    def test_radius_zero_returns_all(self, dlg):
+        caches, dist_map, warning = dlg._compute_radius()
+        assert warning == ""
+        assert len(caches) == 2
+
+    def test_radius_filters_by_distance(self, dlg):
+        dlg._spin_radius.setValue(5.0)  # km
+        caches, _, warning = dlg._compute_radius()
+        assert warning == ""
+        assert all(c.gc_code == "GCA" for c in caches)  # only the near one
+
+    def test_radius_warns_without_center(self, dlg, settings):
+        settings.home_lat = 0.0
+        settings.home_lon = 0.0
+        dlg._spin_radius.setValue(10.0)
+        _, _, warning = dlg._compute_radius()
+        assert warning != ""
+
+    def test_sort_options(self, dlg):
+        for key in ("distance", "difficulty", "terrain", "hidden_date", "name"):
+            idx = dlg._combo_sort.findData(key)
+            dlg._combo_sort.setCurrentIndex(idx)
+            caches, _, _ = dlg._compute_radius()
+            assert isinstance(caches, list)
+
+    def test_base_filter_excludes_found_archived(self, dlg):
+        dlg._all_caches = [
+            _c("OK"), _c("FOUND", found=True), _c("ARCH", archived=True),
+            _c("UNAVAIL", available=False),
+        ]
+        caches, _, _ = dlg._compute_radius()
+        assert [c.gc_code for c in caches] == ["OK"]
+
+
+class TestRouteCompute:
+    def test_no_points_warns(self, dlg):
+        dlg._tabs.setCurrentIndex(1)
+        caches, _, warning = dlg._compute_route()
+        assert caches == [] and warning != ""
+
+    def test_route_filters_corridor(self, dlg):
+        dlg._route_points = [("A", 55.0, 12.0), ("B", 55.0, 13.0)]
+        dlg._spin_corridor.setValue(3.0)
+        caches, dist_map, warning = dlg._compute_route()
+        assert warning == ""
+        assert isinstance(caches, list)
+
+
+class TestRoutePoints:
+    def test_coord_feedback(self, dlg):
+        dlg._on_pt_coord_changed(_VALID)
+        assert "✓" in dlg._pt_hint.text()
+        dlg._on_pt_coord_changed("garbage")
+        assert dlg._pt_hint.text() != ""
+        dlg._on_pt_coord_changed("")
+        assert dlg._pt_hint.text() == ""
+
+    def test_add_point_requires_coord(self, dlg, warn):
+        dlg._pt_coord.setText("")
+        dlg._add_route_point()
+        warn.assert_called_once()
+
+    def test_add_point_rejects_bad_coord(self, dlg, warn):
+        dlg._pt_coord.setText("garbage")
+        dlg._add_route_point()
+        warn.assert_called_once()
+
+    def test_add_point_valid_autonames(self, dlg):
+        dlg._pt_coord.setText(_VALID)
+        dlg._add_route_point()
+        assert len(dlg._route_points) == 1
+        assert dlg._route_points[0][0] == "A"  # auto-named
+
+    def test_add_point_max_reached(self, dlg, warn):
+        dlg._route_points = [("x", 1.0, 2.0)] * dlg.MAX_ROUTE_POINTS
+        dlg._pt_coord.setText(_VALID)
+        dlg._add_route_point()
+        warn.assert_called_once()
+
+    def test_add_from_home_no_points(self, dlg, settings, monkeypatch):
+        info = MagicMock()
+        monkeypatch.setattr(td.QMessageBox, "information", info)
+        settings.home_points = []
+        dlg._add_from_home_points()
+        info.assert_called_once()
+
+    def test_add_from_home_picks(self, dlg, settings, monkeypatch):
+        settings.home_points = [SimpleNamespace(name="Home", lat=55.0, lon=12.0)]
+        monkeypatch.setattr(QInputDialog, "getItem", lambda *a, **k: ("Home", True))
+        dlg._add_from_home_points()
+        assert dlg._route_points[-1][0] == "Home"
+
+    def test_add_from_home_max_reached(self, dlg, settings, warn):
+        dlg._route_points = [("x", 1.0, 2.0)] * dlg.MAX_ROUTE_POINTS
+        dlg._add_from_home_points()
+        warn.assert_called_once()
+
+    def test_move_delete_clear(self, dlg):
+        dlg._route_points = [("A", 1.0, 1.0), ("B", 2.0, 2.0), ("C", 3.0, 3.0)]
+        dlg._refresh_route_list()
+        dlg._route_list.setCurrentRow(2)
+        dlg._move_point_up()
+        assert dlg._route_points[1][0] == "C"
+        dlg._route_list.setCurrentRow(0)
+        dlg._move_point_down()
+        assert dlg._route_points[0][0] != "A" or dlg._route_points[1][0] == "A"
+        dlg._route_list.setCurrentRow(0)
+        dlg._delete_point()
+        assert len(dlg._route_points) == 2
+        dlg._clear_points()
+        assert dlg._route_points == []
+
+    def test_route_reordered_triggers_preview(self, dlg, monkeypatch):
+        called = []
+        monkeypatch.setattr(dlg, "_update_preview", lambda: called.append(True))
+        dlg._on_route_reordered()
+        assert called == [True]
+
+
+class TestExport:
+    def test_export_gps_no_caches(self, dlg):
+        dlg._selected_caches = []
+        dlg._export_to_gps()  # early return, no crash
+
+    def test_export_gps_opens_dialog(self, dlg, monkeypatch):
+        opened = []
+
+        class FakeGps:
+            def __init__(self, parent, caches=None):
+                opened.append(caches)
+            def exec(self):
+                return 0
+        monkeypatch.setattr("opensak.gui.dialogs.gps_dialog.GpsExportDialog", FakeGps)
+        dlg._selected_caches = [_c("X")]
+        dlg._export_to_gps()
+        assert opened
+
+    def test_export_file_success(self, dlg, monkeypatch, tmp_path):
+        monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                            lambda *a, **k: (str(tmp_path / "t.gpx"), "f"))
+        monkeypatch.setattr("opensak.gps.garmin.export_to_file", lambda c, p: "ok")
+        info = MagicMock()
+        monkeypatch.setattr(td.QMessageBox, "information", info)
+        dlg._selected_caches = [_c("X")]
+        dlg._export_to_file()
+        info.assert_called_once()
+
+    def test_export_file_cancel(self, dlg, monkeypatch):
+        monkeypatch.setattr(QFileDialog, "getSaveFileName", lambda *a, **k: ("", ""))
+        dlg._selected_caches = [_c("X")]
+        dlg._export_to_file()  # cancelled, no crash
+
+    def test_export_file_error(self, dlg, monkeypatch, tmp_path):
+        monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                            lambda *a, **k: (str(tmp_path / "t.gpx"), "f"))
+        monkeypatch.setattr("opensak.gps.garmin.export_to_file",
+                            lambda c, p: (_ for _ in ()).throw(RuntimeError("io")))
+        crit = MagicMock()
+        monkeypatch.setattr(td.QMessageBox, "critical", crit)
+        dlg._selected_caches = [_c("X")]
+        dlg._export_to_file()
+        crit.assert_called_once()
+
+    def test_save_to_database_new(self, dlg, monkeypatch, tmp_path):
+        monkeypatch.setattr(QInputDialog, "getItem",
+                            lambda *a, **k: (td.tr("trip_db_choice_new"), True))
+        monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                            lambda *a, **k: (str(tmp_path / "trip.db"), "f"))
+        monkeypatch.setattr("opensak.db.manager.get_db_manager",
+                            lambda: (_ for _ in ()).throw(RuntimeError("none")))
+        info = MagicMock()
+        monkeypatch.setattr(td.QMessageBox, "information", info)
+        dlg._selected_caches = [Cache(gc_code="GCSAVE", name="Save Me",
+                                      latitude=55.0, longitude=12.0,
+                                      cache_type="Traditional Cache")]
+        dlg._save_to_database()
+        info.assert_called_once()
+        assert (tmp_path / "trip.db").exists()
+
+    def test_save_to_database_cancel_choice(self, dlg, monkeypatch):
+        monkeypatch.setattr(QInputDialog, "getItem", lambda *a, **k: ("", False))
+        dlg._selected_caches = [_c("X")]
+        dlg._save_to_database()  # cancelled before any file IO
+
+
+class TestMapPreview:
+    def test_open_map_preview_no_caches(self, dlg):
+        dlg._selected_caches = []
+        dlg._open_map_preview()  # early return
+
+    def test_open_map_preview_shows_window(self, dlg, monkeypatch):
+        shown = []
+
+        class FakeWin:
+            def __init__(self, caches):
+                shown.append(caches)
+            def show(self): pass
+            def raise_(self): pass
+            def activateWindow(self): pass
+        monkeypatch.setattr(td, "TripMapPreviewDialog", FakeWin)
+        dlg._selected_caches = [_c("X")]
+        dlg._open_map_preview()
+        assert shown
+
+    def test_update_preview_updates_open_window(self, dlg, monkeypatch):
+        from PySide6.QtWidgets import QApplication
+        updated = []
+        win = SimpleNamespace(isVisible=lambda: True,
+                              update_caches=lambda c: updated.append(c))
+        QApplication.instance()._trip_map_win = win
+        dlg._tabs.setCurrentIndex(0)
+        dlg._update_preview()
+        assert updated  # window refreshed with selected caches
+        del QApplication.instance()._trip_map_win
+
+    def test_preview_dialog_construct_and_update(self, qtbot, settings):
+        win = TripMapPreviewDialog([_c("A")])
+        qtbot.addWidget(win)
+        assert "1" in win._info_lbl.text() or win._info_lbl.text()
+        win.update_caches([_c("A"), _c("B")])
+        assert win._caches == win._caches  # no crash; caches replaced


### PR DESCRIPTION
Third phase of the #225 test-coverage initiative. Brings the largest and least-tested
GUI modules up to high coverage and fixes three real bugs found while writing the tests.

Overall project coverage is now **93%**.

### Coverage gains

| Module | Before | After |
|---|---|---|
| `gui/mainwindow.py` | 62% | **98%** |
| `gui/cache_table.py` | 51% | 97% |
| `gui/theme.py` | 18% | 93% |
| `gui/settings.py` | 79% | 100% |
| `gui/icon.py` | 26% | 100% |
| `gui/icon_provider.py` | 43% | 100% |
| `gui/map_widget.py` | 41% | 100% |
| `gui/dialogs/filter_dialog.py` | — | 95% |
| `gui/dialogs/trip_dialog.py` | 54% | 98% |
| `gui/dialogs/import_dialog.py` | 55% | 97% |
| `gui/dialogs/database_dialog.py` | 49% | 96% |
| `gui/dialogs/gps_dialog.py` | 72% | 100% |
| `gui/dialogs/settings_dialog.py` | 93% | 93% |

### Bug fixes (not just tests)

- **`settings_dialog.py`** — home coordinates were "validated" inside a `try/except`,
  but `parse_coords()` returns `None` for bad input and never raises, so invalid text
  was saved and the warning branch was dead. Now validated via the return value.
- **`filter_dialog.py`** — loading a saved filter set with OR-mode attribute filters
  crashed with `AttributeError`: it set `self._attr_mode_any`, a widget that never
  existed. The UI only has the "all selected" checkbox, so OR-mode now unchecks it.
- **`settings.py`** — removed a duplicate dead `is_setup_complete` method shadowed by
  an identical later definition.
