### PR TITLE
Fix: keep "(no hint)" visible after decode/encode toggle

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -298,10 +298,10 @@ class CacheDetailPanel(QWidget):
                     "NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm"
                 )
             )
-            self._hint_browser.setPlainText(decoded)
+            self._hint_browser.setPlainText(decoded if decoded else tr("detail_no_hint"))
             self._decode_btn.setText(tr("detail_encode_btn"))
         else:
-            self._hint_browser.setPlainText(self._raw_hint)
+            self._hint_browser.setPlainText(self._raw_hint if self._raw_hint else tr("detail_no_hint"))
             self._decode_btn.setText(tr("detail_decode_btn"))
 
     def _format_coords(self, lat: float, lon: float) -> str:

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -8,6 +8,7 @@ import pytest
 pytest.importorskip("pytestqt")
 
 from opensak.gui import cache_detail as cd
+from opensak.gui.cache_detail import CacheDetailPanel
 from opensak.utils.types import DateFormat
 
 
@@ -25,3 +26,17 @@ def test_format_date_respects_settings(monkeypatch, qapp, fmt, expected):
     monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(fmt))
     result = cd._format_date(datetime(2024, 12, 25))
     assert result == expected
+
+
+def test_decode_no_hint_shows_no_hint_label(qapp):
+    # Regression for #324: decoding a cache with no hint showed an empty text
+    # browser instead of keeping the "(no hint)" feedback visible.
+    panel = CacheDetailPanel()
+    panel._raw_hint = ""
+    panel._hint_decoded = False
+
+    panel._toggle_hint_decode()  # decode
+    assert panel._hint_browser.toPlainText() != ""
+
+    panel._toggle_hint_decode()  # encode back
+    assert panel._hint_browser.toPlainText() != ""


### PR DESCRIPTION
When a cache has no encoded hint, toggling the decode button set an empty string in the hint browser instead of preserving the "(no hint)" label.

#324