### PR TITLE
Show outlined flag placeholder in unset user_flag

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -21,7 +21,7 @@ from opensak.coords import format_coords, format_lat, format_lon, format_lat, fo
 from opensak.lang import tr
 from opensak.utils.types import DateFormat, GcCode, TEXT_SIZE_MAP, TextSize
 from opensak.utils.utils import normalize_geocacher_name
-from opensak.gui.icon_provider import get_cache_type_icon, get_cache_size_icon
+from opensak.gui.icon_provider import get_cache_type_icon, get_cache_size_icon, get_flag_placeholder_icon
 from opensak.gui.dialogs.column_dialog import get_column_widths, set_column_widths, get_container_display
 import math
 
@@ -697,6 +697,8 @@ class CacheTableModel(QAbstractTableModel):
             if get_container_display() == "text":
                 return None
             return get_cache_size_icon(self._size_icon_key(cache), size=20)
+        if col == "user_flag" and not cache.user_flag:
+            return get_flag_placeholder_icon(16)
         return None
 
     @staticmethod

--- a/src/opensak/gui/icon_provider.py
+++ b/src/opensak/gui/icon_provider.py
@@ -507,3 +507,19 @@ def get_all_type_keys() -> list[str]:
 def get_all_size_keys() -> list[str]:
     """Return sorteret liste af alle kendte cache størrelse nøgler."""
     return sorted(_CACHE_SIZE_SVGS.keys())
+
+
+_FLAG_PLACEHOLDER_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">'
+    '<line x1="4" y1="2" x2="4" y2="14" stroke="#aaaaaa" stroke-width="1.5"'
+    ' stroke-linecap="round"/>'
+    '<polygon points="4,3 13,6 4,9" fill="none" stroke="#aaaaaa" stroke-width="1"'
+    ' stroke-linejoin="round"/>'
+    '</svg>'
+)
+
+
+@lru_cache(maxsize=8)
+def get_flag_placeholder_icon(size: int = 16) -> QIcon:
+    """Faint outlined flag QIcon shown in the user_flag column when flag is unset."""
+    return QIcon(_svg_to_pixmap(_FLAG_PLACEHOLDER_SVG, size))

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -298,6 +298,13 @@ class TestDataRoles:
         assert model.data(type_idx, Qt.ItemDataRole.DecorationRole) is not None
         assert model.data(cont_idx, Qt.ItemDataRole.DecorationRole) is not None
 
+    def test_flag_placeholder_icon_when_unset(self, model):
+        model.load([_cache(user_flag=False), _cache(gc_code="GCB", user_flag=True)])
+        unset_idx = model.index(0, ALL_COLUMNS.index("user_flag"))
+        set_idx   = model.index(1, ALL_COLUMNS.index("user_flag"))
+        assert model.data(unset_idx, Qt.ItemDataRole.DecorationRole) is not None
+        assert model.data(set_idx,   Qt.ItemDataRole.DecorationRole) is None
+
     def test_userrole_returns_cache_and_dict(self, model):
         model.load([_cache(container="Micro", cache_type="Virtual Cache")])
         idx = model.index(0, 0)


### PR DESCRIPTION
## Summary

Closes #290.

The `user_flag` column showed a completely blank cell when the flag was not set, giving users no visual cue that the space was clickable. This fix adds a faint outlined flag icon (SVG, neutral gray `#aaaaaa`) as a placeholder in every unset cell, making the click target discoverable without touching the set state (which continues to show 🚩).

- **`icon_provider.py`** — adds `get_flag_placeholder_icon(size)`: an inline SVG outlined flag rendered to `QIcon`, cached via `@lru_cache`.
- **`cache_table.py`** — `_decoration_value()` returns the placeholder icon via `DecorationRole` when `col == "user_flag"` and the flag is unset. Set cells return `None` for `DecorationRole` and keep the existing `"🚩"` text via `DisplayRole`.
- **`test_cache_table.py`** — `test_flag_placeholder_icon_when_unset` asserts `DecorationRole` is non-`None` for unset cells and `None` for set cells.

## Test plan

- [x] Open a database with caches — the flag column shows a faint outlined flag on every row where the flag is not set
- [x] Click an unset cell → flag is set, placeholder disappears, 🚩 appears
- [x] Click a set cell → flag is cleared, 🚩 disappears, placeholder reappears
- [x] Tooltip "Click to set flag" still appears on hover over unset cells
- [x] `pytest tests/unit-tests/ -q` — all tests pass (1485 passed locally)