### PR TITLE
CI: gate beta branch and target Dependabot at beta

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,12 @@
 version: 2
 
-# PRs land on the default branch (main); set target-branch here once a beta branch exists.
+# PRs land on the beta branch (the primary development branch); they go through CI
+# and reach main via a beta -> main PR.
 
 updates:
   - package-ecosystem: pip
     directory: /
+    target-branch: beta
     schedule:
       interval: daily
     open-pull-requests-limit: 10
@@ -14,6 +16,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: beta
     schedule:
       interval: daily
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, beta ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, beta ]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Add beta to the CI push/PR triggers so the new primary development branch runs the Tests and Quality gates, and point Dependabot's pip and github-actions updates at beta so their PRs flow through CI before reaching main. Part of #257.