### PR TITLE
Fix: reject out-of-range coordinates in parse_coords 

### DIFF
--- a/src/opensak/coords.py
+++ b/src/opensak/coords.py
@@ -116,10 +116,15 @@ def format_lon(lon: float, fmt: CoordFormat) -> str:
 
 # ── Parsing ───────────────────────────────────────────────────────────────────
 
+def _valid_range(lat: float, lon: float) -> bool:
+    return -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0
+
+
 def parse_coords(text: str) -> Coordinate | None:
     """
     Try to parse a coordinate string in any supported format.
-    Returns (lat, lon) as decimal degrees, or None if parsing fails.
+    Returns (lat, lon) as decimal degrees, or None if parsing fails or
+    the values fall outside valid geographic ranges.
 
     Accepted formats
     ----------------
@@ -138,7 +143,8 @@ def parse_coords(text: str) -> Coordinate | None:
         r'^([+-]?\d+\.\d+)[,\s]+([+-]?\d+\.\d+)$', text
     )
     if m:
-        return float(m.group(1)), float(m.group(2))
+        lat, lon = float(m.group(1)), float(m.group(2))
+        return (lat, lon) if _valid_range(lat, lon) else None
 
     # ── DMM°: "N 34° 58.088' E 034° 03.281'" (geocaching.com format) ─────────
     # Grads-tegn efter grader, apostrof efter minutter er valgfri (fixes #59)
@@ -149,13 +155,15 @@ def parse_coords(text: str) -> Coordinate | None:
     )
     if m:
         lat_h, lat_d, lat_m, lon_h, lon_d, lon_m = m.groups()
+        if float(lat_m) >= 60.0 or float(lon_m) >= 60.0:
+            return None
         lat = int(lat_d) + float(lat_m) / 60
         lon = int(lon_d) + float(lon_m) / 60
         if lat_h.upper() == "S":
             lat = -lat
         if lon_h.upper() == "W":
             lon = -lon
-        return lat, lon
+        return (lat, lon) if _valid_range(lat, lon) else None
 
     # Plain DMM "N55 47.250 E012 25.000" is already matched by the DMM° branch
     # above (the degree sign and apostrophe are optional there), so no separate
@@ -169,12 +177,16 @@ def parse_coords(text: str) -> Coordinate | None:
     )
     if m:
         lat_h, lat_d, lat_m, lat_s, lon_h, lon_d, lon_m, lon_s = m.groups()
+        if int(lat_m) >= 60 or int(lon_m) >= 60:
+            return None
+        if float(lat_s) >= 60.0 or float(lon_s) >= 60.0:
+            return None
         lat = int(lat_d) + int(lat_m) / 60 + float(lat_s) / 3600
         lon = int(lon_d) + int(lon_m) / 60 + float(lon_s) / 3600
         if lat_h.upper() == "S":
             lat = -lat
         if lon_h.upper() == "W":
             lon = -lon
-        return lat, lon
+        return (lat, lon) if _valid_range(lat, lon) else None
 
     return None

--- a/tests/unit-tests/test_coords.py
+++ b/tests/unit-tests/test_coords.py
@@ -224,6 +224,52 @@ class TestParseCoordsInvalid:
         assert parse_coords("   ") is None
 
 
+class TestParseCoordsOutOfRange:
+    # Regression for #323: syntactically valid but geographically impossible inputs
+    # must return None instead of producing nonsense coordinates.
+
+    def test_dd_lat_exceeds_90(self):
+        assert parse_coords("91.0, 10.0") is None
+
+    def test_dd_lon_exceeds_180(self):
+        assert parse_coords("45.0, 181.0") is None
+
+    def test_dd_lat_below_minus_90(self):
+        assert parse_coords("-91.0, 10.0") is None
+
+    def test_dd_lon_below_minus_180(self):
+        assert parse_coords("45.0, -181.0") is None
+
+    def test_dmm_lat_degrees_exceeds_90(self):
+        # N418 33.000 E008 40.000 — lat degrees way out of range
+        assert parse_coords("N418 33.000 E008 40.000") is None
+
+    def test_dmm_lon_minutes_overflow(self):
+        # minutes value far exceeds 59.999
+        assert parse_coords("N41 08.330 W008 40000000000000.323") is None
+
+    def test_dmm_lat_minutes_at_60(self):
+        assert parse_coords("N41 60.000 E008 30.000") is None
+
+    def test_dmm_lon_degrees_exceeds_180(self):
+        assert parse_coords("N41 30.000 E181 00.000") is None
+
+    def test_dms_lat_degrees_exceeds_90(self):
+        assert parse_coords("N91° 00' 00.00\" E012° 00' 00.00\"") is None
+
+    def test_dms_lat_minutes_at_60(self):
+        assert parse_coords("N45° 60' 00.00\" E012° 00' 00.00\"") is None
+
+    def test_dms_lon_seconds_at_60(self):
+        assert parse_coords("N45° 00' 00.00\" E012° 00' 60.00\"") is None
+
+    def test_boundary_lat_90_is_valid(self):
+        assert parse_coords("N90 00.000 E000 00.000") is not None
+
+    def test_boundary_lon_180_is_valid(self):
+        assert parse_coords("N00 00.000 E180 00.000") is not None
+
+
 class TestParseCoordsRoundtrip:
     # format_coords → parse_coords should recover the original values.
 


### PR DESCRIPTION
Regex patterns accepted syntactically valid but geographically impossible values (e.g. N418 33.000, minutes >= 60) and returned nonsense lat/lon instead of None. Added _valid_range() check on the parsed result for all three formats, plus explicit minutes/seconds < 60 guards for DMM and DMS. The error label in coord_converter_dialog already fires on None — no UI changes needed.

#323 

<img width="538" height="263" alt="Screenshot 2026-06-21 at 22 11 20" src="https://github.com/user-attachments/assets/8bf55d42-398b-4683-a250-c9ba6b67a448" />
