### PR TITLE
207 & 236 - Fix export crash & export progress indicator implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ Thumbs.db
 *.db
 *.log
 
+# Local export output (GPX/LOC/GGZ/KML written during manual testing)
+*.gpx
+*.loc
+*.ggz
+*.kml
+
 # OAuth tokens
 gc_token.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   output). Exports now reload the full cache data first, so GPX/LOC/GGZ/KML files always include
   hints, logs and waypoints.
 
+- **Re-importing an exported GPX no longer imports 0 caches** — OpenSAK exports GPX 1.1 (with the
+  Groundspeak data wrapped in `<extensions>`), but the importer only recognised GPX 1.0 with the
+  Groundspeak block as a direct child, so importing an OpenSAK-exported file (or any GPX 1.1 file)
+  found nothing. The importer now reads both GPX 1.0 and 1.1.
+
 For planned features and known issues see the [GitHub Issues list](https://github.com/AgreeDK/opensak/issues).
 
 ## [1.13.11] — 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Export progress shows how far it has reached** (closes #207) — the GPS, file (GPX/LOC/GGZ)
+  and KML export dialogs now display a determinate progress bar with the number of caches
+  processed and the percentage (e.g. `320 / 500 (64%)`) instead of an indeterminate "running"
+  bar, giving a sense of how long the export will take. Suggested in issue #207.
+
 For planned features and known issues see the [GitHub Issues list](https://github.com/AgreeDK/opensak/issues).
 
 ## [1.13.11] — 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   processed and the percentage (e.g. `320 / 500 (64%)`) instead of an indeterminate "running"
   bar, giving a sense of how long the export will take. Suggested in issue #207.
 
+### Fixed
+
+- **Export no longer crashes with DetachedInstanceError** — the cache table loads rows with the
+  description/hint text and logs/waypoints left out for speed, so exporting them straight from the
+  table raised `DetachedInstanceError` (and would otherwise have dropped hints and logs from the
+  output). Exports now reload the full cache data first, so GPX/LOC/GGZ/KML files always include
+  hints, logs and waypoints.
+
 For planned features and known issues see the [GitHub Issues list](https://github.com/AgreeDK/opensak/issues).
 
 ## [1.13.11] — 2026-05-29

--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -465,6 +465,48 @@ def make_session():
     return _SessionLocal()
 
 
+def reload_caches_full(caches: list) -> list:
+    """Reload *caches* with everything an export needs eagerly loaded.
+
+    Table-model caches come from apply_filters(), which defers the text blobs
+    (hints/descriptions) and noloads logs/waypoints for speed. Once their
+    session closes they are detached, so an export worker that reads those
+    attributes raises DetachedInstanceError. Reloading here returns fully
+    populated, detached-safe objects (logs, waypoints, attributes, user_note
+    and the text blobs) in the original order.
+
+    Objects without a matching DB row (e.g. test stand-ins) pass through
+    unchanged.
+    """
+    from opensak.db.models import Cache
+    from sqlalchemy.orm import joinedload, selectinload, undefer
+
+    # Only persisted Cache rows can be reloaded; pass anything else through
+    # (e.g. SimpleNamespace stand-ins in tests).
+    ids = [c.id for c in caches if isinstance(c, Cache) and c.id is not None]
+    if not ids:
+        return list(caches)
+
+    with get_session() as session:
+        rows = (
+            session.query(Cache)
+            .options(
+                selectinload(Cache.logs),
+                selectinload(Cache.waypoints),
+                selectinload(Cache.attributes),
+                joinedload(Cache.user_note),
+                undefer(Cache.short_description),
+                undefer(Cache.long_description),
+                undefer(Cache.encoded_hints),
+            )
+            .filter(Cache.id.in_(ids))
+            .all()
+        )
+
+    by_id = {c.id: c for c in rows}
+    return [by_id.get(c.id, c) if isinstance(c, Cache) else c for c in caches]
+
+
 # ── Health-check helper ───────────────────────────────────────────────────────
 
 def db_health_check() -> dict:

--- a/src/opensak/export/kml.py
+++ b/src/opensak/export/kml.py
@@ -144,11 +144,14 @@ def export_kml(
     *,
     include_waypoints: bool = True,
     include_found: bool = True,
+    progress_cb=None,
 ) -> int:
     """
     Write a KML file to *output_path*.
 
     Returns the number of caches written.
+
+    progress_cb(done, total): optional per-cache callback for GUI progress.
     """
     cache_list = list(caches)
     if not include_found:
@@ -188,7 +191,10 @@ def export_kml(
 
     waypoints_to_export: list[tuple] = []  # (Waypoint, gc_code)
 
-    for cache in cache_list:
+    total = len(cache_list)
+    for i, cache in enumerate(cache_list, 1):
+        if progress_cb:
+            progress_cb(i, total)
         # Use corrected coordinates if available, fall back to originals
         note = cache.user_note
         if note and note.is_corrected and note.corrected_lat is not None:

--- a/src/opensak/gps/garmin.py
+++ b/src/opensak/gps/garmin.py
@@ -229,7 +229,7 @@ def _effective_coords(cache) -> tuple[float, float]:
     return cache.latitude, cache.longitude
 
 
-def generate_gpx(caches: list, filename: str = "opensak_export") -> str:
+def generate_gpx(caches: list, filename: str = "opensak_export", progress_cb=None) -> str:
     """
     Generer GPX 1.1 indhold fra en liste af Cache objekter.
     Returnerer GPX som en streng klar til at skrive til fil.
@@ -237,6 +237,8 @@ def generate_gpx(caches: list, filename: str = "opensak_export") -> str:
     Caches med korrigerede koordinater eksporteres med de korrigerede
     koordinater som waypoint-position. De originale koordinater bevares
     i en cmt (comment) feltom muligt.
+
+    progress_cb(done, total): valgfrit kald per cache, så GUI kan vise fremgang.
     """
     from xml.etree.ElementTree import Element, SubElement
     import xml.etree.ElementTree as ET
@@ -257,7 +259,10 @@ def generate_gpx(caches: list, filename: str = "opensak_export") -> str:
     time_el = SubElement(metadata, "time")
     time_el.text = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    for cache in caches:
+    total = len(caches)
+    for i, cache in enumerate(caches, 1):
+        if progress_cb:
+            progress_cb(i, total)
         if cache.latitude is None or cache.longitude is None:
             continue
 
@@ -392,7 +397,7 @@ def _indent(elem, level: int = 0) -> None:
 
 # ── LOC generator ─────────────────────────────────────────────────────────────
 
-def generate_loc(caches: list) -> str:
+def generate_loc(caches: list, progress_cb=None) -> str:
     """
     Generate LOC 1.0 XML content from a list of Cache objects.
     Returns the LOC content as a string ready to write to file.
@@ -400,6 +405,8 @@ def generate_loc(caches: list) -> str:
     LOC is a simple waypoint format supported by many GPS apps and devices.
     It includes GC code, name, coordinates, difficulty, terrain and container.
     Corrected coordinates are used when available.
+
+    progress_cb(done, total): optional per-cache callback for GUI progress.
     """
     from xml.etree.ElementTree import Element, SubElement
     import xml.etree.ElementTree as ET
@@ -408,7 +415,10 @@ def generate_loc(caches: list) -> str:
     root.set("version", "1.0")
     root.set("src", "OpenSAK")
 
-    for cache in caches:
+    total = len(caches)
+    for i, cache in enumerate(caches, 1):
+        if progress_cb:
+            progress_cb(i, total)
         if cache.latitude is None or cache.longitude is None:
             continue
 
@@ -473,7 +483,7 @@ def generate_loc(caches: list) -> str:
 
 # ── GGZ generator ─────────────────────────────────────────────────────────────
 
-def generate_ggz(caches: list, filename: str = "opensak_export") -> bytes:
+def generate_ggz(caches: list, filename: str = "opensak_export", progress_cb=None) -> bytes:
     """
     Generate a GGZ file (ZIP archive) from a list of Cache objects.
     Returns the GGZ content as bytes ready to write to file.
@@ -485,6 +495,9 @@ def generate_ggz(caches: list, filename: str = "opensak_export") -> bytes:
     The format allows Garmin devices to load more than the usual 10,000
     cache limit by using the GGZ container instead of plain GPX files.
     Corrected coordinates are used when available.
+
+    progress_cb(done, total): optional per-cache callback for GUI progress;
+    reported over the index-building pass (the slow part of GGZ).
     """
     import io
     import zipfile
@@ -523,7 +536,10 @@ def generate_ggz(caches: list, filename: str = "opensak_export") -> bytes:
     # Track byte offset into the GPX for each cache entry
     gpx_text = gpx_content.decode("utf-8")
 
-    for cache in caches:
+    total = len(caches)
+    for i, cache in enumerate(caches, 1):
+        if progress_cb:
+            progress_cb(i, total)
         if cache.latitude is None or cache.longitude is None:
             continue
 
@@ -723,6 +739,7 @@ def export_to_device(
     caches: list,
     device_root: Path,
     filename: str = "opensak",
+    progress_cb=None,
 ) -> ExportResult:
     """
     Eksportér caches til en Garmin GPS enhed.
@@ -735,7 +752,7 @@ def export_to_device(
         gpx_dir = get_garmin_gpx_path(device_root)
         gpx_dir.mkdir(parents=True, exist_ok=True)
 
-        gpx_content = generate_gpx(caches, filename)
+        gpx_content = generate_gpx(caches, filename, progress_cb=progress_cb)
 
         output_path = gpx_dir / f"{filename}.gpx"
         output_path.write_text(gpx_content, encoding="utf-8")
@@ -756,6 +773,7 @@ def export_to_device(
 def export_to_file(
     caches: list,
     output_path: Path,
+    progress_cb=None,
 ) -> ExportResult:
     """
     Eksportér caches til en GPX fil (valgfri placering).
@@ -765,7 +783,7 @@ def export_to_file(
 
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        gpx_content = generate_gpx(caches, output_path.stem)
+        gpx_content = generate_gpx(caches, output_path.stem, progress_cb=progress_cb)
         output_path.write_text(gpx_content, encoding="utf-8")
         result.file_path   = output_path
         result.cache_count = len([c for c in caches if c.latitude is not None])

--- a/src/opensak/gui/dialogs/__init__.py
+++ b/src/opensak/gui/dialogs/__init__.py
@@ -1,1 +1,20 @@
 """Dialogs package."""
+
+# Cap GUI progress updates so per-cache callbacks on large exports (thousands of
+# caches) never flood the Qt event loop.
+_MAX_PROGRESS_UPDATES = 200
+
+
+def make_progress_cb(emit):
+    """Return a throttled progress_cb(done, total) that forwards to *emit*.
+
+    Emits at most ~200 updates plus the final one, keeping the progress bar
+    smooth without swamping the event loop.
+    """
+    def cb(done: int, total: int) -> None:
+        if total <= 0:
+            return
+        if done == total or done % max(1, total // _MAX_PROGRESS_UPDATES) == 0:
+            emit(done, total)
+
+    return cb

--- a/src/opensak/gui/dialogs/file_export_dialog.py
+++ b/src/opensak/gui/dialogs/file_export_dialog.py
@@ -38,21 +38,23 @@ class _ExportWorker(QThread):
     def run(self) -> None:
         try:
             from opensak.gps.garmin import generate_gpx, generate_loc, generate_ggz
+            from opensak.db.database import reload_caches_full
 
             self._output_path.parent.mkdir(parents=True, exist_ok=True)
+            caches = reload_caches_full(self._caches)
             cb = make_progress_cb(self.progress.emit)
 
             if self._fmt == "gpx":
-                content = generate_gpx(self._caches, self._output_path.stem, progress_cb=cb)
+                content = generate_gpx(caches, self._output_path.stem, progress_cb=cb)
                 self._output_path.write_text(content, encoding="utf-8")
             elif self._fmt == "loc":
-                content = generate_loc(self._caches, progress_cb=cb)
+                content = generate_loc(caches, progress_cb=cb)
                 self._output_path.write_text(content, encoding="utf-8")
             elif self._fmt == "ggz":
-                data = generate_ggz(self._caches, self._output_path.stem, progress_cb=cb)
+                data = generate_ggz(caches, self._output_path.stem, progress_cb=cb)
                 self._output_path.write_bytes(data)
 
-            count = len([c for c in self._caches if c.latitude is not None])
+            count = len([c for c in caches if c.latitude is not None])
             self.finished.emit(
                 tr("file_export_done_msg").format(
                     count=count, path=str(self._output_path)

--- a/src/opensak/gui/dialogs/file_export_dialog.py
+++ b/src/opensak/gui/dialogs/file_export_dialog.py
@@ -19,13 +19,15 @@ from PySide6.QtWidgets import (
 
 from opensak.lang import tr
 from opensak.gui.icon import OpenSAKMessageBox as QMessageBox
+from opensak.gui.dialogs import make_progress_cb
 
 
 # ── Background worker ─────────────────────────────────────────────────────────
 
 class _ExportWorker(QThread):
-    finished = Signal(str)   # success message
-    error    = Signal(str)   # error message
+    finished = Signal(str)        # success message
+    error    = Signal(str)        # error message
+    progress = Signal(int, int)   # (done, total)
 
     def __init__(self, caches: list, output_path: Path, fmt: str):
         super().__init__()
@@ -38,15 +40,16 @@ class _ExportWorker(QThread):
             from opensak.gps.garmin import generate_gpx, generate_loc, generate_ggz
 
             self._output_path.parent.mkdir(parents=True, exist_ok=True)
+            cb = make_progress_cb(self.progress.emit)
 
             if self._fmt == "gpx":
-                content = generate_gpx(self._caches, self._output_path.stem)
+                content = generate_gpx(self._caches, self._output_path.stem, progress_cb=cb)
                 self._output_path.write_text(content, encoding="utf-8")
             elif self._fmt == "loc":
-                content = generate_loc(self._caches)
+                content = generate_loc(self._caches, progress_cb=cb)
                 self._output_path.write_text(content, encoding="utf-8")
             elif self._fmt == "ggz":
-                data = generate_ggz(self._caches, self._output_path.stem)
+                data = generate_ggz(self._caches, self._output_path.stem, progress_cb=cb)
                 self._output_path.write_bytes(data)
 
             count = len([c for c in self._caches if c.latitude is not None])
@@ -164,13 +167,29 @@ class FileExportDialog(QDialog):
 
         self._log.clear()
         self._log.setVisible(True)
+        self._reset_progress()
         self._progress.setVisible(True)
         self._btn_export.setEnabled(False)
 
         self._worker = _ExportWorker(self._caches, output_path, fmt)
         self._worker.finished.connect(self._on_success)
         self._worker.error.connect(self._on_error)
+        self._worker.progress.connect(self._on_progress)
         self._worker.start()
+
+    def _reset_progress(self) -> None:
+        """Reset the bar to the indeterminate "running" state."""
+        self._progress.setRange(0, 0)
+        self._progress.setTextVisible(False)
+
+    def _on_progress(self, done: int, total: int) -> None:
+        """Switch to a determinate bar showing count and percentage."""
+        if total <= 0:
+            return
+        self._progress.setRange(0, total)
+        self._progress.setValue(done)
+        self._progress.setFormat("%v / %m  (%p%)")
+        self._progress.setTextVisible(True)
 
     def _on_success(self, msg: str) -> None:
         self._progress.setVisible(False)

--- a/src/opensak/gui/dialogs/gps_dialog.py
+++ b/src/opensak/gui/dialogs/gps_dialog.py
@@ -56,7 +56,9 @@ class ExportWorker(QThread):
     def run(self) -> None:
         try:
             from opensak.gps.garmin import export_to_device, export_to_file
+            from opensak.db.database import reload_caches_full
             caches = self.caches[:self.max_caches] if self.max_caches > 0 else self.caches
+            caches = reload_caches_full(caches)
             cb = make_progress_cb(self.progress.emit)
 
             if self.device_path.is_dir() and (self.device_path / "Garmin").exists():

--- a/src/opensak/gui/dialogs/gps_dialog.py
+++ b/src/opensak/gui/dialogs/gps_dialog.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from PySide6.QtCore import Qt, QThread, Signal
 from opensak.lang import tr
+from opensak.gui.dialogs import make_progress_cb
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QComboBox, QLineEdit, QTextEdit,
@@ -43,6 +44,7 @@ class ExportWorker(QThread):
     """Kører eksporten i baggrundstråd."""
     finished = Signal(object)
     error    = Signal(str)
+    progress = Signal(int, int)   # (done, total)
 
     def __init__(self, caches, device_path, filename, max_caches):
         super().__init__()
@@ -55,11 +57,12 @@ class ExportWorker(QThread):
         try:
             from opensak.gps.garmin import export_to_device, export_to_file
             caches = self.caches[:self.max_caches] if self.max_caches > 0 else self.caches
+            cb = make_progress_cb(self.progress.emit)
 
             if self.device_path.is_dir() and (self.device_path / "Garmin").exists():
-                result = export_to_device(caches, self.device_path, self.filename)
+                result = export_to_device(caches, self.device_path, self.filename, progress_cb=cb)
             else:
-                result = export_to_file(caches, self.device_path / f"{self.filename}.gpx")
+                result = export_to_file(caches, self.device_path / f"{self.filename}.gpx", progress_cb=cb)
 
             self.finished.emit(result)
         except Exception as e:
@@ -297,6 +300,7 @@ class GpsExportDialog(QDialog):
                 return
 
         self._export_btn.setEnabled(False)
+        self._reset_progress()
         self._progress.setVisible(True)
 
         if do_delete:
@@ -329,7 +333,22 @@ class GpsExportDialog(QDialog):
         self._worker = ExportWorker(self._caches, dest, filename, max_caches)
         self._worker.finished.connect(self._on_finished)
         self._worker.error.connect(self._on_error)
+        self._worker.progress.connect(self._on_progress)
         self._worker.start()
+
+    def _reset_progress(self) -> None:
+        """Sæt fremgangsbjælken tilbage til "kører" (ubestemt) tilstand."""
+        self._progress.setRange(0, 0)
+        self._progress.setTextVisible(False)
+
+    def _on_progress(self, done: int, total: int) -> None:
+        """Skift til bestemt fremgang og vis antal + procent."""
+        if total <= 0:
+            return
+        self._progress.setRange(0, total)
+        self._progress.setValue(done)
+        self._progress.setFormat("%v / %m  (%p%)")
+        self._progress.setTextVisible(True)
 
     def _on_finished(self, result) -> None:
         self._progress.setVisible(False)

--- a/src/opensak/gui/dialogs/kml_export_dialog.py
+++ b/src/opensak/gui/dialogs/kml_export_dialog.py
@@ -45,8 +45,10 @@ class _ExportWorker(QThread):
 
     def run(self) -> None:
         try:
+            from ...db.database import reload_caches_full
+            caches = reload_caches_full(self._caches)
             count = export_kml(
-                self._caches,
+                caches,
                 self._output_path,
                 include_waypoints=self._include_waypoints,
                 include_found=self._include_found,

--- a/src/opensak/gui/dialogs/kml_export_dialog.py
+++ b/src/opensak/gui/dialogs/kml_export_dialog.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
 
 from ...export.kml import export_kml
 from ...lang import tr
+from . import make_progress_cb
 
 
 # ---------------------------------------------------------------------------
@@ -33,6 +34,7 @@ from ...lang import tr
 class _ExportWorker(QThread):
     finished = Signal(int)
     error    = Signal(str)
+    progress = Signal(int, int)   # (done, total)
 
     def __init__(self, caches, output_path: str, include_waypoints: bool, include_found: bool):
         super().__init__()
@@ -48,6 +50,7 @@ class _ExportWorker(QThread):
                 self._output_path,
                 include_waypoints=self._include_waypoints,
                 include_found=self._include_found,
+                progress_cb=make_progress_cb(self.progress.emit),
             )
             self.finished.emit(count)
         except Exception as exc:  # noqa: BLE001
@@ -143,6 +146,7 @@ class KmlExportDialog(QDialog):
             return
 
         self._export_btn.setEnabled(False)
+        self._reset_progress()
         self._progress.setVisible(True)
 
         self._worker = _ExportWorker(
@@ -153,7 +157,22 @@ class KmlExportDialog(QDialog):
         )
         self._worker.finished.connect(self._on_finished)
         self._worker.error.connect(self._on_error)
+        self._worker.progress.connect(self._on_progress)
         self._worker.start()
+
+    def _reset_progress(self) -> None:
+        """Reset the bar to the indeterminate "running" state."""
+        self._progress.setRange(0, 0)
+        self._progress.setTextVisible(False)
+
+    def _on_progress(self, done: int, total: int) -> None:
+        """Switch to a determinate bar showing count and percentage."""
+        if total <= 0:
+            return
+        self._progress.setRange(0, total)
+        self._progress.setValue(done)
+        self._progress.setFormat("%v / %m  (%p%)")
+        self._progress.setTextVisible(True)
 
     def _on_finished(self, count: int) -> None:
         self._progress.setVisible(False)

--- a/src/opensak/gui/dialogs/trip_dialog.py
+++ b/src/opensak/gui/dialogs/trip_dialog.py
@@ -266,7 +266,9 @@ class _PreviewMixin:
         if not path:
             return
         try:
-            result = export_to_file(self._selected_caches, Path(path))
+            from opensak.db.database import reload_caches_full
+            caches = reload_caches_full(self._selected_caches)
+            result = export_to_file(caches, Path(path))
             QMessageBox.information(
                 self, tr("trip_export_done_title"), str(result)
             )

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -156,32 +156,39 @@ def _parse_wpt(wpt_el) -> Optional[dict]:
     except (TypeError, ValueError):
         return None
 
-    # GC code: <n> in newer PQ files, <n> in older format
+    # Use the file's actual GPX namespace (1/0 for Pocket Queries, 1/1 for
+    # OpenSAK's own export and many third-party tools) so the gpx: lookups match.
+    gpx_ns = {"gpx": etree.QName(wpt_el).namespace or NS["gpx"]}
+
+    # GC code: <name> in newer PQ files, <n> in older format
     gc_code = (
-        _text(wpt_el, "gpx:name", NS) or
-        _text(wpt_el, "gpx:n", NS)
+        _text(wpt_el, "gpx:name", gpx_ns) or
+        _text(wpt_el, "gpx:n", gpx_ns)
     )
     # Accept GC codes (standard caches) and LC codes (Adventure Lab / lab2gpx)
     if not gc_code or not (gc_code.startswith("GC") or gc_code.startswith("LC")):
         return None
 
     # Cache type from <type>Geocache|Traditional Cache</type>
-    type_raw = _text(wpt_el, "gpx:type", NS) or ""
+    type_raw = _text(wpt_el, "gpx:type", gpx_ns) or ""
     cache_type_full = type_raw.split("|")[-1].strip() if "|" in type_raw else type_raw
 
-    hidden_raw = _text(wpt_el, "gpx:time", NS)
+    hidden_raw = _text(wpt_el, "gpx:time", gpx_ns)
 
     # ── Found by me — detekteret via <sym>Geocache Found</sym> ───────────────
     # Groundspeak sætter sym til "Geocache Found" for caches fundet af PQ-ejeren.
-    sym = _text(wpt_el, "gpx:sym", NS) or ""
+    sym = _text(wpt_el, "gpx:sym", gpx_ns) or ""
     found_by_me = sym.strip().lower() == "geocache found"
 
     # ── Groundspeak extension block ───────────────────────────────────────────
     # Detect which Groundspeak namespace this file actually uses (/1/0 or /1/0/1)
+    # groundspeak:cache sits directly under <wpt> in GPX 1.0 Pocket Queries but
+    # inside an <extensions> wrapper in GPX 1.1 (incl. OpenSAK's own export), so
+    # search descendants rather than only direct children.
     gs_cache = None
     active_ns = NS  # default
     for gs_uri in _GS_NAMESPACES:
-        gs_cache = wpt_el.find(f"{{{gs_uri}}}cache")
+        gs_cache = wpt_el.find(f".//{{{gs_uri}}}cache")
         if gs_cache is not None:
             active_ns = _make_ns(gs_uri)
             break
@@ -190,7 +197,7 @@ def _parse_wpt(wpt_el) -> Optional[dict]:
     available    = _bool_attr(gs_cache, "@available")    if gs_cache is not None else True
     archived     = _bool_attr(gs_cache, "@archived")     if gs_cache is not None else False
 
-    name         = _text(gs_cache, "gs:name",              active_ns) or _text(wpt_el, "gpx:urlname", NS) or gc_code
+    name         = _text(gs_cache, "gs:name",              active_ns) or _text(wpt_el, "gpx:urlname", gpx_ns) or gc_code
     placed_by    = _text(gs_cache, "gs:placed_by",         active_ns)
     owner        = _text(gs_cache, "gs:owner",             active_ns)
     owner_id     = gs_cache.find("gs:owner", active_ns).get("id") if gs_cache is not None and gs_cache.find("gs:owner", active_ns) is not None else None
@@ -379,9 +386,11 @@ def _parse_extra_wpt(wpt_el) -> Optional[dict]:
     except (TypeError, ValueError):
         return None
 
+    gpx_ns = {"gpx": etree.QName(wpt_el).namespace or NS["gpx"]}
+
     raw_name = (
-        _text(wpt_el, "gpx:name", NS) or
-        _text(wpt_el, "gpx:n",    NS) or ""
+        _text(wpt_el, "gpx:name", gpx_ns) or
+        _text(wpt_el, "gpx:n",    gpx_ns) or ""
     )
     if len(raw_name) < 2:
         return None
@@ -415,7 +424,7 @@ def _parse_extra_wpt(wpt_el) -> Optional[dict]:
         # Ukendt prefix-format — tjek om type-feltet angiver et gyldigt waypoint-type
         # Eksempler: 'JJ28J63' type='Waypoint|Final Location'
         # Suffix er altid de sidste 6 tegn (Groundspeak standard)
-        type_raw_check = _text(wpt_el, "gpx:type", NS) or ""
+        type_raw_check = _text(wpt_el, "gpx:type", gpx_ns) or ""
         if "|" in type_raw_check and type_raw_check.startswith("Waypoint"):
             # Acceptér som waypoint med generisk prefix
             prefix = raw_name[:2].upper()
@@ -424,7 +433,7 @@ def _parse_extra_wpt(wpt_el) -> Optional[dict]:
         else:
             return None
 
-    type_raw = _text(wpt_el, "gpx:type", NS) or ""
+    type_raw = _text(wpt_el, "gpx:type", gpx_ns) or ""
     if "|" in type_raw:
         wp_type = type_raw.split("|")[-1].strip()
     elif type_raw:
@@ -432,9 +441,9 @@ def _parse_extra_wpt(wpt_el) -> Optional[dict]:
     else:
         wp_type = wp_type_fallback
 
-    desc    = _text(wpt_el, "gpx:desc",    NS)
-    comment = _text(wpt_el, "gpx:cmt",     NS)
-    name    = _text(wpt_el, "gpx:urlname", NS) or desc or raw_name
+    desc    = _text(wpt_el, "gpx:desc",    gpx_ns)
+    comment = _text(wpt_el, "gpx:cmt",     gpx_ns)
+    name    = _text(wpt_el, "gpx:urlname", gpx_ns) or desc or raw_name
 
     return {
         "prefix":      prefix,

--- a/tests/e2e-tests/test_e2e_export_reload.py
+++ b/tests/e2e-tests/test_e2e_export_reload.py
@@ -1,0 +1,52 @@
+"""tests/e2e-tests/test_e2e_export_reload.py — regression for the #207 export crash.
+
+Caches taken from the table model are partial: apply_filters() defers the text
+blobs (encoded_hints / descriptions) and noloads logs/waypoints for speed. Once
+the load session closes they are detached, so exporting them used to raise
+DetachedInstanceError the moment generate_gpx() read cache.encoded_hints. The
+export workers now reload full caches before generating.
+"""
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+
+def _table_caches(window):
+    """The exact (partial, detached) objects the export menu hands to a dialog."""
+    model = window._cache_table._model
+    return [
+        c
+        for c in (model.cache_at(i) for i in range(window._cache_table.row_count()))
+        if c is not None
+    ]
+
+
+def test_table_caches_are_detached_and_deferred(seeded_window):
+    """Precondition: the objects the export receives are the ones that crashed —
+    detached, with a deferred encoded_hints column that needs a live session."""
+    from sqlalchemy.orm.exc import DetachedInstanceError
+
+    caches = _table_caches(seeded_window)
+    assert caches
+    with pytest.raises(DetachedInstanceError):
+        _ = caches[0].encoded_hints
+
+
+def test_file_export_reloads_full_caches(seeded_window, tmp_path):
+    """Exporting table caches to GPX no longer crashes, and the output includes
+    the hint (deferred) and log text (noload'ed) that were absent at load time."""
+    from opensak.gui.dialogs.file_export_dialog import _ExportWorker
+
+    caches = _table_caches(seeded_window)
+    out = tmp_path / "reload.gpx"
+
+    worker = _ExportWorker(caches, out, "gpx")
+    errors = []
+    worker.error.connect(errors.append)
+    worker.run()  # synchronous — deterministic, no thread to wait on
+
+    assert not errors, errors
+    content = out.read_text(encoding="utf-8")
+    assert "Under a rock." in content      # encoded_hints (deferred) reloaded
+    assert "TFTC! Great hide." in content   # log text (noload'ed) reloaded

--- a/tests/unit-tests/test_db.py
+++ b/tests/unit-tests/test_db.py
@@ -14,6 +14,7 @@ from opensak.db.database import (
     make_session,
     dispose_engine,
     db_health_check,
+    reload_caches_full,
 )
 from opensak.db.models import Cache, Waypoint, Log, Attribute, Trackable, UserNote
 
@@ -308,3 +309,48 @@ class TestInitDbDefaultPath:
         monkeypatch.setattr("opensak.config.get_db_path", lambda: path)
         init_db()
         assert "fallback.db" in str(get_engine().url)
+
+
+# ── reload_caches_full ──────────────────────────────────────────────────────────
+
+class TestReloadCachesFull:
+    def test_passes_through_non_cache_objects(self, tmp_db):
+        fakes = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+        assert reload_caches_full(fakes) == fakes  # no DB query, returned as-is
+
+    def test_empty_input(self, tmp_db):
+        assert reload_caches_full([]) == []
+
+    def test_reloads_deferred_blob_and_noloaded_logs(self, tmp_path):
+        from sqlalchemy.orm import defer, noload
+        from sqlalchemy.orm.exc import DetachedInstanceError
+
+        init_db(db_path=tmp_path / "reload.db")
+        with get_session() as s:
+            cache = Cache(
+                gc_code="GCRELOAD", name="Reload me", cache_type="Traditional Cache",
+                latitude=55.0, longitude=12.0, encoded_hints="Behind the sign.",
+            )
+            cache.logs.append(Log(log_type="Found it", finder="T", text="Nice one"))
+            s.add(cache)
+
+        # Load it the way the table does: deferred blob + noload'ed logs, detached.
+        with get_session() as s:
+            partial = (
+                s.query(Cache)
+                .options(defer(Cache.encoded_hints), noload(Cache.logs))
+                .filter_by(gc_code="GCRELOAD")
+                .one()
+            )
+        with pytest.raises(DetachedInstanceError):
+            _ = partial.encoded_hints
+
+        [full] = reload_caches_full([partial])
+        assert full.encoded_hints == "Behind the sign."
+        assert [lg.text for lg in full.logs] == ["Nice one"]
+
+    def test_missing_row_falls_back_to_original(self, tmp_path):
+        init_db(db_path=tmp_path / "missing.db")
+        ghost = Cache(gc_code="GCGONE", name="Not saved")
+        ghost.id = 424242  # an id with no matching row
+        assert reload_caches_full([ghost]) == [ghost]

--- a/tests/unit-tests/test_export_dialogs.py
+++ b/tests/unit-tests/test_export_dialogs.py
@@ -148,6 +148,13 @@ class TestKmlExportDialog:
         assert dlg._progress.value() == 2
         assert dlg._progress.isTextVisible() is True
 
+    def test_on_progress_ignores_zero_total(self, qtbot):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        dlg._reset_progress()
+        dlg._on_progress(0, 0)
+        assert dlg._progress.maximum() == 0
+
     def test_on_finished_accepts(self, qtbot, monkeypatch):
         dlg = KmlExportDialog([])
         qtbot.addWidget(dlg)
@@ -249,6 +256,13 @@ class TestFileExportDialog:
         assert dlg._progress.maximum() == 4
         assert dlg._progress.value() == 4
         assert dlg._progress.isTextVisible() is True
+
+    def test_on_progress_ignores_zero_total(self, qtbot):
+        dlg = FileExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        dlg._reset_progress()
+        dlg._on_progress(0, 0)
+        assert dlg._progress.maximum() == 0
 
     def test_on_success_shows_message(self, qtbot):
         dlg = FileExportDialog([_cache()])

--- a/tests/unit-tests/test_export_dialogs.py
+++ b/tests/unit-tests/test_export_dialogs.py
@@ -9,6 +9,7 @@ pytest.importorskip("pytestqt")
 
 from PySide6.QtWidgets import QDialog
 
+from opensak.gui.dialogs import make_progress_cb
 from opensak.gui.dialogs import file_export_dialog as fed
 from opensak.gui.dialogs import kml_export_dialog as ked
 from opensak.gui.dialogs.file_export_dialog import FileExportDialog
@@ -25,6 +26,33 @@ def _cache(gc_code="GC12345", latitude=55.0, longitude=12.0):
         encoded_hints=None, hidden_date=None, logs=[], user_note=None,
         container="Small", found=False, short_description="", waypoints=[],
     )
+
+
+# ── Throttled progress callback ───────────────────────────────────────────────
+
+class TestMakeProgressCb:
+    def test_emits_each_step_for_small_total(self):
+        seen = []
+        cb = make_progress_cb(lambda d, t: seen.append((d, t)))
+        for i in range(1, 5):
+            cb(i, 4)
+        assert seen == [(1, 4), (2, 4), (3, 4), (4, 4)]
+
+    def test_throttles_large_total_but_always_emits_last(self):
+        seen = []
+        cb = make_progress_cb(lambda d, t: seen.append((d, t)))
+        total = 1000
+        for i in range(1, total + 1):
+            cb(i, total)
+        # ~200 updates (every 5th) plus the final one — never one per cache.
+        assert len(seen) < total
+        assert seen[-1] == (total, total)
+
+    def test_zero_total_emits_nothing(self):
+        seen = []
+        cb = make_progress_cb(lambda d, t: seen.append((d, t)))
+        cb(0, 0)
+        assert seen == []
 
 
 # ── KML export worker ─────────────────────────────────────────────────────────
@@ -47,6 +75,14 @@ class TestKmlExportWorker:
         w.error.connect(errs.append)
         w.run()
         assert errs and "kaboom" in errs[0]
+
+    def test_run_emits_progress(self, tmp_path):
+        caches = [_cache(gc_code=f"GC{i}") for i in range(3)]
+        w = KmlWorker(caches, str(tmp_path / "out.kml"), True, True)
+        seen = []
+        w.progress.connect(lambda d, t: seen.append((d, t)))
+        w.run()
+        assert seen and seen[-1] == (3, 3)
 
 
 # ── KML export dialog ─────────────────────────────────────────────────────────
@@ -90,6 +126,7 @@ class TestKmlExportDialog:
             def __init__(self, **kw):
                 self.finished = MagicMock()
                 self.error = MagicMock()
+                self.progress = MagicMock()
 
             def start(self):
                 started.append(True)
@@ -100,6 +137,16 @@ class TestKmlExportDialog:
         assert started == [True]
         assert dlg._export_btn.isEnabled() is False
         assert not dlg._progress.isHidden()
+
+    def test_on_progress_makes_bar_determinate(self, qtbot):
+        dlg = KmlExportDialog([])
+        qtbot.addWidget(dlg)
+        dlg._reset_progress()
+        assert dlg._progress.maximum() == 0
+        dlg._on_progress(2, 5)
+        assert dlg._progress.maximum() == 5
+        assert dlg._progress.value() == 2
+        assert dlg._progress.isTextVisible() is True
 
     def test_on_finished_accepts(self, qtbot, monkeypatch):
         dlg = KmlExportDialog([])
@@ -142,6 +189,15 @@ class TestFileExportWorker:
         w.run()
         assert errs and "gen failed" in errs[0]
 
+    @pytest.mark.parametrize("fmt,suffix", [("gpx", ".gpx"), ("loc", ".loc"), ("ggz", ".ggz")])
+    def test_run_emits_progress(self, tmp_path, fmt, suffix):
+        caches = [_cache(gc_code=f"GC{i}") for i in range(3)]
+        w = FileWorker(caches, tmp_path / f"export{suffix}", fmt)
+        seen = []
+        w.progress.connect(lambda d, t: seen.append((d, t)))
+        w.run()
+        assert seen and seen[-1] == (3, 3)
+
 
 # ── File export dialog ────────────────────────────────────────────────────────
 
@@ -173,6 +229,7 @@ class TestFileExportDialog:
                 captured["path"] = output_path
                 self.finished = MagicMock()
                 self.error = MagicMock()
+                self.progress = MagicMock()
 
             def start(self):
                 captured["started"] = True
@@ -182,6 +239,16 @@ class TestFileExportDialog:
         assert captured["started"] is True
         assert str(captured["path"]).endswith(".gpx")
         assert dlg._btn_export.isEnabled() is False
+
+    def test_on_progress_makes_bar_determinate(self, qtbot):
+        dlg = FileExportDialog([_cache()])
+        qtbot.addWidget(dlg)
+        dlg._reset_progress()
+        assert dlg._progress.maximum() == 0
+        dlg._on_progress(4, 4)
+        assert dlg._progress.maximum() == 4
+        assert dlg._progress.value() == 4
+        assert dlg._progress.isTextVisible() is True
 
     def test_on_success_shows_message(self, qtbot):
         dlg = FileExportDialog([_cache()])

--- a/tests/unit-tests/test_export_import_roundtrip.py
+++ b/tests/unit-tests/test_export_import_roundtrip.py
@@ -1,0 +1,79 @@
+"""tests/unit-tests/test_export_import_roundtrip.py — exported GPX must re-import.
+
+Regression: OpenSAK exports GPX 1.1 with the groundspeak:cache block wrapped in
+<extensions>, but the importer only recognised GPX 1.0 with groundspeak:cache as
+a direct child of <wpt>, so re-importing an exported file imported 0 caches.
+"""
+
+from opensak.db.database import init_db, get_session, reload_caches_full
+from opensak.db.models import Cache
+from opensak.importer import import_gpx
+from opensak.gps.garmin import generate_gpx
+from tests.data import SAMPLE_GPX, write_gpx
+
+
+# Minimal GPX 1.1 with the groundspeak block nested under <extensions> — the
+# exact shape that used to import as 0 caches.
+GPX_1_1 = """<?xml version="1.0" encoding="utf-8"?>
+<gpx version="1.1" creator="OpenSAK"
+     xmlns="http://www.topografix.com/GPX/1/1"
+     xmlns:groundspeak="http://www.groundspeak.com/cache/1/0/1">
+  <wpt lat="55.0" lon="12.0">
+    <name>GC11ABC</name>
+    <desc>Eleven One</desc>
+    <type>Geocache|Traditional Cache</type>
+    <extensions>
+      <groundspeak:cache id="1" available="True" archived="False">
+        <groundspeak:name>Eleven One</groundspeak:name>
+        <groundspeak:type>Traditional Cache</groundspeak:type>
+        <groundspeak:container>Small</groundspeak:container>
+        <groundspeak:difficulty>1.5</groundspeak:difficulty>
+        <groundspeak:terrain>2.0</groundspeak:terrain>
+        <groundspeak:encoded_hints>Look up.</groundspeak:encoded_hints>
+      </groundspeak:cache>
+    </extensions>
+  </wpt>
+</gpx>
+"""
+
+
+def test_importer_accepts_gpx_1_1_with_extensions(tmp_path):
+    init_db(db_path=tmp_path / "v11.db")
+    f = write_gpx(tmp_path, "v11.gpx", GPX_1_1)
+    with get_session() as s:
+        result = import_gpx(f, s)
+
+    assert result.created == 1
+    with get_session() as s:
+        cache = s.query(Cache).filter_by(gc_code="GC11ABC").one()
+        assert cache.cache_type == "Traditional Cache"
+        assert cache.encoded_hints == "Look up."
+
+
+def test_exported_gpx_reimports_with_full_data(tmp_path):
+    # Seed a source DB and pull full cache objects, as the export menu would.
+    init_db(db_path=tmp_path / "src.db")
+    write_gpx(tmp_path, "src.gpx", SAMPLE_GPX)
+    with get_session() as s:
+        import_gpx(tmp_path / "src.gpx", s)
+    with get_session() as s:
+        caches = reload_caches_full(s.query(Cache).all())
+
+    exported = generate_gpx(caches, "roundtrip")
+    assert "GPX/1/1" in exported  # we export 1.1 with an <extensions> wrapper
+
+    # Re-import into a fresh DB — used to yield 0 caches.
+    out = tmp_path / "out.gpx"
+    out.write_text(exported, encoding="utf-8")
+    init_db(db_path=tmp_path / "dst.db")
+    with get_session() as s:
+        result = import_gpx(out, s)
+
+    assert result.created == 2
+    assert result.skipped == 0
+    with get_session() as s:
+        rows = {c.gc_code: c for c in s.query(Cache).all()}
+        assert set(rows) == {"GC12345", "GC99999"}
+        assert rows["GC12345"].cache_type == "Traditional Cache"
+        assert rows["GC12345"].encoded_hints == "Under a rock."
+        assert len(rows["GC12345"].logs) == 2

--- a/tests/unit-tests/test_gps_dialog.py
+++ b/tests/unit-tests/test_gps_dialog.py
@@ -39,9 +39,9 @@ class TestExportWorker:
     def test_run_to_device(self, monkeypatch, tmp_path):
         (tmp_path / "Garmin").mkdir()
         monkeypatch.setattr("opensak.gps.garmin.export_to_device",
-                            lambda c, d, f: "to device")
+                            lambda c, d, f, progress_cb=None: "to device")
         monkeypatch.setattr("opensak.gps.garmin.export_to_file",
-                            lambda c, p: "to file")
+                            lambda c, p, progress_cb=None: "to file")
         w = ExportWorker(["c1", "c2", "c3"], tmp_path, "out", max_caches=2)
         got = []
         w.finished.connect(got.append)
@@ -49,7 +49,8 @@ class TestExportWorker:
         assert got == ["to device"]
 
     def test_run_to_file(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("opensak.gps.garmin.export_to_file", lambda c, p: "to file")
+        monkeypatch.setattr("opensak.gps.garmin.export_to_file",
+                            lambda c, p, progress_cb=None: "to file")
         w = ExportWorker(["c1"], tmp_path, "out", max_caches=0)  # 0 = all
         got = []
         w.finished.connect(got.append)
@@ -58,12 +59,32 @@ class TestExportWorker:
 
     def test_run_error(self, monkeypatch, tmp_path):
         monkeypatch.setattr("opensak.gps.garmin.export_to_file",
-                            lambda c, p: (_ for _ in ()).throw(RuntimeError("disk full")))
+                            lambda c, p, progress_cb=None: (_ for _ in ()).throw(RuntimeError("disk full")))
         w = ExportWorker(["c1"], tmp_path, "out", max_caches=0)
         errs = []
         w.error.connect(errs.append)
         w.run()
         assert errs and "disk full" in errs[0]
+
+    def test_run_emits_progress(self, monkeypatch, tmp_path):
+        # Drive the real generator so progress_cb fires per cache.
+        from types import SimpleNamespace
+
+        def _cache(gc):
+            return SimpleNamespace(
+                id=1, gc_code=gc, name="n", cache_type="Traditional Cache",
+                latitude=55.0, longitude=12.0, difficulty=1.0, terrain=1.0,
+                placed_by="o", available=True, archived=False, country="DK",
+                encoded_hints=None, hidden_date=None, logs=[], user_note=None,
+                container="Small", found=False,
+            )
+
+        caches = [_cache(f"GC{i}") for i in range(3)]
+        w = ExportWorker(caches, tmp_path, "out", max_caches=0)  # file mode
+        seen = []
+        w.progress.connect(lambda d, t: seen.append((d, t)))
+        w.run()
+        assert seen and seen[-1] == (3, 3)
 
 
 # ── GpsExportDialog ─────────────────────────────────────────────────────────────
@@ -149,6 +170,7 @@ class TestDialogInteraction:
             def __init__(self, *a, **k):
                 self.finished = MagicMock()
                 self.error = MagicMock()
+                self.progress = MagicMock()
             def start(self):
                 launched.append(True)
             def isRunning(self):
@@ -207,6 +229,7 @@ class TestDialogInteraction:
             def __init__(self, *a, **k):
                 self.finished = MagicMock()
                 self.error = MagicMock()
+                self.progress = MagicMock()
             def start(self):
                 launched.append(True)
             def isRunning(self):
@@ -224,3 +247,16 @@ class TestDialogInteraction:
         assert dlg._export_btn.isEnabled() is True
         dlg._on_error("boom")
         assert "boom" in dlg._log.toPlainText()
+
+    def test_on_progress_makes_bar_determinate(self, dlg):
+        dlg._reset_progress()
+        assert dlg._progress.maximum() == 0  # indeterminate
+        dlg._on_progress(3, 10)
+        assert dlg._progress.maximum() == 10
+        assert dlg._progress.value() == 3
+        assert dlg._progress.isTextVisible() is True
+
+    def test_on_progress_ignores_zero_total(self, dlg):
+        dlg._reset_progress()
+        dlg._on_progress(0, 0)
+        assert dlg._progress.maximum() == 0  # still indeterminate


### PR DESCRIPTION
# Export progress indicator + export/re-import fixes (#207, #236)

Closes #207 (export progress) and closes #236 (export crash + re-import returns 0 caches).

## Summary

Three related changes to the cache-export feature:

1. **#207 — Progress feedback.** All export dialogs (GPS, file GPX/LOC/GGZ, KML) now show a
   *determinate* progress bar with a live count and percentage (e.g. `320 / 500 (64%)`) instead of
   an indeterminate "running" bar, so you can tell how far along an export is.
2. **#236 (crash) — Export no longer crashes with `DetachedInstanceError`.** Exporting caches
   straight from the table reloads their full data first, so hints, logs and waypoints are always
   included (and the export no longer throws).
3. **#236 (re-import) — An exported GPX re-imports correctly.** The importer now reads GPX 1.1 and
   `<extensions>`-wrapped Groundspeak data, so re-importing an OpenSAK-exported file (which used to
   import 0 caches) works.

`16 files changed, +517 / −38`.

---

## #207 — Determinate export progress

**Before:** every export dialog created its progress bar with `setRange(0, 0)` (an animated
"busy" bar) and never updated it — there was no sense of how long an export would take.

**Now:** the bar fills as caches are processed and shows `done / total (percent)`.

How it works:

- **Generators report progress.** `generate_gpx` / `generate_loc` / `generate_ggz`
  ([`gps/garmin.py`](src/opensak/gps/garmin.py)) and `export_kml`
  ([`export/kml.py`](src/opensak/export/kml.py)) take an optional `progress_cb(done, total)` that
  fires per cache. `export_to_device` / `export_to_file` forward it through. (GGZ reports over its
  index-building pass, the slow part.)
- **Workers emit a Qt signal.** Each export worker
  ([`gps_dialog.py`](src/opensak/gui/dialogs/gps_dialog.py),
  [`file_export_dialog.py`](src/opensak/gui/dialogs/file_export_dialog.py),
  [`kml_export_dialog.py`](src/opensak/gui/dialogs/kml_export_dialog.py)) gained a
  `progress = Signal(int, int)`.
- **Throttling.** A shared helper `make_progress_cb` in
  [`gui/dialogs/__init__.py`](src/opensak/gui/dialogs/__init__.py) caps emissions to ~200 updates
  (plus the final one) so a per-cache callback on a multi-thousand-cache export never floods the Qt
  event loop.
- **Dialogs switch the bar to determinate** on the first tick and render `%v / %m (%p%)` via Qt's
  native format placeholders (no translatable text, no language-file churn).

---

## #236 — Export crash (`DetachedInstanceError`)

**Root cause:** for speed on large databases, the cache table is loaded by `apply_filters()`, which
`defer()`s the text blobs (`encoded_hints`, descriptions) and `noload()`s logs/waypoints. Once that
load session closes, those objects are *detached*. Exporting them read `cache.encoded_hints` →
SQLAlchemy attempted a deferred load with no session → `DetachedInstanceError`. (Even without the
crash, logs and waypoints would have exported empty.) This predates #207 — the export already went
through this path.

**Fix:** a new helper `reload_caches_full()` in [`db/database.py`](src/opensak/db/database.py)
reloads the caches in the worker's own session with everything an export needs eagerly loaded
(`selectinload` for logs/waypoints/attributes, `joinedload` for `user_note`, `undefer` for the text
blobs), preserving order and passing non-ORM objects through untouched. Every export worker calls it
first (also the Trip Planner's file export). The reload runs in the background thread, so the UI
isn't blocked.

---

## #236 — Re-importing an exported GPX returned 0 caches

**Root cause:** two format mismatches between our export and our importer:

| | Export (`generate_gpx`) | Importer (before) |
|---|---|---|
| GPX namespace | **1.1** (`.../GPX/1/1`) | hardcoded **1.0** XPath → `gc_code` came back `None` |
| `groundspeak:cache` | wrapped in `<extensions>` (required by 1.1) | looked at **direct children** of `<wpt>` only |

Either mismatch alone caused every `<wpt>` to be skipped → 0 imported.

**Fix** in [`importer/__init__.py`](src/opensak/importer/__init__.py):

- Resolve each `<wpt>`'s **actual** GPX namespace (`etree.QName(...).namespace`) instead of assuming
  1.0 — so both 1.0 and 1.1 parse (this also lets us import 1.1 GPX from other tools).
- Find `groundspeak:cache` with a **descendant** search (`.//`), matching both the direct-child
  (1.0 Pocket Query) and `<extensions>`-wrapped (1.1) layouts.
- Applied to both `_parse_wpt` (caches) and `_parse_extra_wpt` (waypoints).

The export format is unchanged (still standards-compliant GPX 1.1); the importer was made tolerant.

---

## Tests

All new behaviour is covered, and the existing suite is green (**1448 passed**, unit + e2e).

- **Progress:** worker `progress` emissions and the determinate-bar slots for all three dialogs;
  direct tests for the `make_progress_cb` throttle (per-step, large-total throttling, zero-total).
- **Detached fix:** `TestReloadCachesFull` in [`test_db.py`](tests/unit-tests/test_db.py)
  (pass-through, reload of deferred blob + noload'ed logs, missing-row fallback) and an end-to-end
  regression [`test_e2e_export_reload.py`](tests/e2e-tests/test_e2e_export_reload.py) that exports
  the *actual* partial/detached table objects and asserts the hint and log text survive (the
  existing e2e tests masked the bug by eagerly pre-loading caches).
- **Re-import:** [`test_export_import_roundtrip.py`](tests/unit-tests/test_export_import_roundtrip.py)
  — an isolated GPX 1.1 + `<extensions>` import, and a full export → re-import round-trip asserting
  the caches come back with type, hints and logs.

Updated the existing export/GPS dialog tests for the new worker signatures/signals, and added a
`.gitignore` rule for local export artifacts (`*.gpx/*.loc/*.ggz/*.kml`).

---

## Commits

```
feat(export): add progress_cb to GPX/LOC/GGZ/KML generators (#207)
feat(export): show determinate progress (count + %) in export dialogs (#207)
test: cover zero-total guard in file/kml export progress (#207)
fix(export): reload full caches before export to stop DetachedInstanceError (#207)
fix(import): accept GPX 1.1 + extensions-wrapped groundspeak so exported files re-import (#207)
chore: gitignore local export artifacts (gpx/loc/ggz/kml)
docs: changelog entries (#207)
```
