### PR TITLE
Fix: macOS Intel Build Warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
+  # Opt into Homebrew's upcoming trust enforcement (default in 5.2/6.0) so the
+  # macOS jobs silently ignore the runners' pre-installed untrusted taps
+  # (aws/tap, azure/bicep) instead of printing a migration notice. create-dmg
+  # lives in the always-trusted core tap, so the build is unaffected.
+  HOMEBREW_REQUIRE_TAP_TRUST: "1"
 
 jobs:
 


### PR DESCRIPTION
The macOS build jobs install create-dmg via Homebrew. On GitHub-hosted runners this triggered a migration notice about the pre-installed, untrusted aws/tap and azure/bicep taps. Setting HOMEBREW_REQUIRE_TAP_TRUST=1 adopts the upcoming default behaviour, so those unused taps are ignored silently while create-dmg (core tap) still installs normally.