### PR TITLE
Fix: date format does not update

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -7,8 +7,9 @@ Supports corrected coordinates (user-solved mystery cache finals).
 from __future__ import annotations
 import re
 import webbrowser
+from datetime import datetime
 from opensak.utils.constants import LOG_COLOURS
-from PySide6.QtCore import Qt, QUrl, Signal
+from PySide6.QtCore import Qt, QUrl, Signal, QDate, QLocale
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QTextBrowser, QTabWidget, QFrame, QSizePolicy,
@@ -22,6 +23,19 @@ from opensak.db.models import Cache
 from opensak.lang import tr
 from opensak.coords import format_coords
 from opensak.gui.settings import get_settings
+from opensak.utils.types import DateFormat
+
+
+def _format_date(d: datetime) -> str:
+    fmt = get_settings().date_format
+    if fmt == DateFormat.DMY:
+        return d.strftime("%d.%m.%Y")
+    if fmt == DateFormat.MDY:
+        return d.strftime("%m/%d/%Y")
+    if fmt == DateFormat.YMD:
+        return d.strftime("%Y-%m-%d")
+    qd = QDate(d.year, d.month, d.day)
+    return QLocale.system().toString(qd, QLocale.FormatType.ShortFormat)
 
 
 # issue #219 — geocaching.com logge bruger markdown-links: [linktekst](https://url)
@@ -466,7 +480,7 @@ class CacheDetailPanel(QWidget):
         if cache.placed_by:
             parts.append(tr("detail_placed_by", name=cache.placed_by))
         if cache.hidden_date:
-            parts.append(tr("detail_hidden_date", date=cache.hidden_date.strftime('%d.%m.%Y')))
+            parts.append(tr("detail_hidden_date", date=_format_date(cache.hidden_date)))
         self._placed_lbl.setText("   |   ".join(parts))
 
         # Description — renderes via QWebEngineView så billeder og CJK-fonte virker
@@ -537,7 +551,7 @@ class CacheDetailPanel(QWidget):
         html = []
         for log in filtered:
             colour = colours.get(log.log_type, "#555555")
-            date_str = log.log_date.strftime("%d.%m.%Y") if log.log_date else "?"
+            date_str = _format_date(log.log_date) if log.log_date else "?"
             # issue #218 — ingen trunkering: hele logteksten vises (QTextBrowser scroller selv)
             text = log.text or ""
             if filter_text and filter_text in text.lower():

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -1205,6 +1205,12 @@ class MainWindow(QMainWindow):
         if dlg.exec():
             self._reload_home_combo()
             self._map_widget.reload_map(self._refresh_cache_list)
+            self._refresh_cache_list()
+            cache = self._cache_table.selected_cache()
+            if cache:
+                full = self._load_full_cache(cache.gc_code)
+                if full:
+                    self._detail_panel.show_cache(full)
 
     def _reload_home_combo(self) -> None:
         """Genindlæs hjemmepunkts-dropdown fra settings."""

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -1,0 +1,27 @@
+# tests/unit-tests/test_cache_detail.py — cache detail panel helpers.
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from opensak.gui import cache_detail as cd
+from opensak.utils.types import DateFormat
+
+
+def _fake_settings(fmt: DateFormat) -> SimpleNamespace:
+    return SimpleNamespace(date_format=fmt)
+
+
+@pytest.mark.parametrize("fmt, expected", [
+    (DateFormat.DMY, "25.12.2024"),
+    (DateFormat.MDY, "12/25/2024"),
+    (DateFormat.YMD, "2024-12-25"),
+])
+def test_format_date_respects_settings(monkeypatch, qapp, fmt, expected):
+    # Regression for #322: dates in the detail panel were hardcoded to DMY.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(fmt))
+    result = cd._format_date(datetime(2024, 12, 25))
+    assert result == expected


### PR DESCRIPTION
- Add _format_date helper to cache_detail.py that reads from settings, replacing the two hardcoded '%d.%m.%Y' strftime calls
- Refresh the cache list and re-render the detail panel in _open_settings so date changes are visible without restarting the app

Closes #322 