### PR TITLE
Fix 227: sync home_lat/lon on combo reload so distances use the correct origin

### DIFF
--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -1198,6 +1198,22 @@ class MainWindow(QMainWindow):
                     self._home_combo.setCurrentIndex(i)
                     break
         self._home_combo.blockSignals(False)
+        self._sync_active_home_coords()
+
+    def _sync_active_home_coords(self) -> None:
+        # _reload_home_combo blocks signals, so _on_home_changed never fires
+        # during a reload. This ensures home_lat/home_lon always reflect the
+        # active home point before _update_distances reads them.
+        s = get_settings()
+        name = s.active_home_name
+        for p in s.home_points:
+            if p.name == name:
+                if p.name == "★ Home":
+                    real = s.get_gc_home_point()
+                    s.set_active_home(real if real else p)
+                else:
+                    s.set_active_home(p)
+                return
 
     def _on_home_changed(self, index: int) -> None:
         """Skift aktivt hjemmepunkt — gem per-db og pan kort."""

--- a/tests/e2e-tests/test_e2e_mainwindow.py
+++ b/tests/e2e-tests/test_e2e_mainwindow.py
@@ -746,6 +746,29 @@ class TestTripBlocked:
 
 
 class TestHomeAndCwExtra:
+    def test_reload_home_combo_syncs_home_coords(self, seeded_window):
+        # Regression: _reload_home_combo blocked signals, so home_lat/lon were
+        # never written on startup/db-switch, causing distances from Copenhagen.
+        from opensak.gui.settings import HomePoint, get_settings
+        s = get_settings()
+        p = HomePoint("Idaho", 43.5, -116.2)
+        s.add_or_update_home_point(p)
+        s.active_home_name = p.name  # name only — lat/lon not yet written
+        assert s.home_lat == pytest.approx(55.6761)  # Copenhagen default
+        seeded_window._reload_home_combo()
+        assert s.home_lat == pytest.approx(43.5)
+        assert s.home_lon == pytest.approx(-116.2)
+
+    def test_reload_home_combo_syncs_star_home_coords(self, seeded_window):
+        # ★ Home coordinates come from gc_home_location, not homepoints.list.
+        from opensak.gui.settings import get_settings
+        s = get_settings()
+        s.gc_home_location = "N43 30.000 W116 12.000"
+        s.active_home_name = "★ Home"
+        seeded_window._reload_home_combo()
+        assert s.home_lat == pytest.approx(43.5, abs=0.01)
+        assert s.home_lon == pytest.approx(-116.2, abs=0.01)
+
     def test_on_home_changed_user_and_gc_home(self, seeded_window, iso_settings):
         from opensak.gui.settings import HomePoint, get_settings
         s = get_settings()


### PR DESCRIPTION
_reload_home_combo blocked signals to avoid side effects, which meant _on_home_changed never fired and home_lat/home_lon were never written from the active home point on startup or database switch. They fell back to the Copenhagen defaults (55.6761 / 12.5683), causing _update_distances to report all caches as close to Denmark regardless of the chosen home location.

Add _sync_active_home_coords, called at the end of _reload_home_combo, that resolves the active home point (handling the ★ Home / gc_home_location path) and calls set_active_home to persist the correct coordinates. Add two e2e regression tests covering both user-defined and ★ Home coordinate sync.

Related to #277