### PR TITLE
Fix: re-evaluate palette() stylesheet refs on theme switch

### DIFF
--- a/src/opensak/gui/theme.py
+++ b/src/opensak/gui/theme.py
@@ -200,14 +200,22 @@ def apply_theme(app: "QApplication", theme: str | None = None) -> None:
     palette = _dark_palette() if dark else _light_palette()
     app.setPalette(palette)
 
+    from PySide6.QtWidgets import QWidget
+
     # Qt does not always propagate a new palette to already-visible widgets
     # automatically — we need to poke each top-level window so it repaints.
+    # Widgets with palette() references in their stylesheets also need
+    # setStyleSheet() re-called to force re-evaluation of those references;
+    # update() alone repaints but does not re-parse the cached stylesheet.
     for widget in app.topLevelWidgets():
         widget.setPalette(palette)
+        if widget.styleSheet():
+            widget.setStyleSheet(widget.styleSheet())
         widget.update()
-        # Also refresh all child widgets that might have inherited the old palette
-        for child in widget.findChildren(__import__("PySide6.QtWidgets", fromlist=["QWidget"]).QWidget):
+        for child in widget.findChildren(QWidget):
             child.setPalette(palette)
+            if child.styleSheet():
+                child.setStyleSheet(child.styleSheet())
             child.update()
 
 

--- a/tests/unit-tests/test_theme.py
+++ b/tests/unit-tests/test_theme.py
@@ -139,6 +139,27 @@ class TestApplyTheme:
         theme.apply_theme(qapp, "dark")
         assert w.palette().color(QPalette.ColorRole.Window).lightness() < 100
 
+    def test_palette_stylesheet_refs_reapplied_on_theme_switch(self, qtbot, qapp):
+        # Regression for #325: palette() refs in stylesheets were not re-evaluated
+        # after a theme switch because update() alone does not re-parse the stylesheet.
+        from PySide6.QtWidgets import QWidget, QLabel
+        w = QWidget()
+        lbl = QLabel("stats", w)
+        lbl.setStyleSheet("color: palette(text); font-size: 11px;")
+        w.setStyleSheet("QWidget { background-color: palette(window); }")
+        qtbot.addWidget(w)
+        w.show()
+
+        theme.apply_theme(qapp, "dark")
+        assert w.palette().color(QPalette.ColorRole.Window).lightness() < 100
+        assert "palette(window)" in w.styleSheet()
+
+        theme.apply_theme(qapp, "light")
+        assert w.palette().color(QPalette.ColorRole.Window).lightness() > 200
+        # stylesheet must survive re-application intact
+        assert "palette(window)" in w.styleSheet()
+        assert "palette(text)" in lbl.styleSheet()
+
 
 # ── effective_theme ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Qt caches palette() references in stylesheets at parse time. Calling setPalette() + update() repaints but does not re-parse, so widgets like the stats bar kept stale colors after switching themes. Fix: call setStyleSheet(widget.styleSheet()) on any widget with an explicit stylesheet so the palette() calls are re-evaluated with the new palette.

#325 