### PR TITLE
Fix: clarify trash icon tooltip to mention filter profile

### DIFF
--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -446,7 +446,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Uložený filtr:",
     "filter_none":                  "(Žádný)",
     "filter_save_btn":              "💾  Uložit",
-    "filter_delete_profile_tooltip":"Smazat vybraný profil",
+    "filter_delete_profile_tooltip":"Smazat vybraný profil filtru",
     "filter_apply_btn":             "⚡  Použít",
     "filter_reset_all_btn":         "↺  Resetovat vše",
     "filter_reset_tab_btn":         "↺  Resetovat záložku",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -446,7 +446,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Gemt filter:",
     "filter_none":                  "(Intet)",
     "filter_save_btn":              "💾  Gem",
-    "filter_delete_profile_tooltip":"Slet valgt profil",
+    "filter_delete_profile_tooltip":"Slet valgt filterprofil",
     "filter_apply_btn":             "⚡  Udfør",
     "filter_reset_all_btn":         "↺  Reset alle",
     "filter_reset_tab_btn":         "↺  Reset fane",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -446,7 +446,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Gespeicherte Filter:",
     "filter_none":                  "(Keine)",
     "filter_save_btn":              "💾  Speichern",
-    "filter_delete_profile_tooltip":"Lösche ausgewähltes Profil",
+    "filter_delete_profile_tooltip":"Lösche ausgewähltes Filterprofil",
     "filter_apply_btn":             "⚡  Anwenden",
     "filter_reset_all_btn":         "↺  Alle zurücksetzen",
     "filter_reset_tab_btn":         "↺  Tab zurücksetzen",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -447,7 +447,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Saved filter:",
     "filter_none":                  "(None)",
     "filter_save_btn":              "💾  Save",
-    "filter_delete_profile_tooltip":"Delete selected profile",
+    "filter_delete_profile_tooltip":"Delete selected filter profile",
     "filter_apply_btn":             "⚡  Apply",
     "filter_reset_all_btn":         "↺  Reset all",
     "filter_reset_tab_btn":         "↺  Reset tab",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -446,7 +446,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Filtre enregistré:",
     "filter_none":                  "(Aucun)",
     "filter_save_btn":              "💾  Enregistrer",
-    "filter_delete_profile_tooltip":"Supprimer le profil sélectionné",
+    "filter_delete_profile_tooltip":"Supprimer le profil de filtre sélectionné",
     "filter_apply_btn":             "⚡  Appliquer",
     "filter_reset_all_btn":         "↺  Réinitialiser tout",
     "filter_reset_tab_btn":         "↺  Réinitialiser l'onglet",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -449,7 +449,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Opgeslagen filter:",
     "filter_none":                  "(Geen)",
     "filter_save_btn":              "💾  Opslaan",
-    "filter_delete_profile_tooltip":"Geselecteerd profiel verwijderen",
+    "filter_delete_profile_tooltip":"Geselecteerd filterprofiel verwijderen",
     "filter_apply_btn":             "⚡  Toepassen",
     "filter_reset_all_btn":         "↺  Alles resetten",
     "filter_reset_tab_btn":         "↺  Tabblad resetten",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -446,7 +446,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Filtro guardado:",
     "filter_none":                  "(Nenhum)",
     "filter_save_btn":              "💾  Guardar",
-    "filter_delete_profile_tooltip":"Eliminar perfil selecionado",
+    "filter_delete_profile_tooltip":"Eliminar perfil de filtro selecionado",
     "filter_apply_btn":             "⚡  Aplicar",
     "filter_reset_all_btn":         "↺  Repor tudo",
     "filter_reset_tab_btn":         "↺  Repor separador",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -446,7 +446,7 @@ STRINGS: dict[str, str] = {
     "filter_saved_label":           "Sparat filter:",
     "filter_none":                  "(Inget)",
     "filter_save_btn":              "💾  Spara",
-    "filter_delete_profile_tooltip":"Ta bort vald profil",
+    "filter_delete_profile_tooltip":"Ta bort valt filterprofil",
     "filter_apply_btn":             "⚡  Använd",
     "filter_reset_all_btn":         "↺  Återställ allt",
     "filter_reset_tab_btn":         "↺  Återställ flik",


### PR DESCRIPTION
"Delete selected profile" was ambiguous without context; updated all 8 language files to say "Delete selected filter profile" (or equivalent).

Fix #292