### PR TITLE
Fix: remove show found/archived from settings, rely on filters only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ exclude = ["tests/e2e-tests/conftest.py"]
 mypy_path = "src"
 explicit_package_bases = true
 namespace_packages = true
-python_version = "3.11"
+python_version = "3.12"
 follow_imports = "silent"
 ignore_missing_imports = true
 

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -197,12 +197,6 @@ class SettingsDialog(QDialog):
         self._miles_cb = QCheckBox(tr("settings_use_miles"))
         disp_layout.addWidget(self._miles_cb)
 
-        self._archived_cb = QCheckBox(tr("settings_show_archived"))
-        disp_layout.addWidget(self._archived_cb)
-
-        self._found_cb = QCheckBox(tr("settings_show_found"))
-        disp_layout.addWidget(self._found_cb)
-
         map_row = QHBoxLayout()
         map_row.addWidget(QLabel(tr("settings_map_label")))
         self._map_provider = QComboBox()
@@ -842,8 +836,6 @@ class SettingsDialog(QDialog):
         self._install_dir_row.set_path(get_install_dir())
         self._db_dir_row.set_path(get_db_dir())
         self._miles_cb.setChecked(s.use_miles)
-        self._archived_cb.setChecked(s.show_archived)
-        self._found_cb.setChecked(s.show_found)
         idx = self._map_provider.findData(s.map_provider)
         self._map_provider.setCurrentIndex(idx if idx >= 0 else 0)
         idx = self._coord_format.findData(s.coord_format)
@@ -884,8 +876,6 @@ class SettingsDialog(QDialog):
             if parse_coords(home_text) is not None:  # keep existing if invalid
                 s.gc_home_location = home_text
         s.use_miles         = self._miles_cb.isChecked()
-        s.show_archived     = self._archived_cb.isChecked()
-        s.show_found        = self._found_cb.isChecked()
         s.map_provider      = self._map_provider.currentData()
         s.coord_format      = self._coord_format.currentData()
         s.date_format       = self._date_format.currentData()

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -982,12 +982,6 @@ class MainWindow(QMainWindow):
             from opensak.filters.engine import ArchivedFilter
             fs.add(ArchivedFilter())
 
-        # Hide archived caches globally unless the user explicitly asked for them
-        # (idx 5 = "Archived" quick filter) or enabled them in display settings.
-        if idx != 5 and not get_settings().show_archived:
-            from opensak.filters.engine import AvailabilityFilter
-            fs.add(AvailabilityFilter(show_avail=True, show_unavail=True, show_archived=False))
-
         # GC-nummer søgefelt (søger kun i GC kode)
         gc_search = self._search_gc.text().strip()
         if gc_search:

--- a/src/opensak/gui/settings.py
+++ b/src/opensak/gui/settings.py
@@ -285,28 +285,6 @@ class AppSettings:
 
     # ── Display ───────────────────────────────────────────────────────────────
 
-    @property
-    def show_archived(self) -> bool:
-        val = get_store().get("display.show_archived", False)
-        if isinstance(val, bool):
-            return val
-        return str(val).lower() in ("true", "1", "yes")
-
-    @show_archived.setter
-    def show_archived(self, value: bool) -> None:
-        get_store().set("display.show_archived", bool(value))
-
-    @property
-    def show_found(self) -> bool:
-        val = get_store().get("display.show_found", True)
-        if isinstance(val, bool):
-            return val
-        return str(val).lower() in ("true", "1", "yes")
-
-    @show_found.setter
-    def show_found(self, value: bool) -> None:
-        get_store().set("display.show_found", bool(value))
-
     # ── Window state ──────────────────────────────────────────────────────────
 
     @property

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -223,8 +223,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "Uživatelská místa",
     "settings_group_display":       "Zobrazení",
     "settings_use_miles":           "Zobrazovat vzdálenosti v mílích (místo km)",
-    "settings_show_archived":       "Zobrazovat archivované keše",
-    "settings_show_found":          "Zobrazovat nalezené keše",
     "settings_map_label":           "Mapová aplikace:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -223,8 +223,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "Brugerplaceringer",
     "settings_group_display":       "Visning",
     "settings_use_miles":           "Vis afstande i miles (i stedet for km)",
-    "settings_show_archived":       "Vis arkiverede caches",
-    "settings_show_found":          "Vis fundne caches",
     "settings_map_label":           "Kortapp:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -223,8 +223,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "Benutzerstandorte",
     "settings_group_display":       "Anzeige",
     "settings_use_miles":           "Entfernungen in Meilen anzeigen (anstelle von km)",
-    "settings_show_archived":       "Archivierte Caches anzeigen",
-    "settings_show_found":          "Gefundene Caches anzeigen",
     "settings_map_label":           "Karten-App:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -223,8 +223,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "User locations",
     "settings_group_display":       "Display",
     "settings_use_miles":           "Show distances in miles (instead of km)",
-    "settings_show_archived":       "Show archived caches",
-    "settings_show_found":          "Show found caches",
     "settings_map_label":           "Map app:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -223,8 +223,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "Emplacements utilisateur",
     "settings_group_display":       "Affichage",
     "settings_use_miles":           "Afficher les distances en miles (au lieu de km)",
-    "settings_show_archived":       "Afficher les caches archivées",
-    "settings_show_found":          "Afficher les caches trouvées",
     "settings_map_label":           "Application de carte:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -226,8 +226,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "Gebruikerslocaties",
     "settings_group_display":       "Weergave",
     "settings_use_miles":           "Afstanden weergeven in mijlen (in plaats van km)",
-    "settings_show_archived":       "Gearchiveerde caches weergeven",
-    "settings_show_found":          "Gevonden caches weergeven",
     "settings_map_label":           "Kaartapp:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -223,8 +223,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "Localizações do utilizador",
     "settings_group_display":       "Mostrar",
     "settings_use_miles":           "Mostrar distâncias em milhas (em vez de km)",
-    "settings_show_archived":       "Mostrar caches arquivadas",
-    "settings_show_found":          "Mostrar caches encontradas",
     "settings_map_label":           "Mapa:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -223,8 +223,6 @@ STRINGS: dict[str, str] = {
     "settings_group_user_locations":                "Användarplatser",
     "settings_group_display":       "Visa",
     "settings_use_miles":           "Visa avstånd i miles (i stället för km)",
-    "settings_show_archived":       "Visa arkiverade cacher",
-    "settings_show_found":          "Visa hittade cacher",
     "settings_map_label":           "Kart app:",
     "settings_map_google":          "Google Maps",
     "settings_map_osm":             "OpenStreetMap",

--- a/src/opensak/settings_store.py
+++ b/src/opensak/settings_store.py
@@ -250,8 +250,6 @@ def repair_corrupted_bool_keys(store: SettingsStore) -> None:
     bool_keys = [
         "updates.check_enabled",
         "display.use_miles",
-        "display.show_archived",
-        "display.show_found",
         "location.nominatim_enabled",
     ]
     fixes: dict[str, Any] = {}
@@ -297,8 +295,6 @@ def migrate_from_qsettings(store: SettingsStore) -> bool:
             "display/use_miles":        "display.use_miles",
             "display/coord_format":     "display.coord_format",
             "display/map_provider":     "display.map_provider",
-            "display/show_archived":    "display.show_archived",
-            "display/show_found":       "display.show_found",
             # Sprog
             "language":                 "app.language",
             # Søgning

--- a/tests/e2e-tests/test_e2e_mainwindow.py
+++ b/tests/e2e-tests/test_e2e_mainwindow.py
@@ -189,8 +189,7 @@ class TestCacheList:
         fs = seeded_window._build_current_filterset()
         assert len(fs) >= 2
 
-    def test_show_archived_setting_hides_archived(self, seeded_window):
-        from opensak.gui.settings import get_settings
+    def test_archived_quick_filter_shows_archived(self, seeded_window):
         from opensak.db.database import get_session
         from opensak.db.models import Cache as CacheModel
 
@@ -199,30 +198,12 @@ class TestCacheList:
             cache.archived = True
             session.commit()
 
-        get_settings().show_archived = False
-        seeded_window._quick_filter.setCurrentIndex(0)
-        seeded_window._refresh_cache_list()
-        codes = [c.gc_code for c in seeded_window._cache_table.get_all_caches()]
-        assert "GC12345" not in codes
-
-    def test_show_archived_setting_shows_archived(self, seeded_window):
-        from opensak.gui.settings import get_settings
-        from opensak.db.database import get_session
-        from opensak.db.models import Cache as CacheModel
-
-        with get_session() as session:
-            cache = session.query(CacheModel).filter_by(gc_code="GC12345").one()
-            cache.archived = True
-            session.commit()
-
-        get_settings().show_archived = True
-        seeded_window._quick_filter.setCurrentIndex(0)
+        seeded_window._quick_filter.setCurrentIndex(5)  # "Archived" quick filter
         seeded_window._refresh_cache_list()
         codes = [c.gc_code for c in seeded_window._cache_table.get_all_caches()]
         assert "GC12345" in codes
 
-    def test_archived_quick_filter_overrides_setting(self, seeded_window):
-        from opensak.gui.settings import get_settings
+    def test_archived_visible_by_default(self, seeded_window):
         from opensak.db.database import get_session
         from opensak.db.models import Cache as CacheModel
 
@@ -231,8 +212,7 @@ class TestCacheList:
             cache.archived = True
             session.commit()
 
-        get_settings().show_archived = False
-        seeded_window._quick_filter.setCurrentIndex(5)  # "Archived" quick filter
+        seeded_window._quick_filter.setCurrentIndex(0)
         seeded_window._refresh_cache_list()
         codes = [c.gc_code for c in seeded_window._cache_table.get_all_caches()]
         assert "GC12345" in codes

--- a/tests/unit-tests/test_app_settings.py
+++ b/tests/unit-tests/test_app_settings.py
@@ -174,12 +174,6 @@ class TestDisplay:
         s.map_provider = "osm"
         assert "openstreetmap.org" in s.get_maps_url(55.0, 12.0)
 
-    def test_show_flags(self, s):
-        s.show_archived = True
-        s.show_found = False
-        assert s.show_archived is True
-        assert s.show_found is False
-
 
 # ── window state / search / nominatim / paths ─────────────────────────────────────
 

--- a/tests/unit-tests/test_settings_store.py
+++ b/tests/unit-tests/test_settings_store.py
@@ -182,13 +182,11 @@ class TestRepairCorruptedBoolKeys:
         store._data = {
             "updates.check_enabled": "AA==",
             "display.use_miles": "AQ==",
-            "display.show_archived": "AA==",
         }
         store._flush()
         ss.repair_corrupted_bool_keys(store)
         assert store.get("updates.check_enabled") is False
         assert store.get("display.use_miles") is True
-        assert store.get("display.show_archived") is False
 
     def test_does_not_touch_unrelated_string_values(self, store):
         store.set("user.gc_username", "AA==")  # coincidentally same string


### PR DESCRIPTION
#320

Archived and found geocache visibility is now controlled exclusively through the filter dialog, eliminating the confusing duplicate controls in the Settings page that did not work correctly anyway.