### PR TITLE
Architecture: the offline reverse-geocoding engine

### DIFF
--- a/architecture/reverse-geocoding.md
+++ b/architecture/reverse-geocoding.md
@@ -225,35 +225,35 @@ The `counties/` directory **is the cache**: a country's pack is downloaded once 
 ```mermaid
 flowchart TD
     subgraph UI["GUI thread"]
-        DLG["Update Location dialog\n(scope: all / missing / this cache / filter)\n(coords: posted | corrected)"]
-        IMP["GPX/PQ import\n(auto-fill on import)"]
+        DLG["Update Location dialog<br/>(scope: all / missing / this cache / filter)<br/>(coords: posted | corrected)"]
+        IMP["GPX/PQ import<br/>(auto-fill on import)"]
     end
 
     subgraph WORKER["QThread — reverse-geocode worker"]
-        BATCH["batch resolve(coords[])"]
+        BATCH["batch resolve(coords)"]
     end
 
     subgraph ENGINE["geo.boundaries.TerritoryResolver"]
-        S1["Stage 1: per-layer R-Tree query\n(boundaries.db)"]
-        S2["Stage 2: point-in-polygon\n(only on overlaps)"]
-        POLY["Polygon cache\n(lazy-loaded GeoJSON)"]
+        S1["Stage 1: per-layer R-Tree query<br/>(boundaries.db)"]
+        S2["Stage 2: point-in-polygon<br/>(only on overlaps)"]
+        POLY["Polygon cache<br/>(lazy-loaded GeoJSON)"]
     end
 
     subgraph STORE["geo.store + geo.packs"]
-        BB[("boundaries.db\nrtree_country/state/county")]
-        GJ[["GeoJSON packs\n(local cache)"]]
-        DL["on-demand pack fetch\nGitHub Releases + version check"]
+        BB[("boundaries.db<br/>rtree_country / state / county")]
+        GJ[["GeoJSON packs<br/>(local cache)"]]
+        DL["on-demand pack fetch<br/>GitHub Releases + version check"]
     end
 
-    DB[("Cache DB\ncountry/state/county + metadata")]
+    DB[("Cache DB<br/>country / state / county + metadata")]
 
-    DLG --> WORKER
-    IMP --> WORKER
+    DLG --> BATCH
+    IMP --> BATCH
     BATCH --> S1
     S1 -->|1 hit| RESULT["GeoLocation"]
-    S1 -->|>1 hit| S2
+    S1 -->|2+ hits| S2
     S2 --> POLY
-    POLY -.cache miss.-> DL
+    POLY -. cache miss .-> DL
     S2 --> RESULT
     S1 --- BB
     POLY --- GJ
@@ -295,14 +295,14 @@ A maintainer-run pipeline lives under `tools/` (kept out of the runtime package 
 
 ```mermaid
 flowchart LR
-    A["raw polygon files\n(native text, mixed encodings)"] --> B["normalise\nUTF-8, fix diacritics,\nconsistent keys"]
-    OSM["OSM / Natural Earth / GADM\n(refresh stale polygons)"] --> B
-    B --> X["convert to GeoJSON\n(1 FeatureCollection / country)"]
-    X --> C["validate geometry\n(rings, winding, holes)"]
+    A["raw polygon files<br/>(native text, mixed encodings)"] --> B["normalise<br/>UTF-8, fix diacritics,<br/>consistent keys"]
+    OSM["OSM / Natural Earth / GADM<br/>(refresh stale polygons)"] --> B
+    B --> X["convert to GeoJSON<br/>(1 FeatureCollection / country)"]
+    X --> C["validate geometry<br/>(rings, winding, holes)"]
     C --> D["read bbox per feature"]
-    D --> E["generate boundaries.db\n(per-layer R-Trees + metadata)"]
-    C --> F["group counties per country\n+ assemble baseline"]
-    E --> G["manifest.json\n(versions)"]
+    D --> E["generate boundaries.db<br/>(per-layer R-Trees + metadata)"]
+    C --> F["group counties per country<br/>+ assemble baseline"]
+    E --> G["manifest.json<br/>(versions)"]
     F --> G
     G --> H["publish to GitHub Releases"]
 ```
@@ -334,17 +334,11 @@ Boundaries move and names change, so **both** artefacts are versioned and refres
 
 ```mermaid
 flowchart TD
-    L["app launch / manual check\n(throttled, e.g. weekly)"] --> M["fetch manifest.json\nfrom latest data release"]
-    M --> C{"dataset version\nnewer?"}
+    L["app launch / manual check<br/>(throttled, ~weekly)"] --> M["fetch manifest.json<br/>(latest data release)"]
+    M --> C{"dataset<br/>newer?"}
     C -->|no| DONE["nothing to do"]
-    C -->|yes| I{"boundaries.db\nversion changed?"}
-    I -->|yes| DLI["download new boundaries.db\nto temp, then atomic swap"]
-    I -->|no| P
-    DLI --> P{"any cached pack\nout of date?"}
-    P -->|yes| DLP["re-download only the\ncached packs that changed"]
-    P -->|no| DONE2["up to date"]
-    DLP --> STALE
-    DLI --> STALE["mark affected caches' location_dataset\nas stale (do not silently rewrite)"]
+    C -->|yes| DLD["download only the changed files<br/>boundaries.db + out-of-date cached packs<br/>(temp, then atomic swap)"]
+    DLD --> STALE["flag affected caches' location_dataset as stale<br/>(no silent rewrite)"]
     STALE --> PROMPT["offer 'Update Location' re-run"]
 ```
 

--- a/architecture/reverse-geocoding.md
+++ b/architecture/reverse-geocoding.md
@@ -1,9 +1,11 @@
 # Architecture — Offline Reverse Geocoding
 
 OpenSAK assigns a **country**, **state/region** and **county** to every cache by
-reverse geocoding its coordinates against a local, polygon-accurate boundary
-dataset. The whole operation runs **offline**, on a background thread, with no
-network calls on the hot path and no per-request rate limits.
+reverse geocoding its coordinates against a polygon-accurate boundary dataset
+held on the user's machine. The dataset is **local-first**: boundary data is
+fetched once from a remote source and cached on disk, after which lookups need
+no network and have no rate limits. A full database resolves on a background
+thread in seconds.
 
 This document describes the design of that subsystem — the *boundary engine*.
 
@@ -16,6 +18,9 @@ This document describes the design of that subsystem — the *boundary engine*.
 - [3. Benefits](#3-benefits)
 - [4. Design decisions](#4-design-decisions)
 - [5. Boundary data model](#5-boundary-data-model)
+  - [5.1 Polygon files](#51-polygon-files)
+  - [5.2 The bounding-box database](#52-the-bounding-box-database)
+  - [5.3 On-disk layout and caching](#53-on-disk-layout-and-caching)
 - [6. System overview](#6-system-overview)
   - [6.1 The two-stage query](#61-the-two-stage-query)
   - [6.2 Build-time data pipeline](#62-build-time-data-pipeline)
@@ -58,7 +63,7 @@ The data is **not** reliably available from the source files:
 Reverse geocoding is fundamentally a **point-in-region** query: given a point,
 find which administrative polygons contain it. The challenge is doing that
 **accurately** (correct at and near borders) and **fast** (tens of thousands of
-caches at once), entirely offline.
+caches at once), without depending on a live network service per lookup.
 
 ---
 
@@ -81,18 +86,20 @@ The boundary engine uses a **two-stage lookup** built on a spatial index (see
    precise point-in-polygon test, and only on the 2–3 candidates Stage 1
    returned.
 
-This keeps the expensive geometry off the hot path. Because a county polygon
-records its parent state and country, a single county hit fills all three fields
+This keeps the expensive geometry off the hot path. Because a county record
+names its parent state and country, a single county hit fills all three fields
 at once.
+
+The design follows the proven structure GSAK has used for years (its
+`bb.db3` + polygon-file system), re-expressed in clean, modern data.
 
 ---
 
 ## 3. Benefits
 
-- **Instant and offline.** A 10k+ cache database resolves locally in seconds.
-  No network on the hot path, so it works on a plane, in the field, anywhere.
-- **No rate limits, no bans.** Nothing is throttled or quota'd — the engine is
-  pure local computation.
+- **Local-first and fast.** Once the relevant boundary data is cached on the
+  machine, a 10k+ cache database resolves locally in seconds — no per-lookup
+  network call, no rate limits, works in the field.
 - **Polygon-accurate.** Results are correct at and near borders, not snapped to
   the nearest town. This is what challenge caching requires.
 - **Auditable provenance.** Every value records where it came from (imported vs
@@ -101,11 +108,11 @@ at once.
 - **Both coordinate bases.** Posted coordinates by default (checker
   compatibility); corrected coordinates on demand for physical planning.
 - **Controlled footprint.** A small baseline ships with the app; detailed
-  county data downloads only when needed.
+  county data is fetched and cached only when a region actually needs it.
 - **Live-updatable data.** Boundaries refresh independently of app releases via
-  a versioned manifest.
-- **Tool parity.** Built on the same public-domain boundary dataset the wider
-  community already uses, so results line up with established tools.
+  per-file version numbers.
+- **Tool parity.** Built on the same boundary lineage the wider community
+  already uses, so results line up with established tools.
 - **Extensible.** The same engine serves any boundary *layer* — custom polygons
   (Delorme, Ordnance Survey, challenge regions) need only data, not code.
 
@@ -115,10 +122,10 @@ at once.
 
 | # | Decision | Choice | Rationale |
 |---|----------|--------|-----------|
-| D1 | **Boundary data source** | Public-domain polygon files (community/GSAK lineage), **normalised** to UTF-8 + standard GeoJSON, from which OpenSAK regenerates its own R-Tree database. | Community parity for support; crowd-sourced coverage; clean diacritics (`Türkiye`) and refreshable stale polygons. |
+| D1 | **Boundary data source** | Community polygon files of GSAK lineage, **normalised** to UTF-8 with consistent naming, from which OpenSAK regenerates its own R-Tree database. The native text format is kept (no conversion). | Community parity for support; crowd-sourced coverage; fixes the mixed encodings/diacritics (`Türkiye`, broken `©`) in the source files; direct compatibility with the files maintainers already produce. |
 | D2 | **Result storage** | `Cache.country/state/county` hold the single result set; **provenance metadata** (source, coordinate basis, timestamp, dataset version) sits alongside. | Re-runnable and auditable without doubling every column. |
-| D3 | **Distribution** | Ship a small **baseline** dataset (country + state); download **county packs on demand** with a checkable version number. | Controls install/DB footprint; updates boundaries without an app release. |
-| D4 | **Granularity** | A **generic layered polygon engine** — country/state/county today, extensible to custom layers. | One engine for every layer; no rewrite to add custom polygons. |
+| D3 | **Distribution** | Ship a small **baseline** dataset (country + state); fetch **county packs per country, on demand**, and cache them locally with a checkable version number. | Controls install/DB footprint; updates boundaries without an app release; avoids shipping 26k+ county polygons up front. |
+| D4 | **Granularity** | A **layered** engine — country/state/county today, extensible to custom layers — each layer being its own R-Tree + metadata table. | One query path for every layer; adding a custom layer is data, not code. |
 
 Recorded alternatives:
 
@@ -126,71 +133,111 @@ Recorded alternatives:
   county coverage is hard and results diverge from established tools, generating
   support load. These sources are used to **refresh** individual polygons under
   D1, not as the wholesale base.
+- *Convert polygons to GeoJSON* — the native text format is simpler (a header
+  plus `lat,lon` rows), already carries a precomputed bounding box, and matches
+  what upstream maintainers ship and edit. Conversion is left as an optional
+  interop step, not a requirement.
 - *Separate `corrected_*` columns* — instead, D2's `location_basis` records
-  which coordinates produced the stored value. Storing both bases at once can be
-  revisited if filtering demand appears.
+  which coordinates produced the stored value.
 - *Bundle every polygon* — simplest, but bloats the install; rejected for D3.
 
 ---
 
 ## 5. Boundary data model
 
-Two artefacts, in open formats:
+Two artefacts, mirroring the GSAK lineage in cleaned form.
 
-### 5.1 Polygon files (the geometry)
+### 5.1 Polygon files
 
-One file per region, standard **GeoJSON** (`Feature`), UTF-8, with normalised
-names. A region can be a `MultiPolygon` (islands) and may contain holes
-(enclaves) — GeoJSON ring winding handles both.
+One self-describing text file per region (or per grouped set, for counties).
+A header of `#` comment lines carries the display name, the **source and
+licence**, and a **precomputed bounding box**; the body is one `lat,lon` pair
+per line. A file may hold several polygons (islands); each polygon's first and
+last coordinate match (closed ring), and holes (enclaves) are wound in the
+opposite direction.
 
-```jsonc
-// counties/us-tx-travis.geojson
-{
-  "type": "Feature",
-  "properties": {
-    "layer": "county",
-    "name": "Travis",
-    "parent": "US/TX",          // state/country this nests under
-    "version": 7,               // bumped when the polygon is corrected
-    "source": "community|osm|user"
-  },
-  "geometry": { "type": "MultiPolygon", "coordinates": [ /* ... */ ] }
-}
+```text
+# GsakName=Denmark
+# This Country polygon is based on data © OpenStreetMap contributors
+# The OpenStreetMap data is made available under the Open Database License (ODbL)
+# Bounding Box: 57.9524297,54.4516667,12.9058301,7.7153255
+54.8370717,9.4829269
+54.8316638,9.4629539
+54.8333102,9.4601121
+...
 ```
 
-### 5.2 The bounding-box database (`boundaries.db`)
+Key consequences captured by the format:
 
-A SQLite file generated **once** from all polygon files. It holds the R-Tree
-plus an auxiliary metadata table, and contains **no information not derivable
-from the polygons**, so it inherits their public-domain status.
+- The **licence travels with the data.** OSM-derived polygons are **ODbL**
+  (attribution + share-alike), *not* public domain; other files may carry other
+  terms. The engine preserves the header and surfaces the aggregate attributions
+  (see [§13](#13-risks)).
+- The bounding box is **already computed**, so building the index ([§5.2](#52-the-bounding-box-database))
+  is a trivial read, not a geometry pass.
+- Files are **normalised to UTF-8** on ingest (the source files are mixed
+  encodings — note the broken `©` above), fixing diacritics and renames.
+
+County granularity is grouped: a country's county polygons live together (e.g.
+all of Portugal's ~3,900, all of Brazil's ~5,500) and each county record points
+to its polygon **within** that group — which makes "per-country" the natural
+download unit ([§5.3](#53-on-disk-layout-and-caching)).
+
+### 5.2 The bounding-box database
+
+A SQLite file (`boundaries.db`) generated **once** from the polygon-file
+headers. It is the spatial index plus metadata, and contains **no information
+not derivable from the polygons**, so it inherits their terms.
+
+GSAK's shipped `bb.db3` uses **one R-Tree per layer** with a companion metadata
+table, joined by id — for example:
 
 ```sql
--- Stage 1: R-Tree of axis-aligned bounding boxes (SQLite built-in module)
-CREATE VIRTUAL TABLE region_bbox USING rtree(
-    id,                 -- INTEGER primary key
-    min_lat, max_lat,
-    min_lon, max_lon
-);
+-- one spatial index per layer (country / state / county)
+CREATE VIRTUAL TABLE rtree_county USING rtree(bbid, MinLat, MaxLat, MinLon, MaxLon);
 
--- Auxiliary metadata, joined by id
-CREATE TABLE region_meta (
-    id            INTEGER PRIMARY KEY,
-    layer         TEXT NOT NULL,   -- 'country' | 'state' | 'county' | <custom>
-    name          TEXT NOT NULL,   -- UTF-8, normalised ('Türkiye')
-    parent        TEXT,            -- e.g. 'US/TX'
-    polygon_file  TEXT NOT NULL,   -- relative path to the GeoJSON
-    poly_version  INTEGER NOT NULL,
-    is_bundled    INTEGER NOT NULL -- 1 = in baseline install, 0 = on-demand pack
-);
+-- companion metadata; bbid == rowid of this table
+CREATE TABLE bb_county (Country, State, File, MaxLat, MinLat, MaxLon, MinLon, Cname);
 ```
+
+OpenSAK keeps that proven shape, cleaned and consistently named:
+
+```sql
+-- Stage 1: one R-Tree per layer (SQLite built-in module)
+CREATE VIRTUAL TABLE rtree_country USING rtree(id, min_lat, max_lat, min_lon, max_lon);
+CREATE VIRTUAL TABLE rtree_state   USING rtree(id, min_lat, max_lat, min_lon, max_lon);
+CREATE VIRTUAL TABLE rtree_county  USING rtree(id, min_lat, max_lat, min_lon, max_lon);
+
+-- Stage 2 / metadata: one row per region, id == matching R-Tree id
+CREATE TABLE region_county (
+    id            INTEGER PRIMARY KEY,
+    name          TEXT NOT NULL,   -- UTF-8, normalised ('Türkiye')
+    parent        TEXT,            -- 'US/TX' — links county -> state -> country
+    polygon_file  TEXT NOT NULL,   -- file (and index within it, for grouped counties)
+    poly_version  INTEGER NOT NULL,
+    is_bundled    INTEGER NOT NULL -- 1 = baseline install, 0 = on-demand pack
+);
+-- region_country / region_state follow the same shape.
+
+-- Per-file versions, driving update checks (mirrors GSAK's Version table)
+CREATE TABLE file_version (layer TEXT, country TEXT, state TEXT, version INTEGER);
+```
+
+A US-county name/abbreviation reference table is carried alongside (GSAK ships
+one) to normalise names — e.g. stripping the spurious word "County" some sources
+append.
 
 > **Why SQLite's own R-Tree** rather than an external index package: it is a
 > compile-time-standard SQLite module (no extra native dependency to ship on
 > Windows/macOS/Linux), it persists to disk for free, and it keeps the index
-> next to the data. Point-in-polygon (Stage 2) is the only piece needing a
+> next to the metadata. Point-in-polygon (Stage 2) is the only piece needing a
 > geometry library — see [§8](#8-dependencies).
 
-### 5.3 On-disk layout
+For scale: a real `bb.db3` holds ~384 countries, ~2,330 state polygons and
+~26,170 county polygons in roughly 7 MB — bounding boxes only. The polygon files
+themselves are far larger and are why counties are fetched on demand.
+
+### 5.3 On-disk layout and caching
 
 Under the platform app-data directory (resolved by `config.get_app_data_dir()`):
 
@@ -198,15 +245,20 @@ Under the platform app-data directory (resolved by `config.get_app_data_dir()`):
 <app-data>/opensak/
 ├── Default.db                 # the cache database
 └── boundaries/
-    ├── boundaries.db          # generated R-Tree + metadata (baseline)
-    ├── manifest.json          # dataset + per-pack version numbers
-    ├── countries/             # baseline, bundled with the install
-    │   └── *.geojson
-    ├── states/                # baseline, bundled with the install
-    │   └── *.geojson
-    └── counties/              # downloaded on demand (D3)
-        └── *.geojson
+    ├── boundaries.db          # generated R-Trees + metadata (baseline)
+    ├── manifest.json          # dataset version + per-pack versions
+    ├── countries/             # baseline — bundled with the install
+    │   └── *.txt
+    ├── states/                # baseline — bundled with the install
+    │   └── *.txt
+    └── counties/              # fetched per country on demand, then cached
+        ├── prt.txt
+        └── usa-tx.txt
 ```
+
+The `counties/` directory **is the cache**: a county pack is downloaded once,
+written here, and every later lookup reads it locally. Nothing is re-fetched
+unless a version bump says the data changed ([§6.3](#63-distribution-and-updates)).
 
 ---
 
@@ -224,15 +276,15 @@ flowchart TD
     end
 
     subgraph ENGINE["geo.boundaries.TerritoryResolver"]
-        S1["Stage 1: R-Tree bbox query\n(boundaries.db)"]
+        S1["Stage 1: per-layer R-Tree query\n(boundaries.db)"]
         S2["Stage 2: point-in-polygon\n(only on overlaps)"]
-        POLY["Polygon cache\n(lazy-loaded GeoJSON)"]
+        POLY["Polygon cache\n(lazy-loaded files)"]
     end
 
     subgraph STORE["geo.store + geo.packs"]
-        BB[("boundaries.db")]
-        GJ[["*.geojson packs"]]
-        DL["on-demand pack download\n+ version check (D3)"]
+        BB[("boundaries.db\nrtree_country/state/county")]
+        GJ[["polygon files\n(local cache)"]]
+        DL["on-demand pack fetch\n+ version check (D3)"]
     end
 
     DB[("Cache DB\ncountry/state/county + metadata")]
@@ -243,7 +295,7 @@ flowchart TD
     S1 -->|1 hit| RESULT["GeoLocation"]
     S1 -->|>1 hit| S2
     S2 --> POLY
-    POLY -.miss.-> DL
+    POLY -.cache miss.-> DL
     S2 --> RESULT
     S1 --- BB
     POLY --- GJ
@@ -270,7 +322,7 @@ flowchart TD
         ▼                    ▼
      DONE          ┌────────────────────────┐
    (no geometry)   │ Stage 2  point-in-poly  │  only on 2–3 candidates
-                   │ load GeoJSON, ray-cast  │
+                   │ load polygon, ray-cast  │
                    │ (holes respected)       │
                    └───────────┬─────────────┘
                                ▼
@@ -278,41 +330,47 @@ flowchart TD
 ```
 
 The lookup runs per layer; a county hit also yields its state and country
-through the polygon's `parent`, so one query can fill all three fields.
+through the record's `parent`, so one query can fill all three fields.
 
 ### 6.2 Build-time data pipeline
 
 A maintainer-run pipeline lives under `tools/` (kept out of the runtime package
-and excluded from release bundles). It turns raw public-domain polygons into
-shippable artefacts:
+and excluded from release bundles). It turns raw polygon files into shippable
+artefacts:
 
 ```mermaid
 flowchart LR
-    A["raw polygon files\n(mixed encodings/formats)"] --> B["normalise\nUTF-8 names, fix diacritics,\nconvert to GeoJSON"]
+    A["raw polygon files\n(mixed encodings)"] --> B["normalise\nUTF-8 names, fix diacritics,\nconsistent keys"]
     OSM["OSM / Natural Earth / GADM\n(refresh stale polygons)"] --> B
     B --> C["validate geometry\n(closed rings, winding, holes)"]
-    C --> D["compute bbox per region"]
-    D --> E["generate boundaries.db\n(R-Tree + meta)"]
-    C --> F["split into baseline + county packs"]
+    C --> D["read precomputed bbox\nfrom each header"]
+    D --> E["generate boundaries.db\n(per-layer R-Trees + metadata)"]
+    C --> F["group counties per country\n+ assemble baseline"]
     E --> G["manifest.json\n(versions)"]
     F --> G
 ```
 
-`boundaries.db` is derived purely by extracting the min/max latitude and
-longitude of each polygon — a quick, one-off process repeated whenever the
-dataset changes.
+Building `boundaries.db` is mostly reading the `# Bounding Box` line already
+present in each file — a quick, one-off process repeated whenever the dataset
+changes.
 
 ### 6.3 Distribution and updates
 
 - **Baseline** (`countries/`, `states/`, `boundaries.db`) ships as package data
-  in the install, so country/state resolution works offline immediately.
-- **County packs** download on demand: when a county lookup needs a polygon
-  listed in `region_meta` but absent on disk, `geo.packs` fetches that pack from
-  a versioned host (release assets / `opensak.com`).
-- **`manifest.json`** carries a dataset version and per-pack versions. On launch
-  (or on user request) OpenSAK compares against the remote manifest and offers
-  to refresh changed packs, so boundary data — including `boundaries.db` —
-  updates independently of app releases.
+  in the install, so country/state resolution works with no network from first
+  launch.
+- **County packs** are fetched per country the first time a lookup needs one:
+  when a county box is hit but its polygon file is not yet in the local cache,
+  `geo.packs` downloads that country's pack from a versioned host (release
+  assets / `opensak.com`), writes it under `counties/`, and serves it locally
+  thereafter.
+- **Versions.** `boundaries.db` carries per-file versions; `manifest.json`
+  carries a dataset version. On launch (or on user request) OpenSAK compares
+  against the remote manifest and offers to refresh changed packs — so boundary
+  data, including `boundaries.db` itself, updates independently of app releases.
+
+So the **only** time the network is involved is the first fetch of a region's
+data (or a deliberate refresh); steady-state operation is fully local.
 
 ---
 
@@ -353,7 +411,7 @@ whether it predates a boundary refresh.
 |------|--------|-------|
 | R-Tree (Stage 1) | **SQLite built-in `rtree`** | No new dependency; standard in CPython's bundled SQLite. |
 | Point-in-polygon (Stage 2) | **`shapely`** | C-backed (GEOS), correct with holes/multipolygons, cross-platform wheels. A pure-Python ray-casting fallback stays available for a zero-native-dependency build, at some speed/robustness cost. |
-| GeoJSON parsing | stdlib `json` | No `geojson`/`fiona`/`geopandas` needed. |
+| Polygon parsing | stdlib | Plain `lat,lon` text; no GIS reader needed. |
 | Country code → name | `pycountry` | Normalising ISO codes to display names in the pipeline. |
 
 ---
@@ -367,13 +425,13 @@ and not packaged.
 src/opensak/geo/
 ├── __init__.py
 ├── boundaries.py     # TerritoryResolver: two-stage lookup, returns GeoLocation
-├── store.py          # locate/open boundaries.db, resolve polygon paths, lazy polygon cache
-└── packs.py          # on-demand county-pack download + manifest/version check
+├── store.py          # open boundaries.db, resolve polygon paths, lazy polygon cache
+└── packs.py          # on-demand county-pack fetch + manifest/version check
 
 tools/boundaries/     # build-time only, excluded from packaging
-├── normalise.py      # raw polygons -> clean UTF-8 GeoJSON
-├── build_bbdb.py     # GeoJSON -> boundaries.db (R-Tree + meta)
-└── pack.py           # split into baseline + packs, emit manifest.json
+├── normalise.py      # raw polygons -> clean UTF-8
+├── build_bbdb.py     # polygon headers -> boundaries.db (R-Trees + metadata)
+└── pack.py           # group counties, assemble baseline, emit manifest.json
 ```
 
 `TerritoryResolver` returns a `GeoLocation(country, state, county)` value.
@@ -401,10 +459,10 @@ The feature follows the project's UI conventions:
 |-------|------|-------|
 | Stage 1 (R-Tree) | ~`O(log n)` per point | Batched; tens of thousands of points in well under a second. |
 | Stage 2 (polygon) | only on bbox overlaps | Typically 2–3 candidate polygons; skipped entirely for interior points. |
-| Polygon I/O | lazy + cached | Each region's GeoJSON loads once and is reused across the batch — a Pocket Query clusters geographically, so cache hit rates are high. |
+| Polygon I/O | lazy + cached | Each region's file loads once and is reused across the batch — a Pocket Query clusters geographically, so cache hit rates are high. |
 
 The work stays on the `QThread` with progress signals; a 10k+ batch completes in
-seconds.
+seconds once the relevant packs are cached.
 
 ---
 
@@ -413,9 +471,9 @@ seconds.
 - **Borders.** Stage 2 resolves overlapping boxes exactly. The residual risk is
   an *approximate polygon* itself — mitigated by D1's refresh pipeline and the
   user-override path on the roadmap.
-- **Missing polygon.** Box hit but pack not downloaded → fetch on demand (D3);
-  if offline, return the coarser layer already available (e.g. state without
-  county) and flag it, never a wrong guess.
+- **Pack not yet cached.** Box hit but the county pack is absent locally → fetch
+  and cache on demand (D3); if no network is available, return the coarser layer
+  already cached (e.g. state without county) and flag it, never a wrong guess.
 - **No box hit.** A point over open water or an unmapped area leaves the field
   empty rather than snapping to the nearest land.
 - **Diacritics / renames.** Fixed at normalisation time (D1): UTF-8, `Türkiye`,
@@ -432,10 +490,9 @@ seconds.
   import. Builds on the planned custom-fields system.
 - **Macro hook.** A macro can recompute territories and stash the previous value
   in a custom field, respecting locks.
-- **Custom layers.** D4's generic engine already accepts new `layer` values —
-  Delorme, Ordnance Survey, challenge regions — needing only polygon packs.
-- **Crowd-sourced polygon editing.** A web polygon editor could feed corrections
-  back into the dataset.
+- **Custom layers.** D4's layered engine already accepts new layers — Delorme,
+  Ordnance Survey, challenge regions — by adding an `rtree_<layer>` + metadata
+  table and the polygon packs.
 
 ---
 
@@ -444,10 +501,10 @@ seconds.
 | Risk | Mitigation |
 |------|------------|
 | `shapely`/GEOS native wheels across OSes | Verified in the CI matrix (3.11/3.12, Linux/macOS/Windows); pure-Python ray-cast fallback available. |
-| County polygon footprint | D3 on-demand packs; ship only baseline. |
+| County polygon footprint | D3 per-country packs, fetched and cached on demand; ship only baseline. |
 | Stale / approximate polygons | D1 refresh pipeline + `location_dataset` provenance + future overrides. |
 | Disagreement with other tools | Expected when a tool applies different boundaries or a different coordinate basis. The posted/corrected toggle and `location_basis` make disagreements explainable, not silent. |
-| Boundary-data licensing | Polygons are public-domain; `boundaries.db` is derived (no new information); refreshes drawn from open sources with compatible terms. |
+| Boundary-data licensing | The licence travels in each polygon header — OSM-derived data is **ODbL** (attribution + share-alike), not public domain. The engine preserves headers and ships the aggregate attributions; `boundaries.db` is a derived index (bounding boxes only) under the same terms. |
 
 ---
 
@@ -459,7 +516,11 @@ seconds.
 - **R-Tree** — a tree index for rectangles; answers "which boxes contain or
   overlap this point/box?" quickly. SQLite ships one.
 - **Bounding box** — the smallest axis-aligned rectangle enclosing a region; the
-  Stage-1 approximation.
+  Stage-1 approximation, precomputed in each polygon file's header.
 - **Posted vs corrected coordinates** — published listing coordinates vs the
   user's solved/real coordinates (stored on `UserNote`).
-- **Layer** — a category of boundary (country / state / county / custom).
+- **Layer** — a category of boundary (country / state / county / custom), each
+  its own R-Tree + metadata table.
+- **Local-first** — data is fetched from a remote source once, cached on disk,
+  and served locally thereafter; the network is touched only on first fetch or a
+  deliberate refresh.

--- a/architecture/reverse-geocoding.md
+++ b/architecture/reverse-geocoding.md
@@ -1,13 +1,10 @@
 # Architecture — Offline Reverse Geocoding
 
-OpenSAK assigns a **country**, **state/region** and **county** to every cache by
-reverse geocoding its coordinates against a polygon-accurate boundary dataset
-held on the user's machine. The dataset is **local-first**: a baseline ships with
-the app, the rest is fetched once from GitHub and cached on disk, after which
-lookups need no network and have no rate limits. A full database resolves on a
-background thread in seconds.
+OpenSAK assigns a **country**, **state/region** and **county** to every cache by reverse geocoding its coordinates against a polygon-accurate boundary dataset held on the user's machine. The dataset is **local-first**: a baseline ships with the app, the rest is fetched once from GitHub and cached on disk, after which lookups need no network and have no rate limits. A full database resolves on a background thread in seconds.
 
 This document describes the design of that subsystem — the *boundary engine*.
+
+> **Acknowledgements.** The two-stage spatial design and the boundary dataset described here build directly on GSAK. Mike Wood (*Lignumaqua*), GSAK's custodian, generously shared the approach, the bounding-box index and the public polygon files, and offered them to OpenSAK. This architecture adapts that work to a modern, open stack — the credit for the original method and data is his and the wider GSAK community's.
 
 ---
 
@@ -25,101 +22,64 @@ This document describes the design of that subsystem — the *boundary engine*.
 - [6. System overview](#6-system-overview)
   - [6.1 The two-stage query](#61-the-two-stage-query)
   - [6.2 Build-time data pipeline](#62-build-time-data-pipeline)
-  - [6.3 Distribution and updates](#63-distribution-and-updates)
-- [7. Database schema](#7-database-schema)
-- [8. Dependencies](#8-dependencies)
-- [9. Module layout and integration](#9-module-layout-and-integration)
-- [10. Performance](#10-performance)
-- [11. Accuracy and edge cases](#11-accuracy-and-edge-cases)
-- [12. Roadmap](#12-roadmap)
-- [13. Risks](#13-risks)
+  - [6.3 Distribution](#63-distribution)
+- [7. Keeping the data up to date](#7-keeping-the-data-up-to-date)
+- [8. Storage and bandwidth estimates](#8-storage-and-bandwidth-estimates)
+- [9. Database schema](#9-database-schema)
+- [10. Dependencies](#10-dependencies)
+- [11. Module layout and integration](#11-module-layout-and-integration)
+- [12. Performance](#12-performance)
+- [13. Accuracy and edge cases](#13-accuracy-and-edge-cases)
+- [14. Roadmap](#14-roadmap)
+- [15. Risks](#15-risks)
 - [Appendix A — Glossary](#appendix-a--glossary)
 
 ---
 
 ## 1. Problem
 
-Geocachers need reliable **country / state (region) / county** values on every
-cache, for three concrete reasons:
+Geocachers need reliable **country / state (region) / county** values on every cache, for three concrete reasons:
 
-1. **County / region challenges.** Many caches qualify a finder for a
-   "find a cache in every county"-style challenge. Going to the wrong county is
-   expensive — literally, long drives — and frustrating.
-2. **Filtering and trip planning.** "Show me caches in this county" only works
-   when the field is populated and correct.
-3. **Parity with other tools.** Users cross-check OpenSAK against GSAK,
-   Project-GC and Cachetur. When the answer disagrees, OpenSAK gets the support
-   ticket.
+1. **County / region challenges.** Many caches qualify a finder for a "find a cache in every county"-style challenge. Going to the wrong county is expensive — literally, long drives — and frustrating.
+2. **Filtering and trip planning.** "Show me caches in this county" only works when the field is populated and correct.
+3. **Parity with other tools.** Users cross-check OpenSAK against GSAK, Project-GC and Cachetur. When the answer disagrees, OpenSAK gets the support ticket.
 
 The data is **not** reliably available from the source files:
 
-- Imported GPX / Pocket Query files generally fill `country` and sometimes
-  `state`, but **county is almost always empty**.
-- A cache's real-world location can differ from its *posted* coordinates —
-  multi-caches and mystery/puzzle finals can sit tens of miles away. The
-  territory may need computing from **corrected** coordinates.
-- Boundaries change over time (county splits, `Turkey → Türkiye`,
-  `Czech Republic → Czechia`). Static values go stale.
+- Imported GPX / Pocket Query files generally fill `country` and sometimes `state`, but **county is almost always empty**.
+- A cache's real-world location can differ from its *posted* coordinates — multi-caches and mystery/puzzle finals can sit tens of miles away. The territory may need computing from **corrected** coordinates.
+- Boundaries change over time (county splits, `Turkey → Türkiye`, `Czech Republic → Czechia`). Static values go stale.
 
-Reverse geocoding is fundamentally a **point-in-region** query: given a point,
-find which administrative polygons contain it. The challenge is doing that
-**accurately** (correct at and near borders) and **fast** (tens of thousands of
-caches at once), without depending on a live network service per lookup.
+Reverse geocoding is fundamentally a **point-in-region** query: given a point, find which administrative polygons contain it. The challenge is doing that **accurately** (correct at and near borders) and **fast** (tens of thousands of caches at once), without depending on a live network service per lookup.
 
 ---
 
 ## 2. Concept
 
-The naive solution — test the point against every polygon — is `O(regions ×
-vertices)` per cache and does not scale.
+The naive solution — test the point against every polygon — is `O(regions × vertices)` per cache and does not scale.
 
-The boundary engine uses a **two-stage lookup** built on a spatial index (see
-[SQLite R-Tree](https://sqlite.org/rtree.html)):
+The boundary engine uses a **two-stage lookup** built on a spatial index (see [SQLite R-Tree](https://sqlite.org/rtree.html)):
 
-1. **Stage 1 — bounding-box filter (R-Tree).** Every region is reduced to its
-   min/max latitude and longitude — an axis-aligned bounding box. These boxes
-   live in a SQLite **R-Tree** index. Querying it with a point returns only the
-   handful of regions whose box *contains* the point. This is `O(log n)` and
-   extremely fast.
-2. **Stage 2 — point-in-polygon (exact).** In the common case the point lands in
-   exactly one box → done, with no geometry maths. Only when boxes **overlap**
-   (very common for counties, and near any border) does the engine run the
-   precise point-in-polygon test, and only on the 2–3 candidates Stage 1
-   returned.
+1. **Stage 1 — bounding-box filter (R-Tree).** Every region is reduced to its min/max latitude and longitude — an axis-aligned bounding box. These boxes live in a SQLite **R-Tree** index. Querying it with a point returns only the handful of regions whose box *contains* the point. This is `O(log n)` and extremely fast.
+2. **Stage 2 — point-in-polygon (exact).** In the common case the point lands in exactly one box → done, with no geometry maths. Only when boxes **overlap** (very common for counties, and near any border) does the engine run the precise point-in-polygon test, and only on the 2–3 candidates Stage 1 returned.
 
-This keeps the expensive geometry off the hot path. Because a county record
-names its parent state and country, a single county hit fills all three fields
-at once.
+This keeps the expensive geometry off the hot path. Because a county record names its parent state and country, a single county hit fills all three fields at once.
 
-The two-stage structure follows the proven design GSAK has used for years (its
-`bb.db3` index + polygon-file system); OpenSAK re-expresses it in clean, modern
-data — see [Improvements over the GSAK lineage](#improvements-over-the-gsak-lineage).
+The two-stage structure follows the design GSAK has used for years (its bounding-box index plus polygon-file system); OpenSAK re-expresses it in clean, modern data — see [Improvements over the GSAK lineage](#improvements-over-the-gsak-lineage).
 
 ---
 
 ## 3. Benefits
 
-- **Local-first and fast.** Once the relevant boundary data is cached on the
-  machine, a 10k+ cache database resolves locally in seconds — no per-lookup
-  network call, no rate limits, works in the field.
-- **Polygon-accurate.** Results are correct at and near borders, not snapped to
-  the nearest town. This is what challenge caching requires.
-- **Auditable provenance.** Every value records where it came from (imported vs
-  computed), which coordinates produced it (posted vs corrected), when, and
-  against which boundary dataset version.
-- **Both coordinate bases.** Posted coordinates by default (checker
-  compatibility); corrected coordinates on demand for physical planning.
-- **Controlled footprint.** A small baseline ships with the app; detailed county
-  data is fetched and cached only when a region actually needs it.
-- **Standard format.** Boundaries are stored as **GeoJSON**, so they validate in
-  any GIS tool and can be drawn directly by the Leaflet map for a future
-  "show this boundary" overlay.
-- **Live-updatable data.** Boundaries refresh independently of app releases via
-  per-file version numbers.
-- **No project-run server.** The app install plus GitHub Releases cover
-  everything; there is no backend to host, pay for, or keep alive.
-- **Extensible.** The same engine serves any boundary *layer* — custom polygons
-  (Delorme, Ordnance Survey, challenge regions) need only data, not code.
+- **Local-first and fast.** Once the relevant boundary data is cached on the machine, a 10k+ cache database resolves locally in seconds — no per-lookup network call, no rate limits, works in the field.
+- **Polygon-accurate.** Results are correct at and near borders, not snapped to the nearest town. This is what challenge caching requires.
+- **Auditable provenance.** Every value records where it came from (imported vs computed), which coordinates produced it (posted vs corrected), when, and against which boundary dataset version.
+- **Both coordinate bases.** Posted coordinates by default (checker compatibility); corrected coordinates on demand for physical planning.
+- **Controlled footprint.** A small baseline ships with the app; detailed county data is fetched and cached only when a region actually needs it.
+- **Standard format.** Boundaries are stored as **GeoJSON**, so they validate in any GIS tool and can be drawn directly by the Leaflet map for a future "show this boundary" overlay.
+- **Live-updatable data.** Boundaries refresh independently of app releases via per-file version numbers (see [§7](#7-keeping-the-data-up-to-date)).
+- **No project-run server.** The app install plus GitHub Releases cover everything; there is no backend to host, pay for, or keep alive.
+- **Extensible.** The same engine serves any boundary *layer* — custom polygons (Delorme, Ordnance Survey, challenge regions) need only data, not code.
 
 ---
 
@@ -129,46 +89,28 @@ data — see [Improvements over the GSAK lineage](#improvements-over-the-gsak-li
 |---|----------|--------|-----------|
 | D1 | **Boundary data source & format** | Community polygon files of GSAK lineage, **normalised to UTF-8 and converted to GeoJSON** (one `FeatureCollection` per country); OpenSAK regenerates its own R-Tree index from them. The native text is the *ingest* format only. | Community parity for support; crowd-sourced coverage; fixes mixed encodings/diacritics (`Türkiye`, broken `©`); GeoJSON gives unambiguous holes/multipolygons, validation, and direct reuse by the Leaflet map. |
 | D2 | **Result storage** | `Cache.country/state/county` hold the single result set; **provenance metadata** (source, coordinate basis, timestamp, dataset version) sits alongside. | Re-runnable and auditable without doubling every column. |
-| D3 | **Distribution (no own server)** | Ship a small **baseline** (country + state) in the install; fetch **county packs per country, on demand, from GitHub Releases** and cache them locally with a checkable version number. An optional "download all" pre-fetches everything for full offline use. | Controls install/DB footprint; updates without an app release; GitHub Releases is free, CDN-backed and durable, so no backend is needed. |
+| D3 | **Distribution (no own server)** | Ship a small **baseline** (country + state) in the install; fetch **county packs per country, on demand, from GitHub Releases** and cache them locally. An optional "download all" pre-fetches everything for full offline use. | Controls install/DB footprint; GitHub Releases is free, CDN-backed and durable, so no backend is needed. |
 | D4 | **Granularity** | A **layered** engine — country/state/county today, extensible to custom layers — each layer being its own R-Tree + metadata table. | One query path for every layer; adding a custom layer is data, not code. |
 
 Recorded alternatives:
 
-- *Wholesale build from Natural Earth / GADM / OSM only* — clean data, but
-  county coverage is hard and results diverge from established tools, generating
-  support load. These sources are used to **refresh** individual polygons under
-  D1, not as the wholesale base.
-- *Keep the native text format end-to-end* — smaller and zero-conversion, but
-  leaves holes/multipolygons as an implicit convention and gives the map nothing
-  to draw. The pipeline already normalises encoding, so converting to GeoJSON at
-  the same time is nearly free.
-- *Bundle every polygon in the install* — works fully offline from day one, but
-  the global county set is plausibly hundreds of MB and ~99% of it goes unused by
-  any given user; rejected for D3 (the "download all" option covers people who
-  genuinely want everything).
-- *Separate `corrected_*` columns* — instead, D2's `location_basis` records which
-  coordinates produced the stored value.
+- *Wholesale build from Natural Earth / GADM / OSM only* — clean data, but county coverage is hard and results diverge from established tools, generating support load. These sources are used to **refresh** individual polygons under D1, not as the wholesale base.
+- *Keep the native text format end-to-end* — smaller and zero-conversion, but leaves holes/multipolygons as an implicit convention and gives the map nothing to draw. The pipeline already normalises encoding, so converting to GeoJSON at the same time is nearly free.
+- *Bundle every polygon in the install* — works fully offline from day one, but the global county set is plausibly a few hundred MB and ~99% of it goes unused by any given user; rejected for D3 (the "download all" option covers people who genuinely want everything).
+- *Separate `corrected_*` columns* — instead, D2's `location_basis` records which coordinates produced the stored value.
 
 ### Improvements over the GSAK lineage
 
 The data and two-stage method come from GSAK; these are the deliberate changes:
 
-- **UTF-8 everywhere** instead of ANSI — fixes `Türkiye`, `Czechia` and the
-  broken `©` seen in the source files.
-- **GeoJSON** instead of the bespoke text format — standard, validatable,
-  unambiguous geometry, and drawable by the existing Leaflet map.
-- **Independently updatable data** via versioned packs — GSAK's own maintainer
-  noted its `bb.db3` can only be refreshed by shipping a new GSAK release.
-- **Clean schema** — drops the legacy `_old` tables and the mixed
-  full-name/3-letter-code conventions found in `bb.db3`.
-- **Per-cache provenance** (source, coordinate basis, timestamp, dataset
-  version) — GSAK tracked none of this, so it could never explain *which*
-  coordinates a stored value came from.
+- **UTF-8 everywhere** instead of ANSI — fixes `Türkiye`, `Czechia` and the broken `©` seen in the source files.
+- **GeoJSON** instead of the bespoke text format — standard, validatable, unambiguous geometry, and drawable by the existing Leaflet map.
+- **Independently updatable data** via versioned packs — GSAK's own maintainer noted its index can only be refreshed by shipping a new GSAK release. OpenSAK refreshes both the index and the polygons from GitHub (see [§7](#7-keeping-the-data-up-to-date)).
+- **Clean schema** — drops the legacy `_old` tables and the mixed full-name / 3-letter-code conventions found in the original index.
+- **Per-cache provenance** (source, coordinate basis, timestamp, dataset version) — GSAK tracked none of this, so it could never explain *which* coordinates a stored value came from.
 - **64-bit runtime** — none of the 32-bit constraints that slow legacy GSAK.
 
-What is intentionally kept: the **two-stage R-Tree + point-in-polygon** method,
-**one R-Tree per layer**, and **polygon data stored separately** from the index
-(so it can be fetched lazily).
+What is intentionally kept: the **two-stage R-Tree + point-in-polygon** method, **one R-Tree per layer**, and **polygon data stored separately** from the index (so it can be fetched lazily).
 
 ---
 
@@ -178,11 +120,7 @@ Two artefacts, mirroring the GSAK lineage in cleaned, standard form.
 
 ### 5.1 Polygon files
 
-**Ingest (build time).** Upstream files arrive in the native GSAK text format: a
-header of `#` comment lines carrying the display name, the **source and
-licence**, and a **precomputed bounding box**, followed by one `lat,lon` pair per
-line. A file may hold several polygons (islands); each polygon's first and last
-coordinate match (closed ring), and holes are wound in the opposite direction.
+**Ingest (build time).** Upstream files arrive in the native GSAK text format: a header of `#` comment lines carrying the display name, the **source and licence**, and a **precomputed bounding box**, followed by one `lat,lon` pair per line. A file may hold several polygons (islands); each polygon's first and last coordinate match (closed ring), and holes are wound in the opposite direction.
 
 ```text
 # GsakName=Denmark
@@ -194,9 +132,7 @@ coordinate match (closed ring), and holes are wound in the opposite direction.
 ...
 ```
 
-**Stored & distributed.** The pipeline normalises these to UTF-8 and converts
-them to **GeoJSON**, grouped **one `FeatureCollection` per country**. This is the
-format OpenSAK ships, caches and reads.
+**Stored & distributed.** The pipeline normalises these to UTF-8 and converts them to **GeoJSON**, grouped **one `FeatureCollection` per country**. This is the format OpenSAK ships, caches and reads.
 
 ```jsonc
 // counties/prt.geojson — one FeatureCollection per country
@@ -223,23 +159,15 @@ format OpenSAK ships, caches and reads.
 
 Key points the format captures:
 
-- The **licence travels with the data.** OSM-derived polygons are **ODbL**
-  (attribution + share-alike), *not* public domain; the property is preserved and
-  surfaced as aggregate attribution (see [§13](#13-risks)).
-- The bounding box is **already known** from the source header, so building the
-  index ([§5.2](#52-the-bounding-box-database)) is a read, not a geometry pass.
-- Counties are **grouped per country** (Portugal ~3,900 features, Brazil ~5,500),
-  which makes "per-country" the natural download unit ([§5.3](#53-on-disk-layout-and-caching)).
+- The **licence travels with the data.** OSM-derived polygons are **ODbL** (attribution + share-alike), *not* public domain; the property is preserved and surfaced as aggregate attribution (see [§15](#15-risks)).
+- The bounding box is **already known** from the source header, so building the index ([§5.2](#52-the-bounding-box-database)) is a read, not a geometry pass.
+- Counties are **grouped per country** (Portugal ~3,900 features, Brazil ~5,500), which makes "per-country" the natural download unit ([§5.3](#53-on-disk-layout-and-caching)).
 
 ### 5.2 The bounding-box database
 
-A SQLite file (`boundaries.db`) generated **once** from the GeoJSON `bbox`
-members. It is the spatial index plus metadata, and contains **no information not
-derivable from the polygons**, so it inherits their terms.
+A SQLite file — `boundaries.db` (OpenSAK's name for what GSAK ships as `bb.db3`) — generated **once** from the GeoJSON `bbox` members. It is the spatial index plus metadata, and contains **no information not derivable from the polygons**, so it inherits their terms.
 
-GSAK's shipped `bb.db3` uses **one R-Tree per layer** with a companion metadata
-table, joined by id. OpenSAK keeps that proven shape, cleaned and consistently
-named:
+GSAK's index uses **one R-Tree per layer** with a companion metadata table, joined by id. OpenSAK keeps that proven shape, cleaned and consistently named:
 
 ```sql
 -- Stage 1: one R-Tree per layer (SQLite built-in module)
@@ -263,19 +191,11 @@ CREATE TABLE region_county (
 CREATE TABLE file_version (layer TEXT, country TEXT, state TEXT, version INTEGER);
 ```
 
-A US-county name/abbreviation reference table is carried alongside (GSAK ships
-one) to normalise names — e.g. stripping the spurious word "County" some sources
-append.
+A US-county name/abbreviation reference table is carried alongside (GSAK ships one) to normalise names — e.g. stripping the spurious word "County" some sources append.
 
-> **Why SQLite's own R-Tree** rather than an external index package: it is a
-> compile-time-standard SQLite module (no extra native dependency to ship on
-> Windows/macOS/Linux), it persists to disk for free, and it keeps the index next
-> to the metadata. Point-in-polygon (Stage 2) is the only piece needing a
-> geometry library — see [§8](#8-dependencies).
+> **Why SQLite's own R-Tree** rather than an external index package: it is a compile-time-standard SQLite module (no extra native dependency to ship on Windows/macOS/Linux), it persists to disk for free, and it keeps the index next to the metadata. Point-in-polygon (Stage 2) is the only piece needing a geometry library — see [§10](#10-dependencies).
 
-For scale: a real `bb.db3` holds ~384 countries, ~2,330 state polygons and
-~26,170 county polygons in roughly 7 MB — bounding boxes only. The polygon
-geometry is far larger and is why counties are fetched on demand.
+For scale: a real index holds ~384 countries, ~2,330 state polygons and ~26,170 county polygons in roughly 7 MB — bounding boxes only. The polygon geometry is far larger and is why counties are fetched on demand ([§8](#8-storage-and-bandwidth-estimates)).
 
 ### 5.3 On-disk layout and caching
 
@@ -285,7 +205,7 @@ Under the platform app-data directory (resolved by `config.get_app_data_dir()`):
 <app-data>/opensak/
 ├── Default.db                 # the cache database
 └── boundaries/
-    ├── boundaries.db          # generated R-Trees + metadata (baseline)
+    ├── boundaries.db          # generated R-Trees + metadata (seeded from the install)
     ├── manifest.json          # dataset version + per-pack versions
     ├── countries/             # baseline — bundled with the install
     │   └── world.geojson
@@ -296,10 +216,7 @@ Under the platform app-data directory (resolved by `config.get_app_data_dir()`):
         └── usa-tx.geojson
 ```
 
-The `counties/` directory **is the cache**: a country's pack is downloaded once
-from GitHub Releases, written here, and every later lookup reads it locally.
-Nothing is re-fetched unless a version bump says the data changed
-([§6.3](#63-distribution-and-updates)).
+The `counties/` directory **is the cache**: a country's pack is downloaded once from GitHub Releases, written here, and every later lookup reads it locally. Nothing is re-fetched unless a version bump says the data changed ([§7](#7-keeping-the-data-up-to-date)).
 
 ---
 
@@ -370,14 +287,11 @@ flowchart TD
                         winning region
 ```
 
-The lookup runs per layer; a county hit also yields its state and country
-through the record's `parent`, so one query can fill all three fields.
+The lookup runs per layer; a county hit also yields its state and country through the record's `parent`, so one query can fill all three fields.
 
 ### 6.2 Build-time data pipeline
 
-A maintainer-run pipeline lives under `tools/` (kept out of the runtime package
-and excluded from release bundles). It turns raw polygon files into shippable
-artefacts:
+A maintainer-run pipeline lives under `tools/` (kept out of the runtime package and excluded from release bundles). It turns raw polygon files into shippable artefacts:
 
 ```mermaid
 flowchart LR
@@ -393,37 +307,78 @@ flowchart LR
     G --> H["publish to GitHub Releases"]
 ```
 
-Building `boundaries.db` is mostly reading each feature's `bbox` — a quick,
-one-off process repeated whenever the dataset changes, then published as release
-assets.
+Building `boundaries.db` is mostly reading each feature's `bbox` — a quick, one-off process repeated whenever the dataset changes, then published as release assets.
 
-### 6.3 Distribution and updates
+### 6.3 Distribution
 
-There is **no project-run server**. Distribution uses only what an open-source
-project already has:
+There is **no project-run server**. Distribution uses only what an open-source project already has:
 
-- **Baseline** (`countries/`, `states/`, `boundaries.db`) ships as package data
-  in the install, so country/state resolution works with no network from first
-  launch.
-- **County packs** live as **GitHub Releases assets** in a data repository (e.g.
-  `OpenSAK/boundary-data`), each a per-country GeoJSON `FeatureCollection`. The
-  first time a lookup needs a country's counties, `geo.packs` downloads that pack
-  over its stable release URL (GitHub serves these via a CDN), writes it under
-  `counties/`, and serves it locally thereafter.
-- **"Download all"** is an optional one-click action that pre-fetches every pack,
-  for users who want full offline coverage before heading into the field.
-- **Versions.** `boundaries.db` carries per-file versions; `manifest.json`
-  carries a dataset version. On launch (or on user request) OpenSAK compares
-  against the manifest published with the latest release and offers to refresh
-  changed packs — so boundary data, including `boundaries.db` itself, updates
-  independently of app releases.
+- **Baseline** (`countries/`, `states/`, `boundaries.db`) ships as package data in the install, so country/state resolution works with no network from first launch.
+- **County packs** live as **GitHub Releases assets** in a data repository (e.g. `OpenSAK/boundary-data`), each a per-country GeoJSON `FeatureCollection`. The first time a lookup needs a country's counties, `geo.packs` downloads that pack over its stable release URL (GitHub serves these via a CDN), writes it under `counties/`, and serves it locally thereafter.
+- **"Download all"** is an optional one-click action that pre-fetches every pack, for users who want full offline coverage before heading into the field.
 
-So the network is involved **only** on the first fetch of a region's data, a
-"download all", or a deliberate refresh; steady-state operation is fully local.
+So the network is involved **only** on the first fetch of a region's data, a "download all", or a deliberate refresh; steady-state operation is fully local.
 
 ---
 
-## 7. Database schema
+## 7. Keeping the data up to date
+
+Boundaries move and names change, so **both** artefacts are versioned and refreshable independently of the OpenSAK release cycle: the **index** (`boundaries.db`) and the **GeoJSON packs**. The copy shipped in the install is only a first-run *seed* — from then on the data lives in the user's `boundaries/` folder and is updated in place. This deliberately removes the limitation GSAK's maintainer described, where the index could only change by shipping a new application build.
+
+**Version model** (all published together with each data release):
+
+- `manifest.json` — a top-level **dataset version**, plus the version of `boundaries.db` and of every per-country pack.
+- `file_version` inside `boundaries.db` and the `version` property on each GeoJSON feature — fine-grained per-region versions.
+
+**Update flow:**
+
+```mermaid
+flowchart TD
+    L["app launch / manual check\n(throttled, e.g. weekly)"] --> M["fetch manifest.json\nfrom latest data release"]
+    M --> C{"dataset version\nnewer?"}
+    C -->|no| DONE["nothing to do"]
+    C -->|yes| I{"boundaries.db\nversion changed?"}
+    I -->|yes| DLI["download new boundaries.db\nto temp, then atomic swap"]
+    I -->|no| P
+    DLI --> P{"any cached pack\nout of date?"}
+    P -->|yes| DLP["re-download only the\ncached packs that changed"]
+    P -->|no| DONE2["up to date"]
+    DLP --> STALE
+    DLI --> STALE["mark affected caches' location_dataset\nas stale (do not silently rewrite)"]
+    STALE --> PROMPT["offer 'Update Location' re-run"]
+```
+
+Principles:
+
+- **Only what is cached gets refreshed.** Packs the user never downloaded stay absent; they are still fetched lazily when first needed. "Download all" users get every changed pack.
+- **Atomic replacement.** New files download to a temp path and are swapped in, so a failed or interrupted download never corrupts the working copy.
+- **No silent value rewrites.** When a refresh changes a boundary, the affected caches keep their stored `country/state/county` but their `location_dataset` now trails the current dataset version — the UI surfaces this and offers a one-click re-run of *Update Location*. The user decides when values change, which matters for challenge planning.
+- **Throttled checks.** The manifest is small; the check runs at most about once a week (and on explicit request), so it costs effectively nothing.
+
+---
+
+## 8. Storage and bandwidth estimates
+
+Rough, order-of-magnitude figures derived from the sample data: each coordinate line is ~**22 bytes** (`Denmark1.txt`: 21.6 KB / 974 points), the bounding-box index is ~**7 MB** for ~28,900 regions, and the layer counts are 384 countries / 2,330 states / 26,170 counties. GeoJSON is ~1.2× the native text; gzip compresses coordinate text ~4×.
+
+| Layer | Polygons | Native text | GeoJSON (~1.2×) | Gzipped (~4×) |
+|-------|---------:|------------:|----------------:|--------------:|
+| Countries | 384 | ~11 MB | ~14 MB | ~3.5 MB |
+| States | 2,330 | ~35 MB | ~42 MB | ~10 MB |
+| Counties | 26,170 | ~180 MB | ~215 MB | ~55 MB |
+| Index (`boundaries.db`) | — | — | ~7 MB | ~3 MB |
+| **Total (whole world)** | ~28,900 | ~225 MB | **~270 MB** | **~70 MB** |
+
+What this means in practice:
+
+- **Added to the install (baseline = countries + states + index):** ~**60 MB** of GeoJSON. **Geometry simplification** (Douglas–Peucker) is the main lever and is recommended for the baseline: at the zoom these layers need it cuts size 2–5× with negligible accuracy loss, bringing the baseline to roughly **15–25 MB**. (GSAK's polygons are already simplified for the same reason.)
+- **A typical on-demand county download:** Portugal ~3,900 features ≈ **~14 MB** (~3.5 MB gzipped); a US state such as Texas (~250 counties) ≈ **~2.5 MB** (~0.7 MB gzipped); a small country well under 1 MB. A user who caches in a handful of countries downloads **single-digit to low-tens of MB, ever**.
+- **Disk cache.** Packs can be kept gzipped on disk and decompressed on read (cheap for `json`), so even a full "download all" footprint is ~**70 MB**, not 270 MB.
+- **What goes to GitHub.** The full set published as gzipped release assets is ~**70 MB per release**; re-publishing only changed packs makes most releases far smaller. Release assets do **not** count toward the git repository size and the per-asset limit is 2 GB, so this sits comfortably within GitHub's free hosting.
+
+---
+
+## 9. Database schema
 
 The `Cache` model carries the three result fields plus provenance metadata:
 
@@ -440,21 +395,15 @@ location_updated: Mapped[Optional[datetime]] = mapped_column(DateTime)
 location_dataset: Mapped[Optional[str]] = mapped_column(String(32))   # boundary dataset version used
 ```
 
-Corrected coordinates are read from the one-to-one `UserNote`
-(`corrected_lat`, `corrected_lon`, `is_corrected`).
+Corrected coordinates are read from the one-to-one `UserNote` (`corrected_lat`, `corrected_lon`, `is_corrected`).
 
-Schema changes are versioned through `PRAGMA user_version` (see
-`db/database.py`): the engine bumps `SCHEMA_VERSION` and adds the provenance
-columns idempotently, so existing databases upgrade in place with the metadata
-defaulting to "unknown / imported".
+Schema changes are versioned through `PRAGMA user_version` (see `db/database.py`): the engine bumps `SCHEMA_VERSION` and adds the provenance columns idempotently, so existing databases upgrade in place with the metadata defaulting to "unknown / imported".
 
-The provenance fields let a user tell, per cache, whether a value came from the
-import source, from posted coordinates, or from corrected coordinates — and
-whether it predates a boundary refresh.
+The provenance fields let a user tell, per cache, whether a value came from the import source, from posted coordinates, or from corrected coordinates — and whether it predates a boundary refresh (the `location_dataset` check in [§7](#7-keeping-the-data-up-to-date)).
 
 ---
 
-## 8. Dependencies
+## 10. Dependencies
 
 | Need | Choice | Notes |
 |------|--------|-------|
@@ -466,17 +415,16 @@ whether it predates a boundary refresh.
 
 ---
 
-## 9. Module layout and integration
+## 11. Module layout and integration
 
-The engine is a self-contained `geo` subpackage; the build pipeline is separate
-and not packaged.
+The engine is a self-contained `geo` subpackage; the build pipeline is separate and not packaged.
 
 ```
 src/opensak/geo/
 ├── __init__.py
 ├── boundaries.py     # TerritoryResolver: two-stage lookup, returns GeoLocation
 ├── store.py          # open boundaries.db, load GeoJSON packs, lazy polygon cache
-└── packs.py          # on-demand pack fetch from GitHub Releases + version check
+└── packs.py          # on-demand pack fetch + manifest/version check (GitHub Releases)
 
 tools/boundaries/     # build-time only, excluded from packaging
 ├── normalise.py      # raw text polygons -> clean UTF-8
@@ -491,20 +439,14 @@ tools/boundaries/     # build-time only, excluded from packaging
 
 The feature follows the project's UI conventions:
 
-- An **Update Location** dialog drives it, reachable from the Waypoint menu and
-  from the cache-table right-click menu. It offers scope (all caches / only
-  missing / this cache / current filter) and a coordinate-basis choice (posted
-  vs corrected, **defaulting to posted** for checker compatibility).
-- Resolution runs in a **`QThread`** worker that streams progress and results
-  back via Qt signals — the main thread never blocks (a 10k+ batch is heavy).
-- The same worker runs automatically after a GPX/PQ import to fill missing
-  territory data.
-- All user-visible strings go through `tr()` with keys present in every
-  `lang/*.py` module.
+- An **Update Location** dialog drives it, reachable from the Waypoint menu and from the cache-table right-click menu. It offers scope (all caches / only missing / this cache / current filter) and a coordinate-basis choice (posted vs corrected, **defaulting to posted** for checker compatibility).
+- Resolution runs in a **`QThread`** worker that streams progress and results back via Qt signals — the main thread never blocks (a 10k+ batch is heavy).
+- The same worker runs automatically after a GPX/PQ import to fill missing territory data.
+- All user-visible strings go through `tr()` with keys present in every `lang/*.py` module.
 
 ---
 
-## 10. Performance
+## 12. Performance
 
 | Stage | Cost | Notes |
 |-------|------|-------|
@@ -512,51 +454,36 @@ The feature follows the project's UI conventions:
 | Stage 2 (polygon) | only on bbox overlaps | Typically 2–3 candidate polygons; skipped entirely for interior points. |
 | Polygon I/O | lazy + cached | Each country's GeoJSON loads once and is reused across the batch — a Pocket Query clusters geographically, so cache hit rates are high. |
 
-The work stays on the `QThread` with progress signals; a 10k+ batch completes in
-seconds once the relevant packs are cached.
+The work stays on the `QThread` with progress signals; a 10k+ batch completes in seconds once the relevant packs are cached.
 
 ---
 
-## 11. Accuracy and edge cases
+## 13. Accuracy and edge cases
 
-- **Borders.** Stage 2 resolves overlapping boxes exactly. The residual risk is
-  an *approximate polygon* itself — mitigated by D1's refresh pipeline and the
-  user-override path on the roadmap.
-- **Pack not yet cached.** Box hit but the country's pack is absent locally →
-  fetch and cache on demand (D3); if no network is available, return the coarser
-  layer already cached (e.g. state without county) and flag it, never a wrong
-  guess.
-- **No box hit.** A point over open water or an unmapped area leaves the field
-  empty rather than snapping to the nearest land.
-- **Diacritics / renames.** Fixed at normalisation time (D1): UTF-8, `Türkiye`,
-  `Czechia`, etc. `location_dataset` records the dataset version used, so renames
-  stay explainable after the fact.
-- **Posted vs corrected.** `location_basis` records the choice per cache;
-  re-running with the other basis updates both the value and the metadata.
+- **Borders.** Stage 2 resolves overlapping boxes exactly. The residual risk is an *approximate polygon* itself — mitigated by the refresh pipeline (D1, [§7](#7-keeping-the-data-up-to-date)) and the user-override path on the roadmap.
+- **Pack not yet cached.** Box hit but the country's pack is absent locally → fetch and cache on demand (D3); if no network is available, return the coarser layer already cached (e.g. state without county) and flag it, never a wrong guess.
+- **No box hit.** A point over open water or an unmapped area leaves the field empty rather than snapping to the nearest land.
+- **Diacritics / renames.** Fixed at normalisation time (D1): UTF-8, `Türkiye`, `Czechia`, etc. `location_dataset` records the dataset version used, so renames stay explainable after the fact.
+- **Posted vs corrected.** `location_basis` records the choice per cache; re-running with the other basis updates both the value and the metadata.
 
 ---
 
-## 12. Roadmap
+## 14. Roadmap
 
-- **Locking and overrides.** A locked field is never overwritten by re-runs or
-  import. Builds on the planned custom-fields system.
-- **Macro hook.** A macro can recompute territories and stash the previous value
-  in a custom field, respecting locks.
-- **Boundary overlay on the map.** Because packs are GeoJSON, the Leaflet map can
-  draw the resolved county/state outline directly.
-- **Custom layers.** D4's layered engine already accepts new layers — Delorme,
-  Ordnance Survey, challenge regions — by adding an `rtree_<layer>` + metadata
-  table and the polygon packs.
+- **Locking and overrides.** A locked field is never overwritten by re-runs or import. Builds on the planned custom-fields system.
+- **Macro hook.** A macro can recompute territories and stash the previous value in a custom field, respecting locks.
+- **Boundary overlay on the map.** Because packs are GeoJSON, the Leaflet map can draw the resolved county/state outline directly.
+- **Custom layers.** D4's layered engine already accepts new layers — Delorme, Ordnance Survey, challenge regions — by adding an `rtree_<layer>` + metadata table and the polygon packs.
 
 ---
 
-## 13. Risks
+## 15. Risks
 
 | Risk | Mitigation |
 |------|------------|
 | `shapely`/GEOS native wheels across OSes | Verified in the CI matrix (3.11/3.12, Linux/macOS/Windows); pure-Python ray-cast fallback available. |
-| County polygon footprint | D3 per-country packs, fetched and cached on demand; ship only baseline. |
-| Stale / approximate polygons | D1 refresh pipeline + `location_dataset` provenance + future overrides. |
+| County polygon footprint | D3 per-country packs, fetched and cached on demand; ship only a simplified baseline ([§8](#8-storage-and-bandwidth-estimates)). |
+| Stale / approximate polygons | Refresh pipeline + `location_dataset` provenance + future overrides. |
 | Disagreement with other tools | Expected when a tool applies different boundaries or a different coordinate basis. The posted/corrected toggle and `location_basis` make disagreements explainable, not silent. |
 | Distribution without a server | Data ships in the install (baseline) and as **GitHub Releases assets** (packs) — CDN-backed, free, durable; no backend to run. |
 | Boundary-data licensing | The licence travels in each polygon's `licence` property — OSM-derived data is **ODbL** (attribution + share-alike), not public domain. The app ships the aggregate attributions; `boundaries.db` is a derived index (bounding boxes only) under the same terms. |
@@ -566,19 +493,10 @@ seconds once the relevant packs are cached.
 ## Appendix A — Glossary
 
 - **Reverse geocoding** — turning `(lat, lon)` into place names.
-- **Point-in-polygon** — geometric test of whether a point lies inside a polygon
-  (ray casting / winding number).
-- **R-Tree** — a tree index for rectangles; answers "which boxes contain or
-  overlap this point/box?" quickly. SQLite ships one.
-- **Bounding box** — the smallest axis-aligned rectangle enclosing a region; the
-  Stage-1 approximation, carried in each GeoJSON feature's `bbox` member.
-- **GeoJSON** — the standard JSON format for geographic features; a
-  `FeatureCollection` holds many regions, each with geometry, a `bbox`, and
-  properties (name, parent, licence).
-- **Posted vs corrected coordinates** — published listing coordinates vs the
-  user's solved/real coordinates (stored on `UserNote`).
-- **Layer** — a category of boundary (country / state / county / custom), each
-  its own R-Tree + metadata table.
-- **Local-first** — data is fetched from a remote source once, cached on disk,
-  and served locally thereafter; the network is touched only on first fetch, a
-  "download all", or a deliberate refresh.
+- **Point-in-polygon** — geometric test of whether a point lies inside a polygon (ray casting / winding number).
+- **R-Tree** — a tree index for rectangles; answers "which boxes contain or overlap this point/box?" quickly. SQLite ships one.
+- **Bounding box** — the smallest axis-aligned rectangle enclosing a region; the Stage-1 approximation, carried in each GeoJSON feature's `bbox` member.
+- **GeoJSON** — the standard JSON format for geographic features; a `FeatureCollection` holds many regions, each with geometry, a `bbox`, and properties (name, parent, licence).
+- **Posted vs corrected coordinates** — published listing coordinates vs the user's solved/real coordinates (stored on `UserNote`).
+- **Layer** — a category of boundary (country / state / county / custom), each its own R-Tree + metadata table.
+- **Local-first** — data is fetched from a remote source once, cached on disk, and served locally thereafter; the network is touched only on first fetch, a "download all", or a deliberate refresh.

--- a/architecture/reverse-geocoding.md
+++ b/architecture/reverse-geocoding.md
@@ -1,0 +1,465 @@
+# Architecture — Offline Reverse Geocoding
+
+OpenSAK assigns a **country**, **state/region** and **county** to every cache by
+reverse geocoding its coordinates against a local, polygon-accurate boundary
+dataset. The whole operation runs **offline**, on a background thread, with no
+network calls on the hot path and no per-request rate limits.
+
+This document describes the design of that subsystem — the *boundary engine*.
+
+---
+
+## Contents
+
+- [1. Problem](#1-problem)
+- [2. Concept](#2-concept)
+- [3. Benefits](#3-benefits)
+- [4. Design decisions](#4-design-decisions)
+- [5. Boundary data model](#5-boundary-data-model)
+- [6. System overview](#6-system-overview)
+  - [6.1 The two-stage query](#61-the-two-stage-query)
+  - [6.2 Build-time data pipeline](#62-build-time-data-pipeline)
+  - [6.3 Distribution and updates](#63-distribution-and-updates)
+- [7. Database schema](#7-database-schema)
+- [8. Dependencies](#8-dependencies)
+- [9. Module layout and integration](#9-module-layout-and-integration)
+- [10. Performance](#10-performance)
+- [11. Accuracy and edge cases](#11-accuracy-and-edge-cases)
+- [12. Roadmap](#12-roadmap)
+- [13. Risks](#13-risks)
+- [Appendix A — Glossary](#appendix-a--glossary)
+
+---
+
+## 1. Problem
+
+Geocachers need reliable **country / state (region) / county** values on every
+cache, for three concrete reasons:
+
+1. **County / region challenges.** Many caches qualify a finder for a
+   "find a cache in every county"-style challenge. Going to the wrong county is
+   expensive — literally, long drives — and frustrating.
+2. **Filtering and trip planning.** "Show me caches in this county" only works
+   when the field is populated and correct.
+3. **Parity with other tools.** Users cross-check OpenSAK against GSAK,
+   Project-GC and Cachetur. When the answer disagrees, OpenSAK gets the support
+   ticket.
+
+The data is **not** reliably available from the source files:
+
+- Imported GPX / Pocket Query files generally fill `country` and sometimes
+  `state`, but **county is almost always empty**.
+- A cache's real-world location can differ from its *posted* coordinates —
+  multi-caches and mystery/puzzle finals can sit tens of miles away. The
+  territory may need computing from **corrected** coordinates.
+- Boundaries change over time (county splits, `Turkey → Türkiye`,
+  `Czech Republic → Czechia`). Static values go stale.
+
+Reverse geocoding is fundamentally a **point-in-region** query: given a point,
+find which administrative polygons contain it. The challenge is doing that
+**accurately** (correct at and near borders) and **fast** (tens of thousands of
+caches at once), entirely offline.
+
+---
+
+## 2. Concept
+
+The naive solution — test the point against every polygon — is `O(regions ×
+vertices)` per cache and does not scale.
+
+The boundary engine uses a **two-stage lookup** built on a spatial index (see
+[SQLite R-Tree](https://sqlite.org/rtree.html)):
+
+1. **Stage 1 — bounding-box filter (R-Tree).** Every region is reduced to its
+   min/max latitude and longitude — an axis-aligned bounding box. These boxes
+   live in a SQLite **R-Tree** index. Querying it with a point returns only the
+   handful of regions whose box *contains* the point. This is `O(log n)` and
+   extremely fast.
+2. **Stage 2 — point-in-polygon (exact).** In the common case the point lands in
+   exactly one box → done, with no geometry maths. Only when boxes **overlap**
+   (very common for counties, and near any border) does the engine run the
+   precise point-in-polygon test, and only on the 2–3 candidates Stage 1
+   returned.
+
+This keeps the expensive geometry off the hot path. Because a county polygon
+records its parent state and country, a single county hit fills all three fields
+at once.
+
+---
+
+## 3. Benefits
+
+- **Instant and offline.** A 10k+ cache database resolves locally in seconds.
+  No network on the hot path, so it works on a plane, in the field, anywhere.
+- **No rate limits, no bans.** Nothing is throttled or quota'd — the engine is
+  pure local computation.
+- **Polygon-accurate.** Results are correct at and near borders, not snapped to
+  the nearest town. This is what challenge caching requires.
+- **Auditable provenance.** Every value records where it came from (imported vs
+  computed), which coordinates produced it (posted vs corrected), when, and
+  against which boundary dataset version.
+- **Both coordinate bases.** Posted coordinates by default (checker
+  compatibility); corrected coordinates on demand for physical planning.
+- **Controlled footprint.** A small baseline ships with the app; detailed
+  county data downloads only when needed.
+- **Live-updatable data.** Boundaries refresh independently of app releases via
+  a versioned manifest.
+- **Tool parity.** Built on the same public-domain boundary dataset the wider
+  community already uses, so results line up with established tools.
+- **Extensible.** The same engine serves any boundary *layer* — custom polygons
+  (Delorme, Ordnance Survey, challenge regions) need only data, not code.
+
+---
+
+## 4. Design decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| D1 | **Boundary data source** | Public-domain polygon files (community/GSAK lineage), **normalised** to UTF-8 + standard GeoJSON, from which OpenSAK regenerates its own R-Tree database. | Community parity for support; crowd-sourced coverage; clean diacritics (`Türkiye`) and refreshable stale polygons. |
+| D2 | **Result storage** | `Cache.country/state/county` hold the single result set; **provenance metadata** (source, coordinate basis, timestamp, dataset version) sits alongside. | Re-runnable and auditable without doubling every column. |
+| D3 | **Distribution** | Ship a small **baseline** dataset (country + state); download **county packs on demand** with a checkable version number. | Controls install/DB footprint; updates boundaries without an app release. |
+| D4 | **Granularity** | A **generic layered polygon engine** — country/state/county today, extensible to custom layers. | One engine for every layer; no rewrite to add custom polygons. |
+
+Recorded alternatives:
+
+- *Wholesale build from Natural Earth / GADM / OSM only* — clean data, but
+  county coverage is hard and results diverge from established tools, generating
+  support load. These sources are used to **refresh** individual polygons under
+  D1, not as the wholesale base.
+- *Separate `corrected_*` columns* — instead, D2's `location_basis` records
+  which coordinates produced the stored value. Storing both bases at once can be
+  revisited if filtering demand appears.
+- *Bundle every polygon* — simplest, but bloats the install; rejected for D3.
+
+---
+
+## 5. Boundary data model
+
+Two artefacts, in open formats:
+
+### 5.1 Polygon files (the geometry)
+
+One file per region, standard **GeoJSON** (`Feature`), UTF-8, with normalised
+names. A region can be a `MultiPolygon` (islands) and may contain holes
+(enclaves) — GeoJSON ring winding handles both.
+
+```jsonc
+// counties/us-tx-travis.geojson
+{
+  "type": "Feature",
+  "properties": {
+    "layer": "county",
+    "name": "Travis",
+    "parent": "US/TX",          // state/country this nests under
+    "version": 7,               // bumped when the polygon is corrected
+    "source": "community|osm|user"
+  },
+  "geometry": { "type": "MultiPolygon", "coordinates": [ /* ... */ ] }
+}
+```
+
+### 5.2 The bounding-box database (`boundaries.db`)
+
+A SQLite file generated **once** from all polygon files. It holds the R-Tree
+plus an auxiliary metadata table, and contains **no information not derivable
+from the polygons**, so it inherits their public-domain status.
+
+```sql
+-- Stage 1: R-Tree of axis-aligned bounding boxes (SQLite built-in module)
+CREATE VIRTUAL TABLE region_bbox USING rtree(
+    id,                 -- INTEGER primary key
+    min_lat, max_lat,
+    min_lon, max_lon
+);
+
+-- Auxiliary metadata, joined by id
+CREATE TABLE region_meta (
+    id            INTEGER PRIMARY KEY,
+    layer         TEXT NOT NULL,   -- 'country' | 'state' | 'county' | <custom>
+    name          TEXT NOT NULL,   -- UTF-8, normalised ('Türkiye')
+    parent        TEXT,            -- e.g. 'US/TX'
+    polygon_file  TEXT NOT NULL,   -- relative path to the GeoJSON
+    poly_version  INTEGER NOT NULL,
+    is_bundled    INTEGER NOT NULL -- 1 = in baseline install, 0 = on-demand pack
+);
+```
+
+> **Why SQLite's own R-Tree** rather than an external index package: it is a
+> compile-time-standard SQLite module (no extra native dependency to ship on
+> Windows/macOS/Linux), it persists to disk for free, and it keeps the index
+> next to the data. Point-in-polygon (Stage 2) is the only piece needing a
+> geometry library — see [§8](#8-dependencies).
+
+### 5.3 On-disk layout
+
+Under the platform app-data directory (resolved by `config.get_app_data_dir()`):
+
+```
+<app-data>/opensak/
+├── Default.db                 # the cache database
+└── boundaries/
+    ├── boundaries.db          # generated R-Tree + metadata (baseline)
+    ├── manifest.json          # dataset + per-pack version numbers
+    ├── countries/             # baseline, bundled with the install
+    │   └── *.geojson
+    ├── states/                # baseline, bundled with the install
+    │   └── *.geojson
+    └── counties/              # downloaded on demand (D3)
+        └── *.geojson
+```
+
+---
+
+## 6. System overview
+
+```mermaid
+flowchart TD
+    subgraph UI["GUI thread"]
+        DLG["Update Location dialog\n(scope: all / missing / this cache / filter)\n(coords: posted | corrected)"]
+        IMP["GPX/PQ import\n(auto-fill on import)"]
+    end
+
+    subgraph WORKER["QThread — reverse-geocode worker"]
+        BATCH["batch resolve(coords[])"]
+    end
+
+    subgraph ENGINE["geo.boundaries.TerritoryResolver"]
+        S1["Stage 1: R-Tree bbox query\n(boundaries.db)"]
+        S2["Stage 2: point-in-polygon\n(only on overlaps)"]
+        POLY["Polygon cache\n(lazy-loaded GeoJSON)"]
+    end
+
+    subgraph STORE["geo.store + geo.packs"]
+        BB[("boundaries.db")]
+        GJ[["*.geojson packs"]]
+        DL["on-demand pack download\n+ version check (D3)"]
+    end
+
+    DB[("Cache DB\ncountry/state/county + metadata")]
+
+    DLG --> WORKER
+    IMP --> WORKER
+    BATCH --> S1
+    S1 -->|1 hit| RESULT["GeoLocation"]
+    S1 -->|>1 hit| S2
+    S2 --> POLY
+    POLY -.miss.-> DL
+    S2 --> RESULT
+    S1 --- BB
+    POLY --- GJ
+    DL --> GJ
+    RESULT -->|signal| DB
+```
+
+### 6.1 The two-stage query
+
+```
+            point (lat, lon)
+                  │
+                  ▼
+   ┌──────────────────────────────┐
+   │ Stage 1  R-Tree bbox SELECT   │   ~O(log n), microseconds
+   │ WHERE min_lat<=? AND max_lat  │
+   │   >=? AND min_lon<=? ...       │
+   └──────────────┬────────────────┘
+                  │ candidate region ids
+        ┌─────────┴──────────┐
+        │                    │
+   exactly 1 hit        2+ hits (overlap / border)
+        │                    │
+        ▼                    ▼
+     DONE          ┌────────────────────────┐
+   (no geometry)   │ Stage 2  point-in-poly  │  only on 2–3 candidates
+                   │ load GeoJSON, ray-cast  │
+                   │ (holes respected)       │
+                   └───────────┬─────────────┘
+                               ▼
+                        winning region
+```
+
+The lookup runs per layer; a county hit also yields its state and country
+through the polygon's `parent`, so one query can fill all three fields.
+
+### 6.2 Build-time data pipeline
+
+A maintainer-run pipeline lives under `tools/` (kept out of the runtime package
+and excluded from release bundles). It turns raw public-domain polygons into
+shippable artefacts:
+
+```mermaid
+flowchart LR
+    A["raw polygon files\n(mixed encodings/formats)"] --> B["normalise\nUTF-8 names, fix diacritics,\nconvert to GeoJSON"]
+    OSM["OSM / Natural Earth / GADM\n(refresh stale polygons)"] --> B
+    B --> C["validate geometry\n(closed rings, winding, holes)"]
+    C --> D["compute bbox per region"]
+    D --> E["generate boundaries.db\n(R-Tree + meta)"]
+    C --> F["split into baseline + county packs"]
+    E --> G["manifest.json\n(versions)"]
+    F --> G
+```
+
+`boundaries.db` is derived purely by extracting the min/max latitude and
+longitude of each polygon — a quick, one-off process repeated whenever the
+dataset changes.
+
+### 6.3 Distribution and updates
+
+- **Baseline** (`countries/`, `states/`, `boundaries.db`) ships as package data
+  in the install, so country/state resolution works offline immediately.
+- **County packs** download on demand: when a county lookup needs a polygon
+  listed in `region_meta` but absent on disk, `geo.packs` fetches that pack from
+  a versioned host (release assets / `opensak.com`).
+- **`manifest.json`** carries a dataset version and per-pack versions. On launch
+  (or on user request) OpenSAK compares against the remote manifest and offers
+  to refresh changed packs, so boundary data — including `boundaries.db` —
+  updates independently of app releases.
+
+---
+
+## 7. Database schema
+
+The `Cache` model carries the three result fields plus provenance metadata:
+
+```python
+# Territory result (one set per cache)
+country: Mapped[Optional[str]] = mapped_column(String(64))
+state:   Mapped[Optional[str]] = mapped_column(String(64))
+county:  Mapped[Optional[str]] = mapped_column(String(64))
+
+# Provenance (D2)
+location_source:  Mapped[Optional[str]] = mapped_column(String(16))   # 'groundspeak' | 'computed'
+location_basis:   Mapped[Optional[str]] = mapped_column(String(16))   # 'posted' | 'corrected'
+location_updated: Mapped[Optional[datetime]] = mapped_column(DateTime)
+location_dataset: Mapped[Optional[str]] = mapped_column(String(32))   # boundary dataset version used
+```
+
+Corrected coordinates are read from the one-to-one `UserNote`
+(`corrected_lat`, `corrected_lon`, `is_corrected`).
+
+Schema changes are versioned through `PRAGMA user_version` (see
+`db/database.py`): the engine bumps `SCHEMA_VERSION` and adds the provenance
+columns idempotently, so existing databases upgrade in place with the metadata
+defaulting to "unknown / imported".
+
+The provenance fields let a user tell, per cache, whether a value came from the
+import source, from posted coordinates, or from corrected coordinates — and
+whether it predates a boundary refresh.
+
+---
+
+## 8. Dependencies
+
+| Need | Choice | Notes |
+|------|--------|-------|
+| R-Tree (Stage 1) | **SQLite built-in `rtree`** | No new dependency; standard in CPython's bundled SQLite. |
+| Point-in-polygon (Stage 2) | **`shapely`** | C-backed (GEOS), correct with holes/multipolygons, cross-platform wheels. A pure-Python ray-casting fallback stays available for a zero-native-dependency build, at some speed/robustness cost. |
+| GeoJSON parsing | stdlib `json` | No `geojson`/`fiona`/`geopandas` needed. |
+| Country code → name | `pycountry` | Normalising ISO codes to display names in the pipeline. |
+
+---
+
+## 9. Module layout and integration
+
+The engine is a self-contained `geo` subpackage; the build pipeline is separate
+and not packaged.
+
+```
+src/opensak/geo/
+├── __init__.py
+├── boundaries.py     # TerritoryResolver: two-stage lookup, returns GeoLocation
+├── store.py          # locate/open boundaries.db, resolve polygon paths, lazy polygon cache
+└── packs.py          # on-demand county-pack download + manifest/version check
+
+tools/boundaries/     # build-time only, excluded from packaging
+├── normalise.py      # raw polygons -> clean UTF-8 GeoJSON
+├── build_bbdb.py     # GeoJSON -> boundaries.db (R-Tree + meta)
+└── pack.py           # split into baseline + packs, emit manifest.json
+```
+
+`TerritoryResolver` returns a `GeoLocation(country, state, county)` value.
+
+### GUI integration
+
+The feature follows the project's UI conventions:
+
+- An **Update Location** dialog drives it, reachable from the Waypoint menu and
+  from the cache-table right-click menu. It offers scope (all caches / only
+  missing / this cache / current filter) and a coordinate-basis choice (posted
+  vs corrected, **defaulting to posted** for checker compatibility).
+- Resolution runs in a **`QThread`** worker that streams progress and results
+  back via Qt signals — the main thread never blocks (a 10k+ batch is heavy).
+- The same worker runs automatically after a GPX/PQ import to fill missing
+  territory data.
+- All user-visible strings go through `tr()` with keys present in every
+  `lang/*.py` module.
+
+---
+
+## 10. Performance
+
+| Stage | Cost | Notes |
+|-------|------|-------|
+| Stage 1 (R-Tree) | ~`O(log n)` per point | Batched; tens of thousands of points in well under a second. |
+| Stage 2 (polygon) | only on bbox overlaps | Typically 2–3 candidate polygons; skipped entirely for interior points. |
+| Polygon I/O | lazy + cached | Each region's GeoJSON loads once and is reused across the batch — a Pocket Query clusters geographically, so cache hit rates are high. |
+
+The work stays on the `QThread` with progress signals; a 10k+ batch completes in
+seconds.
+
+---
+
+## 11. Accuracy and edge cases
+
+- **Borders.** Stage 2 resolves overlapping boxes exactly. The residual risk is
+  an *approximate polygon* itself — mitigated by D1's refresh pipeline and the
+  user-override path on the roadmap.
+- **Missing polygon.** Box hit but pack not downloaded → fetch on demand (D3);
+  if offline, return the coarser layer already available (e.g. state without
+  county) and flag it, never a wrong guess.
+- **No box hit.** A point over open water or an unmapped area leaves the field
+  empty rather than snapping to the nearest land.
+- **Diacritics / renames.** Fixed at normalisation time (D1): UTF-8, `Türkiye`,
+  `Czechia`, etc. `location_dataset` records the dataset version used, so
+  renames stay explainable after the fact.
+- **Posted vs corrected.** `location_basis` records the choice per cache;
+  re-running with the other basis updates both the value and the metadata.
+
+---
+
+## 12. Roadmap
+
+- **Locking and overrides.** A locked field is never overwritten by re-runs or
+  import. Builds on the planned custom-fields system.
+- **Macro hook.** A macro can recompute territories and stash the previous value
+  in a custom field, respecting locks.
+- **Custom layers.** D4's generic engine already accepts new `layer` values —
+  Delorme, Ordnance Survey, challenge regions — needing only polygon packs.
+- **Crowd-sourced polygon editing.** A web polygon editor could feed corrections
+  back into the dataset.
+
+---
+
+## 13. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `shapely`/GEOS native wheels across OSes | Verified in the CI matrix (3.11/3.12, Linux/macOS/Windows); pure-Python ray-cast fallback available. |
+| County polygon footprint | D3 on-demand packs; ship only baseline. |
+| Stale / approximate polygons | D1 refresh pipeline + `location_dataset` provenance + future overrides. |
+| Disagreement with other tools | Expected when a tool applies different boundaries or a different coordinate basis. The posted/corrected toggle and `location_basis` make disagreements explainable, not silent. |
+| Boundary-data licensing | Polygons are public-domain; `boundaries.db` is derived (no new information); refreshes drawn from open sources with compatible terms. |
+
+---
+
+## Appendix A — Glossary
+
+- **Reverse geocoding** — turning `(lat, lon)` into place names.
+- **Point-in-polygon** — geometric test of whether a point lies inside a polygon
+  (ray casting / winding number).
+- **R-Tree** — a tree index for rectangles; answers "which boxes contain or
+  overlap this point/box?" quickly. SQLite ships one.
+- **Bounding box** — the smallest axis-aligned rectangle enclosing a region; the
+  Stage-1 approximation.
+- **Posted vs corrected coordinates** — published listing coordinates vs the
+  user's solved/real coordinates (stored on `UserNote`).
+- **Layer** — a category of boundary (country / state / county / custom).

--- a/architecture/reverse-geocoding.md
+++ b/architecture/reverse-geocoding.md
@@ -2,10 +2,10 @@
 
 OpenSAK assigns a **country**, **state/region** and **county** to every cache by
 reverse geocoding its coordinates against a polygon-accurate boundary dataset
-held on the user's machine. The dataset is **local-first**: boundary data is
-fetched once from a remote source and cached on disk, after which lookups need
-no network and have no rate limits. A full database resolves on a background
-thread in seconds.
+held on the user's machine. The dataset is **local-first**: a baseline ships with
+the app, the rest is fetched once from GitHub and cached on disk, after which
+lookups need no network and have no rate limits. A full database resolves on a
+background thread in seconds.
 
 This document describes the design of that subsystem — the *boundary engine*.
 
@@ -17,6 +17,7 @@ This document describes the design of that subsystem — the *boundary engine*.
 - [2. Concept](#2-concept)
 - [3. Benefits](#3-benefits)
 - [4. Design decisions](#4-design-decisions)
+  - [Improvements over the GSAK lineage](#improvements-over-the-gsak-lineage)
 - [5. Boundary data model](#5-boundary-data-model)
   - [5.1 Polygon files](#51-polygon-files)
   - [5.2 The bounding-box database](#52-the-bounding-box-database)
@@ -90,8 +91,9 @@ This keeps the expensive geometry off the hot path. Because a county record
 names its parent state and country, a single county hit fills all three fields
 at once.
 
-The design follows the proven structure GSAK has used for years (its
-`bb.db3` + polygon-file system), re-expressed in clean, modern data.
+The two-stage structure follows the proven design GSAK has used for years (its
+`bb.db3` index + polygon-file system); OpenSAK re-expresses it in clean, modern
+data — see [Improvements over the GSAK lineage](#improvements-over-the-gsak-lineage).
 
 ---
 
@@ -107,12 +109,15 @@ The design follows the proven structure GSAK has used for years (its
   against which boundary dataset version.
 - **Both coordinate bases.** Posted coordinates by default (checker
   compatibility); corrected coordinates on demand for physical planning.
-- **Controlled footprint.** A small baseline ships with the app; detailed
-  county data is fetched and cached only when a region actually needs it.
+- **Controlled footprint.** A small baseline ships with the app; detailed county
+  data is fetched and cached only when a region actually needs it.
+- **Standard format.** Boundaries are stored as **GeoJSON**, so they validate in
+  any GIS tool and can be drawn directly by the Leaflet map for a future
+  "show this boundary" overlay.
 - **Live-updatable data.** Boundaries refresh independently of app releases via
   per-file version numbers.
-- **Tool parity.** Built on the same boundary lineage the wider community
-  already uses, so results line up with established tools.
+- **No project-run server.** The app install plus GitHub Releases cover
+  everything; there is no backend to host, pay for, or keep alive.
 - **Extensible.** The same engine serves any boundary *layer* — custom polygons
   (Delorme, Ordnance Survey, challenge regions) need only data, not code.
 
@@ -122,9 +127,9 @@ The design follows the proven structure GSAK has used for years (its
 
 | # | Decision | Choice | Rationale |
 |---|----------|--------|-----------|
-| D1 | **Boundary data source** | Community polygon files of GSAK lineage, **normalised** to UTF-8 with consistent naming, from which OpenSAK regenerates its own R-Tree database. The native text format is kept (no conversion). | Community parity for support; crowd-sourced coverage; fixes the mixed encodings/diacritics (`Türkiye`, broken `©`) in the source files; direct compatibility with the files maintainers already produce. |
+| D1 | **Boundary data source & format** | Community polygon files of GSAK lineage, **normalised to UTF-8 and converted to GeoJSON** (one `FeatureCollection` per country); OpenSAK regenerates its own R-Tree index from them. The native text is the *ingest* format only. | Community parity for support; crowd-sourced coverage; fixes mixed encodings/diacritics (`Türkiye`, broken `©`); GeoJSON gives unambiguous holes/multipolygons, validation, and direct reuse by the Leaflet map. |
 | D2 | **Result storage** | `Cache.country/state/county` hold the single result set; **provenance metadata** (source, coordinate basis, timestamp, dataset version) sits alongside. | Re-runnable and auditable without doubling every column. |
-| D3 | **Distribution** | Ship a small **baseline** dataset (country + state); fetch **county packs per country, on demand**, and cache them locally with a checkable version number. | Controls install/DB footprint; updates boundaries without an app release; avoids shipping 26k+ county polygons up front. |
+| D3 | **Distribution (no own server)** | Ship a small **baseline** (country + state) in the install; fetch **county packs per country, on demand, from GitHub Releases** and cache them locally with a checkable version number. An optional "download all" pre-fetches everything for full offline use. | Controls install/DB footprint; updates without an app release; GitHub Releases is free, CDN-backed and durable, so no backend is needed. |
 | D4 | **Granularity** | A **layered** engine — country/state/county today, extensible to custom layers — each layer being its own R-Tree + metadata table. | One query path for every layer; adding a custom layer is data, not code. |
 
 Recorded alternatives:
@@ -133,28 +138,51 @@ Recorded alternatives:
   county coverage is hard and results diverge from established tools, generating
   support load. These sources are used to **refresh** individual polygons under
   D1, not as the wholesale base.
-- *Convert polygons to GeoJSON* — the native text format is simpler (a header
-  plus `lat,lon` rows), already carries a precomputed bounding box, and matches
-  what upstream maintainers ship and edit. Conversion is left as an optional
-  interop step, not a requirement.
-- *Separate `corrected_*` columns* — instead, D2's `location_basis` records
-  which coordinates produced the stored value.
-- *Bundle every polygon* — simplest, but bloats the install; rejected for D3.
+- *Keep the native text format end-to-end* — smaller and zero-conversion, but
+  leaves holes/multipolygons as an implicit convention and gives the map nothing
+  to draw. The pipeline already normalises encoding, so converting to GeoJSON at
+  the same time is nearly free.
+- *Bundle every polygon in the install* — works fully offline from day one, but
+  the global county set is plausibly hundreds of MB and ~99% of it goes unused by
+  any given user; rejected for D3 (the "download all" option covers people who
+  genuinely want everything).
+- *Separate `corrected_*` columns* — instead, D2's `location_basis` records which
+  coordinates produced the stored value.
+
+### Improvements over the GSAK lineage
+
+The data and two-stage method come from GSAK; these are the deliberate changes:
+
+- **UTF-8 everywhere** instead of ANSI — fixes `Türkiye`, `Czechia` and the
+  broken `©` seen in the source files.
+- **GeoJSON** instead of the bespoke text format — standard, validatable,
+  unambiguous geometry, and drawable by the existing Leaflet map.
+- **Independently updatable data** via versioned packs — GSAK's own maintainer
+  noted its `bb.db3` can only be refreshed by shipping a new GSAK release.
+- **Clean schema** — drops the legacy `_old` tables and the mixed
+  full-name/3-letter-code conventions found in `bb.db3`.
+- **Per-cache provenance** (source, coordinate basis, timestamp, dataset
+  version) — GSAK tracked none of this, so it could never explain *which*
+  coordinates a stored value came from.
+- **64-bit runtime** — none of the 32-bit constraints that slow legacy GSAK.
+
+What is intentionally kept: the **two-stage R-Tree + point-in-polygon** method,
+**one R-Tree per layer**, and **polygon data stored separately** from the index
+(so it can be fetched lazily).
 
 ---
 
 ## 5. Boundary data model
 
-Two artefacts, mirroring the GSAK lineage in cleaned form.
+Two artefacts, mirroring the GSAK lineage in cleaned, standard form.
 
 ### 5.1 Polygon files
 
-One self-describing text file per region (or per grouped set, for counties).
-A header of `#` comment lines carries the display name, the **source and
-licence**, and a **precomputed bounding box**; the body is one `lat,lon` pair
-per line. A file may hold several polygons (islands); each polygon's first and
-last coordinate match (closed ring), and holes (enclaves) are wound in the
-opposite direction.
+**Ingest (build time).** Upstream files arrive in the native GSAK text format: a
+header of `#` comment lines carrying the display name, the **source and
+licence**, and a **precomputed bounding box**, followed by one `lat,lon` pair per
+line. A file may hold several polygons (islands); each polygon's first and last
+coordinate match (closed ring), and holes are wound in the opposite direction.
 
 ```text
 # GsakName=Denmark
@@ -163,44 +191,55 @@ opposite direction.
 # Bounding Box: 57.9524297,54.4516667,12.9058301,7.7153255
 54.8370717,9.4829269
 54.8316638,9.4629539
-54.8333102,9.4601121
 ...
 ```
 
-Key consequences captured by the format:
+**Stored & distributed.** The pipeline normalises these to UTF-8 and converts
+them to **GeoJSON**, grouped **one `FeatureCollection` per country**. This is the
+format OpenSAK ships, caches and reads.
+
+```jsonc
+// counties/prt.geojson — one FeatureCollection per country
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "layer": "county",
+        "name": "Lisboa",
+        "parent": "PT",
+        "version": 7,
+        "source": "osm",
+        "licence": "ODbL"
+      },
+      "bbox": [-9.5, 38.6, -9.0, 38.9],   // standard GeoJSON bbox member
+      "geometry": { "type": "MultiPolygon", "coordinates": [ /* ... */ ] }
+    }
+    // ... every county/parish in Portugal
+  ]
+}
+```
+
+Key points the format captures:
 
 - The **licence travels with the data.** OSM-derived polygons are **ODbL**
-  (attribution + share-alike), *not* public domain; other files may carry other
-  terms. The engine preserves the header and surfaces the aggregate attributions
-  (see [§13](#13-risks)).
-- The bounding box is **already computed**, so building the index ([§5.2](#52-the-bounding-box-database))
-  is a trivial read, not a geometry pass.
-- Files are **normalised to UTF-8** on ingest (the source files are mixed
-  encodings — note the broken `©` above), fixing diacritics and renames.
-
-County granularity is grouped: a country's county polygons live together (e.g.
-all of Portugal's ~3,900, all of Brazil's ~5,500) and each county record points
-to its polygon **within** that group — which makes "per-country" the natural
-download unit ([§5.3](#53-on-disk-layout-and-caching)).
+  (attribution + share-alike), *not* public domain; the property is preserved and
+  surfaced as aggregate attribution (see [§13](#13-risks)).
+- The bounding box is **already known** from the source header, so building the
+  index ([§5.2](#52-the-bounding-box-database)) is a read, not a geometry pass.
+- Counties are **grouped per country** (Portugal ~3,900 features, Brazil ~5,500),
+  which makes "per-country" the natural download unit ([§5.3](#53-on-disk-layout-and-caching)).
 
 ### 5.2 The bounding-box database
 
-A SQLite file (`boundaries.db`) generated **once** from the polygon-file
-headers. It is the spatial index plus metadata, and contains **no information
-not derivable from the polygons**, so it inherits their terms.
+A SQLite file (`boundaries.db`) generated **once** from the GeoJSON `bbox`
+members. It is the spatial index plus metadata, and contains **no information not
+derivable from the polygons**, so it inherits their terms.
 
 GSAK's shipped `bb.db3` uses **one R-Tree per layer** with a companion metadata
-table, joined by id — for example:
-
-```sql
--- one spatial index per layer (country / state / county)
-CREATE VIRTUAL TABLE rtree_county USING rtree(bbid, MinLat, MaxLat, MinLon, MaxLon);
-
--- companion metadata; bbid == rowid of this table
-CREATE TABLE bb_county (Country, State, File, MaxLat, MinLat, MaxLon, MinLon, Cname);
-```
-
-OpenSAK keeps that proven shape, cleaned and consistently named:
+table, joined by id. OpenSAK keeps that proven shape, cleaned and consistently
+named:
 
 ```sql
 -- Stage 1: one R-Tree per layer (SQLite built-in module)
@@ -212,8 +251,9 @@ CREATE VIRTUAL TABLE rtree_county  USING rtree(id, min_lat, max_lat, min_lon, ma
 CREATE TABLE region_county (
     id            INTEGER PRIMARY KEY,
     name          TEXT NOT NULL,   -- UTF-8, normalised ('Türkiye')
-    parent        TEXT,            -- 'US/TX' — links county -> state -> country
-    polygon_file  TEXT NOT NULL,   -- file (and index within it, for grouped counties)
+    parent        TEXT,            -- 'PT', 'US/TX' — links county -> state -> country
+    pack          TEXT NOT NULL,   -- GeoJSON FeatureCollection holding this region
+    feature_index INTEGER NOT NULL,-- which feature within the pack
     poly_version  INTEGER NOT NULL,
     is_bundled    INTEGER NOT NULL -- 1 = baseline install, 0 = on-demand pack
 );
@@ -229,13 +269,13 @@ append.
 
 > **Why SQLite's own R-Tree** rather than an external index package: it is a
 > compile-time-standard SQLite module (no extra native dependency to ship on
-> Windows/macOS/Linux), it persists to disk for free, and it keeps the index
-> next to the metadata. Point-in-polygon (Stage 2) is the only piece needing a
+> Windows/macOS/Linux), it persists to disk for free, and it keeps the index next
+> to the metadata. Point-in-polygon (Stage 2) is the only piece needing a
 > geometry library — see [§8](#8-dependencies).
 
 For scale: a real `bb.db3` holds ~384 countries, ~2,330 state polygons and
-~26,170 county polygons in roughly 7 MB — bounding boxes only. The polygon files
-themselves are far larger and are why counties are fetched on demand.
+~26,170 county polygons in roughly 7 MB — bounding boxes only. The polygon
+geometry is far larger and is why counties are fetched on demand.
 
 ### 5.3 On-disk layout and caching
 
@@ -248,17 +288,18 @@ Under the platform app-data directory (resolved by `config.get_app_data_dir()`):
     ├── boundaries.db          # generated R-Trees + metadata (baseline)
     ├── manifest.json          # dataset version + per-pack versions
     ├── countries/             # baseline — bundled with the install
-    │   └── *.txt
+    │   └── world.geojson
     ├── states/                # baseline — bundled with the install
-    │   └── *.txt
+    │   └── *.geojson
     └── counties/              # fetched per country on demand, then cached
-        ├── prt.txt
-        └── usa-tx.txt
+        ├── prt.geojson
+        └── usa-tx.geojson
 ```
 
-The `counties/` directory **is the cache**: a county pack is downloaded once,
-written here, and every later lookup reads it locally. Nothing is re-fetched
-unless a version bump says the data changed ([§6.3](#63-distribution-and-updates)).
+The `counties/` directory **is the cache**: a country's pack is downloaded once
+from GitHub Releases, written here, and every later lookup reads it locally.
+Nothing is re-fetched unless a version bump says the data changed
+([§6.3](#63-distribution-and-updates)).
 
 ---
 
@@ -278,13 +319,13 @@ flowchart TD
     subgraph ENGINE["geo.boundaries.TerritoryResolver"]
         S1["Stage 1: per-layer R-Tree query\n(boundaries.db)"]
         S2["Stage 2: point-in-polygon\n(only on overlaps)"]
-        POLY["Polygon cache\n(lazy-loaded files)"]
+        POLY["Polygon cache\n(lazy-loaded GeoJSON)"]
     end
 
     subgraph STORE["geo.store + geo.packs"]
         BB[("boundaries.db\nrtree_country/state/county")]
-        GJ[["polygon files\n(local cache)"]]
-        DL["on-demand pack fetch\n+ version check (D3)"]
+        GJ[["GeoJSON packs\n(local cache)"]]
+        DL["on-demand pack fetch\nGitHub Releases + version check"]
     end
 
     DB[("Cache DB\ncountry/state/county + metadata")]
@@ -322,7 +363,7 @@ flowchart TD
         ▼                    ▼
      DONE          ┌────────────────────────┐
    (no geometry)   │ Stage 2  point-in-poly  │  only on 2–3 candidates
-                   │ load polygon, ray-cast  │
+                   │ load GeoJSON, ray-cast  │
                    │ (holes respected)       │
                    └───────────┬─────────────┘
                                ▼
@@ -340,37 +381,45 @@ artefacts:
 
 ```mermaid
 flowchart LR
-    A["raw polygon files\n(mixed encodings)"] --> B["normalise\nUTF-8 names, fix diacritics,\nconsistent keys"]
+    A["raw polygon files\n(native text, mixed encodings)"] --> B["normalise\nUTF-8, fix diacritics,\nconsistent keys"]
     OSM["OSM / Natural Earth / GADM\n(refresh stale polygons)"] --> B
-    B --> C["validate geometry\n(closed rings, winding, holes)"]
-    C --> D["read precomputed bbox\nfrom each header"]
+    B --> X["convert to GeoJSON\n(1 FeatureCollection / country)"]
+    X --> C["validate geometry\n(rings, winding, holes)"]
+    C --> D["read bbox per feature"]
     D --> E["generate boundaries.db\n(per-layer R-Trees + metadata)"]
     C --> F["group counties per country\n+ assemble baseline"]
     E --> G["manifest.json\n(versions)"]
     F --> G
+    G --> H["publish to GitHub Releases"]
 ```
 
-Building `boundaries.db` is mostly reading the `# Bounding Box` line already
-present in each file — a quick, one-off process repeated whenever the dataset
-changes.
+Building `boundaries.db` is mostly reading each feature's `bbox` — a quick,
+one-off process repeated whenever the dataset changes, then published as release
+assets.
 
 ### 6.3 Distribution and updates
+
+There is **no project-run server**. Distribution uses only what an open-source
+project already has:
 
 - **Baseline** (`countries/`, `states/`, `boundaries.db`) ships as package data
   in the install, so country/state resolution works with no network from first
   launch.
-- **County packs** are fetched per country the first time a lookup needs one:
-  when a county box is hit but its polygon file is not yet in the local cache,
-  `geo.packs` downloads that country's pack from a versioned host (release
-  assets / `opensak.com`), writes it under `counties/`, and serves it locally
-  thereafter.
+- **County packs** live as **GitHub Releases assets** in a data repository (e.g.
+  `OpenSAK/boundary-data`), each a per-country GeoJSON `FeatureCollection`. The
+  first time a lookup needs a country's counties, `geo.packs` downloads that pack
+  over its stable release URL (GitHub serves these via a CDN), writes it under
+  `counties/`, and serves it locally thereafter.
+- **"Download all"** is an optional one-click action that pre-fetches every pack,
+  for users who want full offline coverage before heading into the field.
 - **Versions.** `boundaries.db` carries per-file versions; `manifest.json`
   carries a dataset version. On launch (or on user request) OpenSAK compares
-  against the remote manifest and offers to refresh changed packs — so boundary
-  data, including `boundaries.db` itself, updates independently of app releases.
+  against the manifest published with the latest release and offers to refresh
+  changed packs — so boundary data, including `boundaries.db` itself, updates
+  independently of app releases.
 
-So the **only** time the network is involved is the first fetch of a region's
-data (or a deliberate refresh); steady-state operation is fully local.
+So the network is involved **only** on the first fetch of a region's data, a
+"download all", or a deliberate refresh; steady-state operation is fully local.
 
 ---
 
@@ -410,8 +459,9 @@ whether it predates a boundary refresh.
 | Need | Choice | Notes |
 |------|--------|-------|
 | R-Tree (Stage 1) | **SQLite built-in `rtree`** | No new dependency; standard in CPython's bundled SQLite. |
-| Point-in-polygon (Stage 2) | **`shapely`** | C-backed (GEOS), correct with holes/multipolygons, cross-platform wheels. A pure-Python ray-casting fallback stays available for a zero-native-dependency build, at some speed/robustness cost. |
-| Polygon parsing | stdlib | Plain `lat,lon` text; no GIS reader needed. |
+| Point-in-polygon (Stage 2) | **`shapely`** | C-backed (GEOS), correct with holes/multipolygons, reads GeoJSON geometry directly, cross-platform wheels. A pure-Python ray-casting fallback stays available for a zero-native-dependency build, at some speed/robustness cost. |
+| GeoJSON parsing | stdlib `json` | Packs are plain `FeatureCollection`s; no GIS reader needed at runtime. |
+| Native-text parsing | stdlib (pipeline only) | Reading upstream files happens at build time, not in the app. |
 | Country code → name | `pycountry` | Normalising ISO codes to display names in the pipeline. |
 
 ---
@@ -425,13 +475,14 @@ and not packaged.
 src/opensak/geo/
 ├── __init__.py
 ├── boundaries.py     # TerritoryResolver: two-stage lookup, returns GeoLocation
-├── store.py          # open boundaries.db, resolve polygon paths, lazy polygon cache
-└── packs.py          # on-demand county-pack fetch + manifest/version check
+├── store.py          # open boundaries.db, load GeoJSON packs, lazy polygon cache
+└── packs.py          # on-demand pack fetch from GitHub Releases + version check
 
 tools/boundaries/     # build-time only, excluded from packaging
-├── normalise.py      # raw polygons -> clean UTF-8
-├── build_bbdb.py     # polygon headers -> boundaries.db (R-Trees + metadata)
-└── pack.py           # group counties, assemble baseline, emit manifest.json
+├── normalise.py      # raw text polygons -> clean UTF-8
+├── to_geojson.py     # -> GeoJSON, one FeatureCollection per country
+├── build_bbdb.py     # GeoJSON bbox -> boundaries.db (R-Trees + metadata)
+└── publish.py        # assemble baseline + packs, emit manifest.json, push release
 ```
 
 `TerritoryResolver` returns a `GeoLocation(country, state, county)` value.
@@ -459,7 +510,7 @@ The feature follows the project's UI conventions:
 |-------|------|-------|
 | Stage 1 (R-Tree) | ~`O(log n)` per point | Batched; tens of thousands of points in well under a second. |
 | Stage 2 (polygon) | only on bbox overlaps | Typically 2–3 candidate polygons; skipped entirely for interior points. |
-| Polygon I/O | lazy + cached | Each region's file loads once and is reused across the batch — a Pocket Query clusters geographically, so cache hit rates are high. |
+| Polygon I/O | lazy + cached | Each country's GeoJSON loads once and is reused across the batch — a Pocket Query clusters geographically, so cache hit rates are high. |
 
 The work stays on the `QThread` with progress signals; a 10k+ batch completes in
 seconds once the relevant packs are cached.
@@ -471,14 +522,15 @@ seconds once the relevant packs are cached.
 - **Borders.** Stage 2 resolves overlapping boxes exactly. The residual risk is
   an *approximate polygon* itself — mitigated by D1's refresh pipeline and the
   user-override path on the roadmap.
-- **Pack not yet cached.** Box hit but the county pack is absent locally → fetch
-  and cache on demand (D3); if no network is available, return the coarser layer
-  already cached (e.g. state without county) and flag it, never a wrong guess.
+- **Pack not yet cached.** Box hit but the country's pack is absent locally →
+  fetch and cache on demand (D3); if no network is available, return the coarser
+  layer already cached (e.g. state without county) and flag it, never a wrong
+  guess.
 - **No box hit.** A point over open water or an unmapped area leaves the field
   empty rather than snapping to the nearest land.
 - **Diacritics / renames.** Fixed at normalisation time (D1): UTF-8, `Türkiye`,
-  `Czechia`, etc. `location_dataset` records the dataset version used, so
-  renames stay explainable after the fact.
+  `Czechia`, etc. `location_dataset` records the dataset version used, so renames
+  stay explainable after the fact.
 - **Posted vs corrected.** `location_basis` records the choice per cache;
   re-running with the other basis updates both the value and the metadata.
 
@@ -490,6 +542,8 @@ seconds once the relevant packs are cached.
   import. Builds on the planned custom-fields system.
 - **Macro hook.** A macro can recompute territories and stash the previous value
   in a custom field, respecting locks.
+- **Boundary overlay on the map.** Because packs are GeoJSON, the Leaflet map can
+  draw the resolved county/state outline directly.
 - **Custom layers.** D4's layered engine already accepts new layers — Delorme,
   Ordnance Survey, challenge regions — by adding an `rtree_<layer>` + metadata
   table and the polygon packs.
@@ -504,7 +558,8 @@ seconds once the relevant packs are cached.
 | County polygon footprint | D3 per-country packs, fetched and cached on demand; ship only baseline. |
 | Stale / approximate polygons | D1 refresh pipeline + `location_dataset` provenance + future overrides. |
 | Disagreement with other tools | Expected when a tool applies different boundaries or a different coordinate basis. The posted/corrected toggle and `location_basis` make disagreements explainable, not silent. |
-| Boundary-data licensing | The licence travels in each polygon header — OSM-derived data is **ODbL** (attribution + share-alike), not public domain. The engine preserves headers and ships the aggregate attributions; `boundaries.db` is a derived index (bounding boxes only) under the same terms. |
+| Distribution without a server | Data ships in the install (baseline) and as **GitHub Releases assets** (packs) — CDN-backed, free, durable; no backend to run. |
+| Boundary-data licensing | The licence travels in each polygon's `licence` property — OSM-derived data is **ODbL** (attribution + share-alike), not public domain. The app ships the aggregate attributions; `boundaries.db` is a derived index (bounding boxes only) under the same terms. |
 
 ---
 
@@ -516,11 +571,14 @@ seconds once the relevant packs are cached.
 - **R-Tree** — a tree index for rectangles; answers "which boxes contain or
   overlap this point/box?" quickly. SQLite ships one.
 - **Bounding box** — the smallest axis-aligned rectangle enclosing a region; the
-  Stage-1 approximation, precomputed in each polygon file's header.
+  Stage-1 approximation, carried in each GeoJSON feature's `bbox` member.
+- **GeoJSON** — the standard JSON format for geographic features; a
+  `FeatureCollection` holds many regions, each with geometry, a `bbox`, and
+  properties (name, parent, licence).
 - **Posted vs corrected coordinates** — published listing coordinates vs the
   user's solved/real coordinates (stored on `UserNote`).
 - **Layer** — a category of boundary (country / state / county / custom), each
   its own R-Tree + metadata table.
 - **Local-first** — data is fetched from a remote source once, cached on disk,
-  and served locally thereafter; the network is touched only on first fetch or a
-  deliberate refresh.
+  and served locally thereafter; the network is touched only on first fetch, a
+  "download all", or a deliberate refresh.

--- a/architecture/reverse-geocoding.md
+++ b/architecture/reverse-geocoding.md
@@ -4,7 +4,7 @@ OpenSAK assigns a **country**, **state/region** and **county** to every cache by
 
 This document describes the design of that subsystem — the *boundary engine*.
 
-> **Acknowledgements.** The two-stage spatial design and the boundary dataset described here build directly on GSAK. Mike Wood (*Lignumaqua*), GSAK's custodian, generously shared the approach, the bounding-box index and the public polygon files, and offered them to OpenSAK. This architecture adapts that work to a modern, open stack — the credit for the original method and data is his and the wider GSAK community's.
+> **Acknowledgements.** The two-stage spatial design and the boundary dataset described here build directly on GSAK. Mike (*Lignumaqua*), GSAK's custodian, generously shared the approach, the bounding-box index and the public polygon files, and offered them to OpenSAK. This architecture adapts that work to a modern, open stack — the credit for the original method and data is his and the wider GSAK community's.
 
 ---
 
@@ -314,7 +314,7 @@ Building `boundaries.db` is mostly reading each feature's `bbox` — a quick, on
 There is **no project-run server**. Distribution uses only what an open-source project already has:
 
 - **Baseline** (`countries/`, `states/`, `boundaries.db`) ships as package data in the install, so country/state resolution works with no network from first launch.
-- **County packs** live as **GitHub Releases assets** in a data repository (e.g. `OpenSAK/boundary-data`), each a per-country GeoJSON `FeatureCollection`. The first time a lookup needs a country's counties, `geo.packs` downloads that pack over its stable release URL (GitHub serves these via a CDN), writes it under `counties/`, and serves it locally thereafter.
+- **County packs** live as **GitHub Release assets** in a dedicated data repository, `AgreeDK/OpenSAK-Data`, each a per-country GeoJSON `FeatureCollection`. The first time a lookup needs a country's counties, `geo.packs` downloads that pack over its stable release URL (GitHub serves these via a CDN), writes it under `counties/`, and serves it locally thereafter.
 - **"Download all"** is an optional one-click action that pre-fetches every pack, for users who want full offline coverage before heading into the field.
 
 So the network is involved **only** on the first fetch of a region's data, a "download all", or a deliberate refresh; steady-state operation is fully local.
@@ -368,7 +368,7 @@ What this means in practice:
 - **Added to the install (baseline = countries + states + index):** ~**60 MB** of GeoJSON. **Geometry simplification** (Douglas–Peucker) is the main lever and is recommended for the baseline: at the zoom these layers need it cuts size 2–5× with negligible accuracy loss, bringing the baseline to roughly **15–25 MB**. (GSAK's polygons are already simplified for the same reason.)
 - **A typical on-demand county download:** Portugal ~3,900 features ≈ **~14 MB** (~3.5 MB gzipped); a US state such as Texas (~250 counties) ≈ **~2.5 MB** (~0.7 MB gzipped); a small country well under 1 MB. A user who caches in a handful of countries downloads **single-digit to low-tens of MB, ever**.
 - **Disk cache.** Packs can be kept gzipped on disk and decompressed on read (cheap for `json`), so even a full "download all" footprint is ~**70 MB**, not 270 MB.
-- **What goes to GitHub.** The full set published as gzipped release assets is ~**70 MB per release**; re-publishing only changed packs makes most releases far smaller. Release assets do **not** count toward the git repository size and the per-asset limit is 2 GB, so this sits comfortably within GitHub's free hosting.
+- **What goes to GitHub.** The data lives in the dedicated `AgreeDK/OpenSAK-Data` repository and is published as **GitHub Release assets — never Git LFS**. The distinction is what keeps it free: for public repositories, Release-asset downloads are unmetered and do not count toward repository size, whereas Git LFS is billed beyond a small free tier. The full set is ~**70 MB per release** (gzipped); re-publishing only changed packs keeps most releases far smaller, and the 2 GB per-asset limit is never approached — comfortably within GitHub's free hosting.
 
 ---
 

--- a/plans/reverse-geocoding.md
+++ b/plans/reverse-geocoding.md
@@ -1,0 +1,140 @@
+# Development Plan — Offline Reverse Geocoding (County / State / Country)
+
+Status: Proposed
+Relates to: GitHub issue #60 · design in [`architecture/reverse-geocoding.md`](../architecture/reverse-geocoding.md)
+Scope: full implementation of the offline boundary engine — data pipeline, runtime engine, on-demand packs, schema, GUI, packaging/CI.
+
+This plan turns the architecture document into shippable work. It is ordered **bottom-up**: the data has to exist before the engine can resolve, the engine before the GUI, the GUI before the old code can be retired. Each phase is independently testable and ships on its own branch.
+
+## How this ships
+
+- **One branch per phase**, named `60-phase-N-<desc>` (e.g. `60-phase-1-engine`), off the synced `beta`.
+- **PRs target `beta`** (per issue #257), not `main`.
+- **Commit every logical step**, Conventional Commits, no co-author trailer.
+- New user-visible strings go through `tr()` with keys added to **every** `lang/*.py`.
+- Long work stays on a `QThread`; the main thread never blocks.
+
+## Prerequisites
+
+- [ ] Receive the full polygon-file set from Mike (*Lignumaqua*) — Phase 0 cannot start without the source data. The sample `bb.db3` + `Denmark1.txt` only prove the format.
+- [ ] Create the data repository **`AgreeDK/OpenSAK-Data`** (public) with its own `LICENSE` + attribution file (the polygons are ODbL, not public domain).
+
+## Out of scope (follow-ups)
+
+- Drawing boundary outlines on the Leaflet map (the GeoJSON makes this cheap later).
+- Value **locking** and the macro hook — depend on the future custom-fields system.
+- Maps and altimetry datasets — separate problems, separate plans (the `OpenSAK-Data` repo is built to host them later).
+
+---
+
+## Phase 0 — Data pipeline and the `OpenSAK-Data` repo
+
+**Goal:** a reproducible pipeline that turns raw polygon files into the artefacts the app consumes: a baseline, per-country county packs, the bounding-box index, and a version manifest — all published as GitHub Release assets.
+
+**Tasks**
+- [ ] `tools/boundaries/normalise.py` — read native GSAK text polygons, re-encode to UTF-8, fix diacritics/renames (`Türkiye`, `Czechia`), consistent keys.
+- [ ] `tools/boundaries/to_geojson.py` — emit GeoJSON, **one `FeatureCollection` per country**, carrying `name`, `parent`, `version`, `source`, `licence`, and a `bbox` per feature. Validate geometry (closed rings, winding, holes).
+- [ ] Geometry **simplification** (Douglas–Peucker) for the baseline layer to hit the ~15–25 MB target.
+- [ ] `tools/boundaries/build_bbdb.py` — generate `boundaries.db`: per-layer R-Trees (`rtree_country/state/county`) + `region_*` metadata + `file_version`, from the feature `bbox` members.
+- [ ] `tools/boundaries/publish.py` — assemble the baseline bundle, the per-country packs, and `manifest.json` (dataset version + per-pack versions); upload as Release assets to `AgreeDK/OpenSAK-Data`.
+- [ ] Keep `tools/` **out of the runtime package** and out of the PyInstaller bundle.
+
+**Acceptance:** running the pipeline on the source data reproducibly produces `boundaries.db`, the baseline GeoJSON, the county packs and `manifest.json`; a first Release of `OpenSAK-Data` exists.
+**Risk:** medium — data quality/coverage and simplification tuning. Size: L.
+
+---
+
+## Phase 1 — Core engine (`src/opensak/geo/`)
+
+**Goal:** an offline `TerritoryResolver` that, given coordinates, returns `GeoLocation(country, state, county)` via the two-stage lookup — no GUI, no network.
+
+**Tasks**
+- [ ] Add `shapely` to `[project.dependencies]` in [`pyproject.toml`](../pyproject.toml) (Stage 2 point-in-polygon). Keep a pure-Python ray-cast fallback path behind a flag.
+- [ ] `geo/store.py` — open `boundaries.db`, resolve a region's pack + feature, lazily load and cache GeoJSON geometry.
+- [ ] `geo/boundaries.py` — `TerritoryResolver`: per-layer R-Tree query (Stage 1); on a single box hit return directly; on overlaps run point-in-polygon (Stage 2) over the 2–3 candidates; fill state/country from the county's `parent`.
+- [ ] Ship `boundaries.db` + baseline GeoJSON as package data; seed them into `<app-data>/opensak/boundaries/` on first run (resolved via [`config.get_app_data_dir()`](../src/opensak/config.py)).
+- [ ] Unit tests in `tests/unit-tests/`: known coordinates → expected territory, covering single-hit, overlap/border, hole/enclave, and no-hit (ocean) cases; a perf check that a 10k batch resolves in seconds.
+
+**Acceptance:** a batch of known points resolves correctly offline from the baseline alone; border cases pick the right region; no network is touched.
+**Risk:** medium (geometry correctness). Size: L.
+
+---
+
+## Phase 2 — On-demand packs and updates (`src/opensak/geo/packs.py`)
+
+**Goal:** fetch county packs lazily from `OpenSAK-Data`, cache them locally, and keep both the index and the packs current — all without a project-run server.
+
+**Tasks**
+- [ ] `geo/packs.py` — on a county cache miss, download that country's pack from the `AgreeDK/OpenSAK-Data` Release asset URL, write it under `counties/` with an **atomic** temp-then-swap, and serve locally thereafter.
+- [ ] **"Download all"** — pre-fetch every pack for full offline coverage.
+- [ ] **Update check** — throttled (≈weekly + manual) comparison against the latest `manifest.json`; re-download only the changed `boundaries.db` and any out-of-date *cached* packs, atomically; flag affected caches' `location_dataset` as stale rather than rewriting values.
+- [ ] Tests with the network **mocked/stubbed** (mirror `conftest.py`'s offline pattern): cache-miss → fetch → local second lookup; version compare; atomic swap; offline fallback returns the coarser cached layer, never a wrong guess.
+
+**Acceptance:** a missing country fetches once (mocked) then resolves locally; an update detects a newer manifest and refreshes only what changed.
+**Risk:** medium (network edge cases, atomicity). Size: M.
+
+---
+
+## Phase 3 — Schema and provenance
+
+**Goal:** store where each territory value came from, so results are auditable and re-runnable.
+
+**Tasks**
+- [ ] [`db/models.py`](../src/opensak/db/models.py) — add to `Cache`: `location_source` (`groundspeak`/`computed`), `location_basis` (`posted`/`corrected`), `location_updated` (datetime), `location_dataset` (version string).
+- [ ] [`db/database.py`](../src/opensak/db/database.py) — bump `SCHEMA_VERSION` (currently 11) and add an idempotent `ALTER TABLE caches ADD COLUMN …` block using the existing `PRAGMA table_info` pattern.
+- [ ] Tests: an existing DB upgrades in place; new columns default to NULL ("unknown / imported").
+
+**Acceptance:** old databases open and migrate cleanly; the four provenance columns exist and are writable.
+**Risk:** low. Size: S. (Can land in parallel with Phase 1–2; required by Phase 4.)
+
+---
+
+## Phase 4 — GUI integration and retiring the old engine
+
+**Goal:** wire the engine into the existing Update Location flow, surface provenance and updates, and remove the nearest-neighbour geocoder.
+
+**Tasks**
+- [ ] Point `ReverseGeocodeWorker` in [`update_location_dialog.py`](../src/opensak/gui/dialogs/update_location_dialog.py) at `TerritoryResolver`; write the provenance fields per cache.
+- [ ] Coordinate basis: **default to posted** (the "use corrected" toggle currently defaults on); keep the scope options (all / missing / this cache / filter).
+- [ ] Keep the auto-run after GPX/PQ import; route it through the new engine.
+- [ ] Add menu actions: **Download all boundary packs** and **Check for boundary updates**; show a stale indicator when `location_dataset` trails the current dataset, offering a one-click re-run.
+- [ ] i18n: add every new `tr()` key to all `lang/*.py`; `test_languages.py` / `test_lang_modules.py` stay green.
+- [ ] **Remove** [`geocoder.py`](../src/opensak/geocoder.py) (the `reverse_geocoder` KD-tree and the Nominatim path); drop `reverse_geocoder` (and `pycountry`, if now pipeline-only) from runtime deps.
+- [ ] Widget/e2e tests with `qtbot` (mind the PySide worker-mocking segfault gotcha: patch the worker class, not QObject methods on a live instance).
+
+**Acceptance:** the dialog resolves end-to-end via the new engine; import auto-fills; provenance and stale state are visible; all language key tests pass; no reference to `reverse_geocoder` remains.
+**Risk:** medium (UI wiring + dep removal). Size: L.
+
+---
+
+## Phase 5 — Packaging and CI
+
+**Goal:** the shipped binaries resolve offline on all three OSes, and CI proves it.
+
+**Tasks**
+- [ ] [`opensak.spec`](../opensak.spec) — bundle `boundaries.db` + baseline GeoJSON via `collect_data_files`/`datas`; remove the old `reverse_geocoder` data bundling.
+- [ ] Verify `shapely`/GEOS wheels install across the [`tests.yml`](../.github/workflows/tests.yml) matrix (Linux/macOS/Windows, py 3.11/3.12); enable the pure-Python fallback if a platform lacks wheels.
+- [ ] Add a real-dependency smoke test (in the spirit of `test_geocoder_deps.py`): import `shapely` and resolve a known coordinate under the build's dependency set, so a missing dep fails CI.
+- [ ] Check the install/footprint delta stays within the Phase 0 baseline budget.
+- [ ] Ship the ODbL attribution in the app's About/credits.
+
+**Acceptance:** freshly built binaries on Windows/macOS/Linux perform an offline reverse geocode; CI is green including `shapely` and the smoke test.
+**Risk:** medium (native wheels are the usual culprit). Size: M.
+
+---
+
+## Sequencing
+
+```
+Phase 0 (data)  ──►  Phase 1 (engine)  ──►  Phase 2 (packs/updates)  ──►  Phase 4 (GUI) ──► Phase 5 (CI)
+                                   Phase 3 (schema) ───────────────────────┘
+```
+
+Phase 3 is small and can be done early, but Phase 4 depends on it. Phase 1 needs Phase 0's `boundaries.db` + baseline to test against. Phase 5 closes out packaging once the engine and GUI are real.
+
+## Risks and open questions
+
+- **Data delivery and quality.** Everything hinges on receiving the polygon files; coverage gaps and stale boundaries are inherited from the source (mitigated by the refresh pipeline and provenance).
+- **Simplification vs accuracy.** The baseline budget trades polygon detail for size; counties stay full-resolution because they are fetched on demand.
+- **`shapely` on all platforms.** The main packaging risk; the pure-Python fallback is the safety net.
+- **Behaviour change.** Default flips to posted coordinates and the nearest-neighbour engine is removed — call this out in the release notes for existing users.


### PR DESCRIPTION
This PR adds the design document for OpenSAK's offline reverse-geocoding engine — how every cache gets a correct country / state / county from its coordinates, locally and accurately. It is design only; no implementation yet. The file is architecture/reverse-geocoding.md.

Credit: the two-stage method and the boundary dataset come from GSAK; Mike (Lignumaqua) generously shared the approach and the public data. This adapts it to a modern, open stack.