### PR TITLE
ci: expand mypy type-check to all modules except gui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,10 @@ markers = [
     "gui: tests that require a display and pytest-qt",
 ]
 
-# Typed-first: only the modules below are checked; scope expands over time.
+# Whole package is type-checked except gui/, which is tracked separately.
 [tool.mypy]
-files = ["src/opensak/db", "src/opensak/filters", "src/opensak/geocoder.py"]
+files = ["src/opensak"]
+exclude = ["src/opensak/gui/"]
 mypy_path = "src"
 explicit_package_bases = true
 namespace_packages = true

--- a/src/opensak/api/geocaching.py
+++ b/src/opensak/api/geocaching.py
@@ -123,6 +123,13 @@ def _is_token_valid(token_data: dict) -> bool:
 
 # ── OAuth PKCE flow ───────────────────────────────────────────────────────────
 
+class _CallbackServer(http.server.HTTPServer):
+    """HTTPServer der bærer OAuth-resultatet fra callback-handleren."""
+
+    auth_code: Optional[str] = None
+    auth_error: Optional[str] = None
+
+
 class _CallbackHandler(http.server.BaseHTTPRequestHandler):
     """Minimal HTTP handler der fanger OAuth callback fra browseren."""
 
@@ -198,10 +205,8 @@ def start_oauth_flow() -> Optional[dict]:
     auth_url = GC_AUTH_URL + "?" + urllib.parse.urlencode(params)
 
     # Start lokal callback-server
-    server = http.server.HTTPServer(("localhost", GC_REDIRECT_PORT), _CallbackHandler)
-    server.auth_code  = None
-    server.auth_error = None
-    server.timeout    = 120  # Timeout efter 2 minutter
+    server = _CallbackServer(("localhost", GC_REDIRECT_PORT), _CallbackHandler)
+    server.timeout = 120  # Timeout efter 2 minutter
 
     thread = threading.Thread(target=lambda: server.handle_request(), daemon=True)
     thread.start()

--- a/src/opensak/app.py
+++ b/src/opensak/app.py
@@ -4,7 +4,11 @@ app.py — Application entry point for OpenSAK.
 
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 from opensak.gui.icon import get_app_icon
+
+if TYPE_CHECKING:
+    from PySide6.QtWidgets import QSplashScreen
 
 def _migrate_legacy_db() -> None:
     """

--- a/src/opensak/coords.py
+++ b/src/opensak/coords.py
@@ -91,8 +91,7 @@ def format_lat(lat: float, fmt: CoordFormat) -> str:
         return f"{h}{deg:02d}° {m:02d}' {s:05.2f}\""
     # default: DMM (geocaching standard)
     deg = int(a)
-    m = (a - deg) * 60
-    return f"{h}{deg:02d} {m:06.3f}"
+    return f"{h}{deg:02d} {(a - deg) * 60:06.3f}"
 
 
 def format_lon(lon: float, fmt: CoordFormat) -> str:
@@ -112,8 +111,7 @@ def format_lon(lon: float, fmt: CoordFormat) -> str:
         return f"{h}{deg:03d}° {m:02d}' {s:05.2f}\""
     # default: DMM (geocaching standard)
     deg = int(a)
-    m = (a - deg) * 60
-    return f"{h}{deg:03d} {m:06.3f}"
+    return f"{h}{deg:03d} {(a - deg) * 60:06.3f}"
 
 
 # ── Parsing ───────────────────────────────────────────────────────────────────

--- a/src/opensak/gps/garmin.py
+++ b/src/opensak/gps/garmin.py
@@ -730,7 +730,7 @@ class ExportResult:
             return (
                 f"✓ {self.cache_count} caches eksporteret\n"
                 f"  Enhed: {self.device}\n"
-                f"  Fil: {self.file_path.name}"
+                f"  Fil: {self.file_path.name if self.file_path else ''}"
             )
         return f"✗ Fejl: {self.error}"
 

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -650,7 +650,7 @@ def _upsert_cache(
         existing = session.query(Cache).filter_by(gc_code=gc_code).first()
     created = existing is None
 
-    if created:
+    if existing is None:
         cache = Cache(gc_code=gc_code)
         session.add(cache)
     else:

--- a/src/opensak/lang/__init__.py
+++ b/src/opensak/lang/__init__.py
@@ -51,6 +51,7 @@ def load_language(lang_code: str) -> None:
     # Indlæs sprogfilen som et Python-modul og hent STRINGS dict
     import importlib.util
     spec = importlib.util.spec_from_file_location(f"opensak.lang.{lang_code}", lang_file)
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 

--- a/src/opensak/utils/doctor.py
+++ b/src/opensak/utils/doctor.py
@@ -22,7 +22,7 @@ def _project_metadata() -> dict:
     try:
         meta = importlib.metadata.metadata("opensak")
         return {
-            "requires-python": meta.get("Requires-Python", ""),
+            "requires-python": meta["Requires-Python"] or "",
             "dependencies": [
                 r for r in importlib.metadata.requires("opensak") or []
                 if "extra ==" not in r


### PR DESCRIPTION
Covers the whole package bar gui/ (still tracked separately) and fixes the 15 resulting errors: importlib spec/None guards, Path|None and Cache|None narrowing, a typed OAuth callback server, and coords float formatting.