### PR TITLE
Fix: sort by favourite column raised AttributeError

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -848,6 +848,8 @@ class CacheTableModel(QAbstractTableModel):
             self._caches.sort(key=lambda c: int(c.user_flag or False), reverse=reverse)
         elif col == "user_sort":
             self._caches.sort(key=lambda c: c.user_sort if c.user_sort is not None else 999999, reverse=reverse)
+        elif col == "favorite":
+            self._caches.sort(key=lambda c: int(c.favorite_point or False), reverse=reverse)
         elif col == "favorite_points":
             self._caches.sort(key=lambda c: c.favorite_points or 0, reverse=reverse)
         elif col == "container":

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -388,10 +388,11 @@ class TestSort:
         ]
         caches[1].user_note = None
         caches[0].user_note = _note(1.0, 2.0)
+        caches[0].favorite_point = True
         m = self._loaded(model, caches)
         for col in ("terrain", "found", "corrected", "log_count", "last_log",
                     "hidden_date", "found_date", "dnf_date", "first_to_find",
-                    "user_flag", "user_sort", "favorite_points", "container",
+                    "user_flag", "user_sort", "favorite", "favorite_points", "container",
                     "latitude", "longitude", "country"):
             m.sort(ALL_COLUMNS.index(col), Qt.SortOrder.AscendingOrder)
             m.sort(ALL_COLUMNS.index(col), Qt.SortOrder.DescendingOrder)
@@ -415,6 +416,19 @@ class TestSort:
         for col in ("country", "state", "county", "placed_by", "user_data_1"):
             model.sort(ALL_COLUMNS.index(col), Qt.SortOrder.AscendingOrder)
             model.sort(ALL_COLUMNS.index(col), Qt.SortOrder.DescendingOrder)
+
+    def test_sort_by_favorite_no_crash(self, model):
+        # Regression #319: sort() fell through to getattr(c, "favorite") but the
+        # model attribute is favorite_point, causing AttributeError.
+        caches = [
+            _cache(gc_code="A", favorite_point=True),
+            _cache(gc_code="B"),
+        ]
+        model.load(caches)
+        model.sort(ALL_COLUMNS.index("favorite"), Qt.SortOrder.AscendingOrder)
+        assert model._caches[0].gc_code == "B"  # non-favourite first
+        model.sort(ALL_COLUMNS.index("favorite"), Qt.SortOrder.DescendingOrder)
+        assert model._caches[0].gc_code == "A"  # favourite first
 
 
 # ── flags / setData (needs DB) ──────────────────────────────────────────────────


### PR DESCRIPTION
The sort() method had no handler for the "favorite" column, so it fell through to the else branch which called getattr(c, "favorite"). The Cache model attribute is favorite_point, not favorite.

Add an explicit elif branch using c.favorite_point, and extend the crash-coverage test + add a regression test.

Closes #319