### PR TITLE
Test Coverage - Phase 4

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,22 @@
+# Coverage configuration for OpenSAK (#225).
+#
+# Literal 100% is not a sensible target for a PySide6 desktop app: the
+# QApplication event loop, OS-native dialogs and the QtWebEngine paths
+# (disabled under test) are not meaningfully testable. This file excludes the
+# lines that legitimately cannot or should not be covered so the reported
+# number reflects real, testable code.
+
+[run]
+branch = false
+omit =
+    */tests/*
+
+[report]
+show_missing = true
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    raise NotImplementedError
+    @(abc\.)?abstractmethod
+    \.\.\.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,14 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-qt
+          pip install pytest pytest-qt pytest-cov
 
       - name: Run unit tests
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
           source .venv/bin/activate
-          pytest tests/unit-tests -v
+          pytest tests/unit-tests -v --cov=opensak --cov-report=term-missing
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-qt
+          pip install pytest pytest-qt pytest-cov
 
       - name: Run e2e tests
         env:
@@ -85,4 +85,4 @@ jobs:
         run: |
           source .venv/bin/activate
           xvfb-run -a --server-args="-screen 0 1280x1024x24" \
-            pytest tests/e2e-tests -v
+            pytest tests/e2e-tests -v --cov=opensak --cov-report=term-missing

--- a/tests/unit-tests/test_app.py
+++ b/tests/unit-tests/test_app.py
@@ -1,0 +1,161 @@
+"""tests/unit-tests/test_app.py — application bootstrap (app.py)."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from PySide6.QtWidgets import QSplashScreen
+
+import opensak.app as appmod
+
+
+# ── _migrate_legacy_db ────────────────────────────────────────────────────────
+
+class TestMigrateLegacyDb:
+    @pytest.fixture
+    def app_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("opensak.config.get_app_data_dir", lambda: tmp_path)
+        return tmp_path
+
+    def test_legacy_only_renamed(self, app_dir):
+        (app_dir / "opensak.db").write_text("data")
+        appmod._migrate_legacy_db()
+        assert not (app_dir / "opensak.db").exists()
+        assert (app_dir / "Default.db").read_text() == "data"
+
+    def test_both_legacy_bigger_replaces_default(self, app_dir):
+        (app_dir / "opensak.db").write_text("lots of data here")
+        (app_dir / "Default.db").write_text("x")
+        (app_dir / "Default.db-wal").write_text("w")
+        (app_dir / "Default.db-shm").write_text("s")
+        appmod._migrate_legacy_db()
+        assert not (app_dir / "opensak.db").exists()
+        assert (app_dir / "Default.db").read_text() == "lots of data here"
+        assert not (app_dir / "Default.db-wal").exists()
+
+    def test_both_default_bigger_deletes_legacy(self, app_dir):
+        (app_dir / "opensak.db").write_text("x")
+        (app_dir / "opensak.db-wal").write_text("w")
+        (app_dir / "Default.db").write_text("lots of data here")
+        appmod._migrate_legacy_db()
+        assert not (app_dir / "opensak.db").exists()
+        assert not (app_dir / "opensak.db-wal").exists()
+        assert (app_dir / "Default.db").read_text() == "lots of data here"
+
+    def test_default_only_noop(self, app_dir):
+        (app_dir / "Default.db").write_text("data")
+        appmod._migrate_legacy_db()
+        assert (app_dir / "Default.db").read_text() == "data"
+
+    def test_neither_noop(self, app_dir):
+        appmod._migrate_legacy_db()  # nothing to do, no crash
+
+
+# ── _make_splash ──────────────────────────────────────────────────────────────
+
+def test_make_splash(qapp):
+    splash = appmod._make_splash(qapp)
+    try:
+        assert isinstance(splash, QSplashScreen)
+        assert not splash.pixmap().isNull()
+    finally:
+        splash.close()
+
+
+# ── _apply_version_override ───────────────────────────────────────────────────
+
+class TestVersionOverride:
+    def test_no_version_arg_returns(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["opensak"])
+        assert appmod._apply_version_override() is None
+
+    def test_plain_version_prints_and_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["opensak", "--version"])
+        with pytest.raises(SystemExit) as exc:
+            appmod._apply_version_override()
+        assert exc.value.code == 0
+        import opensak
+        assert opensak.__version__ in capsys.readouterr().out
+
+    def test_version_x_not_in_git_repo(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["opensak", "--version=1.2.3"])
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr=""))
+        with pytest.raises(SystemExit) as exc:
+            appmod._apply_version_override()
+        assert exc.value.code == 1
+
+    def test_version_x_tag_not_found(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["opensak", "--version=1.2.3"])
+
+        def fake_run(cmd, *a, **k):
+            if "rev-parse" in cmd:
+                return SimpleNamespace(returncode=0, stdout="/repo\n", stderr="")
+            if "tag" in cmd:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")  # no tag
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        monkeypatch.setattr("subprocess.run", fake_run)
+        with pytest.raises(SystemExit) as exc:
+            appmod._apply_version_override()
+        assert exc.value.code == 1
+
+    def test_version_x_tag_found_runs_worktree(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["opensak", "--version=1.2.3"])
+        calls = []
+
+        def fake_run(cmd, *a, **k):
+            calls.append(cmd)
+            if "rev-parse" in cmd:
+                return SimpleNamespace(returncode=0, stdout="/repo\n", stderr="")
+            if "tag" in cmd:
+                return SimpleNamespace(returncode=0, stdout="v1.2.3\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        monkeypatch.setattr("subprocess.run", fake_run)
+        with pytest.raises(SystemExit) as exc:
+            appmod._apply_version_override()
+        assert exc.value.code == 0
+        # worktree add + the version run + worktree remove all dispatched
+        assert any("worktree" in c for c in calls)
+
+
+# ── main (bootstrap smoke, event loop mocked) ─────────────────────────────────
+
+def test_main_smoke(qapp, monkeypatch):
+    import PySide6.QtWidgets as W
+    import PySide6.QtCore as C
+
+    monkeypatch.setattr(sys, "argv", ["opensak"])
+    monkeypatch.setattr(type(qapp), "exec", lambda self: 0)
+    monkeypatch.setattr(appmod, "_make_splash",
+                        lambda app: SimpleNamespace(
+                            showMessage=lambda *a, **k: None,
+                            finish=lambda w: None))
+    monkeypatch.setattr(appmod, "_migrate_legacy_db", lambda: None)
+    monkeypatch.setattr("opensak.gui.theme.apply_theme", lambda app: None)
+    monkeypatch.setattr("opensak.config.get_language", lambda: "en")
+    monkeypatch.setattr("opensak.lang.load_language", lambda lang: None)
+    monkeypatch.setattr("opensak.db.manager.get_db_manager",
+                        lambda: SimpleNamespace(ensure_active_initialised=lambda: None))
+
+    class FakeWindow:
+        def show(self):
+            pass
+    monkeypatch.setattr("opensak.gui.mainwindow.MainWindow", FakeWindow)
+
+    # Reuse the existing QApplication; restore the class *before* the test
+    # returns so pytest-qt's post-call _process_events still sees the real one.
+    real_qapp_cls = W.QApplication
+    real_single = C.QTimer.singleShot
+    W.QApplication = lambda *a, **k: qapp
+    C.QTimer.singleShot = staticmethod(lambda ms, cb: cb())  # fire splash-close now
+    try:
+        with pytest.raises(SystemExit) as exc:
+            appmod.main()
+    finally:
+        W.QApplication = real_qapp_cls
+        C.QTimer.singleShot = real_single
+    assert exc.value.code == 0


### PR DESCRIPTION
The last phase of the #225 test-coverage initiative. Covers the application
entry point, adds a `.coveragerc` so the reported number reflects genuinely
testable code, and surfaces coverage in CI.

Overall project coverage is now **~95%** (1438 passing tests) — the initiative's
target.

### Coverage gains

| Module | Before | After |
|---|---|---|
| `app.py` | 0% | **100%** |

> The other modules originally listed for Phase 4 (`theme.py`, `icon.py`,
> `icon_provider.py`, `map_widget.py`) were already brought to 93–100% in
> Phase 3, so the only new source coverage here is `app.py`.

### What's tested (`tests/unit-tests/test_app.py`)

- **`_migrate_legacy_db`** — all five legacy→Default DB scenarios (rename,
  replace-with-WAL/SHM-cleanup, delete-empty, no-op default-only, no-op none).
- **`_make_splash`** — programmatic splash pixmap renders.
- **`_apply_version_override`** — `--version` print/exit, not-in-a-git-repo,
  tag-not-found, and the `--version=X` git-worktree path. **All `subprocess`
  calls are mocked — no real git operations run.**
- **`main()`** — bootstrap smoke with the Qt event loop mocked: the existing
  `QApplication` is reused and `QApplication`/`QTimer.singleShot` are restored
  *before the test returns* so pytest-qt's post-call event processing isn't
  disturbed; heavy collaborators (theme, splash, DB manager, main window) are
  stubbed.

### Coverage hygiene

- New **`.coveragerc`** excludes lines that legitimately cannot/should not be
  covered: `pragma: no cover`, `if __name__ == "__main__":`, `if TYPE_CHECKING:`,
  `@abstractmethod`, `...`, `raise NotImplementedError`.

### CI

- Added `pytest-cov` and `--cov=opensak --cov-report=term-missing` to both the
  unit and e2e jobs. **Reporting only — no `--cov-fail-under` gate**, so coverage
  never blocks a PR.