### PR TITLE
Enabling partial match in GC searches

### DIFF
--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -458,19 +458,23 @@ class GcCodeFilter(BaseFilter):
 
     def __init__(self, text: str):
         self.text = text.upper()
+        # When the input already has the "GC" prefix, a prefix match is enough
+        # and lets SQLite use the B-tree index on gc_code.  Without the prefix,
+        # use a substring match so "BEK" finds "GCBEKKA".
+        self._prefix = self.text.startswith("GC")
         self._sql_applied = False
 
     def apply_to_query(self, query):
         from sqlalchemy import func
         self._sql_applied = True
-        # GC codes are always searched from the start (GC12345) — use a prefix
-        # match so SQLite can exploit the existing B-tree index on gc_code.
-        return query.filter(func.upper(Cache.gc_code).like(f"{self.text}%"))
+        pattern = f"{self.text}%" if self._prefix else f"%{self.text}%"
+        return query.filter(func.upper(Cache.gc_code).like(pattern))
 
     def matches(self, cache: Cache) -> bool:
         if self._sql_applied:
             return True
-        return (cache.gc_code or "").upper().startswith(self.text)
+        code = (cache.gc_code or "").upper()
+        return code.startswith(self.text) if self._prefix else self.text in code
 
     def to_dict(self) -> dict:
         return {"filter_type": self.filter_type, "text": self.text}

--- a/tests/e2e-tests/test_e2e_filter.py
+++ b/tests/e2e-tests/test_e2e_filter.py
@@ -112,6 +112,16 @@ def test_gc_search_prefix_finds_multiple(seeded_window, qtbot):
     assert window._cache_table.row_count() == 2
 
 
+def test_gc_search_partial_without_gc_prefix(seeded_window, qtbot):
+    # "AAA" (no GC prefix) must find GCAAA01 and GCAAA02 via substring match.
+    window = seeded_window
+
+    window._search_gc.setText("AAA")
+    qtbot.waitUntil(lambda: window._cache_table.row_count() == 2, timeout=1_000)
+
+    assert window._cache_table.row_count() == 2
+
+
 # ── FilterDialog (Ctrl+F path) ─────────────────────────────────────────────────
 
 

--- a/tests/unit-tests/test_filters.py
+++ b/tests/unit-tests/test_filters.py
@@ -236,6 +236,43 @@ def test_gc_code_filter(tmp_db):
     assert results[0].gc_code == "GC00001"
 
 
+def test_gc_code_filter_partial_no_prefix_sql(tmp_db):
+    # SQL path: "00001" (no GC prefix) must find GC00001 via substring match.
+    with get_session() as s:
+        results = apply_filters(s, FilterSet().add(GcCodeFilter("00001")))
+    codes = {c.gc_code for c in results}
+    assert "GC00001" in codes
+    assert "GC00002" not in codes
+
+
+def test_gc_code_filter_partial_all_match_sql(tmp_db):
+    # SQL path: "0000" is contained in all six seeded GC codes.
+    with get_session() as s:
+        results = apply_filters(s, FilterSet().add(GcCodeFilter("0000")))
+    assert len(results) == 6
+
+
+def test_gc_code_filter_python_path_with_prefix(tmp_db):
+    # Python path (no SQL call): prefix match when text starts with "GC".
+    f = GcCodeFilter("GC00001")
+    with get_session() as s:
+        all_caches = s.query(Cache).all()
+    matches = [c for c in all_caches if f.matches(c)]
+    assert len(matches) == 1
+    assert matches[0].gc_code == "GC00001"
+
+
+def test_gc_code_filter_python_path_without_prefix(tmp_db):
+    # Python path (no SQL call): substring match when text has no "GC" prefix.
+    f = GcCodeFilter("00001")
+    with get_session() as s:
+        all_caches = s.query(Cache).all()
+    matches = [c for c in all_caches if f.matches(c)]
+    codes = {c.gc_code for c in matches}
+    assert "GC00001" in codes
+    assert "GC00002" not in codes
+
+
 def test_placed_by_filter(tmp_db):
     with get_session() as s:
         results = apply_filters(s, FilterSet().add(PlacedByFilter("ownera")))


### PR DESCRIPTION
When the input lacks the "GC" prefix, switch GcCodeFilter from a prefix match to a substring match so "BEK" finds "GCBEKKA". More user-friendly.

#315 