### PR TITLE
Architecture - Phase 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,50 @@ env:
 jobs:
 
   # ============================================================
+  # Tests — single gate; every build job runs only after this
+  # ============================================================
+  test:
+    name: "Tests (Python ${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install system Qt dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            xvfb libgl1-mesa-dev libegl1 libxkbcommon-x11-0 \
+            libdbus-1-3 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+            libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 \
+            libxcb-xfixes0 libxcb-shape0 libglib2.0-0 \
+            libxcb-cursor0 libfontconfig1 libfreetype6
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run unit tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: pytest tests/unit-tests -v --tb=short
+      - name: Run e2e tests
+        env:
+          QT_QPA_PLATFORM: xcb
+          QTWEBENGINE_CHROMIUM_FLAGS: "--disable-gpu --disable-software-rasterizer"
+        run: xvfb-run -a --server-args="-screen 0 1280x1024x24" pytest tests/e2e-tests -v --tb=short
+
+  # ============================================================
   # Windows .exe
   # ============================================================
   build-windows:
     name: "Build Windows .exe"
     runs-on: windows-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -30,9 +69,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" pyinstaller
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
+          pip install -e . pyinstaller
       - name: Build .exe
         run: pyinstaller opensak.spec --clean --noconfirm
         env:
@@ -52,6 +89,7 @@ jobs:
   build-linux:
     name: "Build Linux AppImage"
     runs-on: ubuntu-22.04
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - name: Install system packages
@@ -65,11 +103,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" pyinstaller
-      - name: Run tests
-        run: xvfb-run -a pytest tests/ -v --tb=short
-        env:
-          PYTHONPATH: src
+          pip install -e . pyinstaller
       - name: Build Linux binary
         run: xvfb-run -a pyinstaller opensak.spec --clean --noconfirm
         env:
@@ -108,6 +142,7 @@ jobs:
   build-macos-arm64:
     name: "Build macOS arm64 (Apple Silicon)"
     runs-on: macos-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -117,12 +152,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" pyinstaller
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
-        env:
-          PYTHONPATH: src
-        continue-on-error: true
+          pip install -e . pyinstaller
       - name: Build macOS .app (arm64)
         run: pyinstaller opensak.spec --clean --noconfirm
         env:
@@ -152,6 +182,7 @@ jobs:
   build-macos-x86:
     name: "Build macOS x86_64 (Intel)"
     runs-on: macos-15-intel
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -161,12 +192,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" pyinstaller
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
-        env:
-          PYTHONPATH: src
-        continue-on-error: true
+          pip install -e . pyinstaller
       - name: Build macOS .app (x86_64)
         run: pyinstaller opensak.spec --clean --noconfirm
         env:


### PR DESCRIPTION
The test suite ran inside every build job (4x duplication) and macOS used continue-on-error: true, so a broken build on a shipped platform still released.

- add one 'test' job (ubuntu, Python 3.11/3.12) running unit + e2e once
- every build job now 'needs: test', so no artifact is built unless tests pass
- drop the per-build 'Run tests' steps and the macOS continue-on-error masking
- build jobs only package; they install runtime deps + pyinstaller, not [dev]

Tested and the Build/Release works as expected
Source: https://github.com/Fabio-A-Sa/OpenSAK/actions/runs/27510406253

<img width="1009" height="328" alt="Screenshot 2026-06-14 at 21 04 19" src="https://github.com/user-attachments/assets/cd14c1a7-ec68-4c68-a5a7-d336ec06ba74" />
