### PR TITLE
Bug: OS-locale date format missing separators and leading zeros

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -23,7 +23,7 @@ from opensak.db.models import Cache
 from opensak.lang import tr
 from opensak.coords import format_coords
 from opensak.gui.settings import get_settings
-from opensak.utils.types import DateFormat, TEXT_SIZE_MAP
+from opensak.utils.types import DateFormat, TEXT_SIZE_MAP, norm_locale_date_fmt
 from opensak.hint_detect import split_hint
 
 
@@ -36,7 +36,8 @@ def _format_date(d: datetime) -> str:
     if fmt == DateFormat.YMD:
         return d.strftime("%Y-%m-%d")
     qd = QDate(d.year, d.month, d.day)
-    return QLocale.system().toString(qd, QLocale.FormatType.ShortFormat)
+    locale_fmt = norm_locale_date_fmt(QLocale.system().dateFormat(QLocale.FormatType.ShortFormat))
+    return QLocale.system().toString(qd, locale_fmt)
 
 
 # issue #219 — geocaching.com logge bruger markdown-links: [linktekst](https://url)

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -19,7 +19,7 @@ from opensak.filters.engine import _haversine_km, haversine_km_batch
 from opensak.gui.settings import get_settings
 from opensak.coords import format_coords, format_lat, format_lon, format_lat, format_lon
 from opensak.lang import tr
-from opensak.utils.types import DateFormat, GcCode, TEXT_SIZE_MAP, TextSize
+from opensak.utils.types import DateFormat, GcCode, TEXT_SIZE_MAP, TextSize, norm_locale_date_fmt
 from opensak.utils.utils import normalize_geocacher_name
 from opensak.gui.icon_provider import get_cache_type_icon, get_cache_size_icon, get_flag_placeholder_icon
 from opensak.gui.dialogs.column_dialog import get_column_widths, set_column_widths, get_container_display
@@ -119,9 +119,10 @@ def _format_date(d: datetime) -> str:
         return d.strftime("%m/%d/%Y")
     if fmt == DateFormat.YMD:
         return d.strftime("%Y-%m-%d")
-    # LOCALE: ask Qt for the OS short-date pattern
+    # LOCALE: ask Qt for the OS short-date pattern, normalised to zero-padded fields
     qd = QDate(d.year, d.month, d.day)
-    return QLocale.system().toString(qd, QLocale.FormatType.ShortFormat)
+    locale_fmt = norm_locale_date_fmt(QLocale.system().dateFormat(QLocale.FormatType.ShortFormat))
+    return QLocale.system().toString(qd, locale_fmt)
 
 
 def _gc_sort_key(gc_code: GcCode) -> str:

--- a/src/opensak/gui/dialogs/filter_dialog.py
+++ b/src/opensak/gui/dialogs/filter_dialog.py
@@ -760,7 +760,7 @@ class FilterDialog(QDialog):
         from PySide6.QtWidgets import QScrollArea as _QScrollArea
         from PySide6.QtCore import QLocale
         from opensak.gui.settings import get_settings
-        from opensak.utils.types import DateFormat
+        from opensak.utils.types import DateFormat, norm_locale_date_fmt
 
         settings = get_settings()
         dist_unit = "mi" if settings.use_miles else "km"
@@ -777,8 +777,9 @@ class FilterDialog(QDialog):
             date_where_eg = "2023-01-01"
         else:  # LOCALE
             _loc = QLocale.system()
-            date_col_eg = _loc.toString(QDate(2020, 6, 15), QLocale.FormatType.ShortFormat)
-            date_where_eg = _loc.toString(QDate(2023, 1, 1), QLocale.FormatType.ShortFormat)
+            _fmt = norm_locale_date_fmt(_loc.dateFormat(QLocale.FormatType.ShortFormat))
+            date_col_eg = _loc.toString(QDate(2020, 6, 15), _fmt)
+            date_where_eg = _loc.toString(QDate(2023, 1, 1), _fmt)
 
         dlg = QDialog(self)
         dlg.setWindowTitle(tr("filter_where_info_title"))

--- a/src/opensak/gui/org_cache_detail.py
+++ b/src/opensak/gui/org_cache_detail.py
@@ -23,7 +23,7 @@ from opensak.db.models import Cache
 from opensak.lang import tr
 from opensak.coords import format_coords
 from opensak.gui.settings import get_settings
-from opensak.utils.types import DateFormat
+from opensak.utils.types import DateFormat, norm_locale_date_fmt
 from opensak.hint_detect import split_hint
 
 
@@ -36,7 +36,8 @@ def _format_date(d: datetime) -> str:
     if fmt == DateFormat.YMD:
         return d.strftime("%Y-%m-%d")
     qd = QDate(d.year, d.month, d.day)
-    return QLocale.system().toString(qd, QLocale.FormatType.ShortFormat)
+    locale_fmt = norm_locale_date_fmt(QLocale.system().dateFormat(QLocale.FormatType.ShortFormat))
+    return QLocale.system().toString(qd, locale_fmt)
 
 
 # issue #219 — geocaching.com logge bruger markdown-links: [linktekst](https://url)

--- a/src/opensak/utils/types.py
+++ b/src/opensak/utils/types.py
@@ -6,6 +6,7 @@ function signatures are self-documenting and the type checker can enforce
 valid values at call sites (instead of accepting any string).
 """
 
+import re
 from enum import Enum, IntEnum, StrEnum, auto
 from typing import TypeAlias
 
@@ -42,10 +43,22 @@ class CoordFormat(StrEnum):
 
 class DateFormat(StrEnum):
     """Supported date display formats for the cache grid."""
-    LOCALE = "locale"  # OS locale short date (e.g. 6/21/25 or 21.06.2026)
+    LOCALE = "locale"  # OS locale short date (e.g. 06/23/2026 or 23.06.2026)
     DMY    = "dmy"     # dd.mm.yyyy
     MDY    = "mdy"     # mm/dd/yyyy
     YMD    = "ymd"     # yyyy-mm-dd
+
+
+def norm_locale_date_fmt(raw: str) -> str:
+    """Normalise a Qt locale short-date format string.
+
+    Ensures zero-padded fields and a 4-digit year while preserving the
+    locale's field order and separator characters.
+    """
+    fmt = re.sub(r'(?<!d)d(?!d)', 'dd', raw)
+    fmt = re.sub(r'(?<!M)M(?!M)', 'MM', fmt)
+    fmt = re.sub(r'(?<!y)yy(?!y)', 'yyyy', fmt)
+    return fmt
 
 
 class TextSize(StrEnum):

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -226,10 +226,12 @@ class TestDisplayValues:
         # YMD
         fake_settings.date_format = DateFormat.YMD
         assert model._display_value(_cache(hidden_date=d), "hidden_date") == "2024-03-01"
-        # LOCALE — just verify it's non-empty (format depends on OS locale)
+        # LOCALE — verify non-empty and zero-padded (regression for issue #369)
         fake_settings.date_format = DateFormat.LOCALE
         result = model._display_value(_cache(hidden_date=d), "hidden_date")
         assert result
+        # March 1 — both day and month are single digits; must appear with leading zero.
+        assert "01" in result and "03" in result
 
     def test_counts_and_user_fields(self, model):
         assert model._display_value(_cache(log_count=7), "log_count") == "7"

--- a/tests/unit-tests/test_utils.py
+++ b/tests/unit-tests/test_utils.py
@@ -167,3 +167,34 @@ class TestNormalizeGeocacherName:
         # Only the specific "(Key=N ...)" stats pattern is stripped — other
         # parenthetical content in a name is left intact.
         assert normalize_geocacher_name("Team (Denmark)") == "team (denmark)"
+
+
+# ── norm_locale_date_fmt (issue #369) ────────────────────────────────────────
+
+from opensak.utils.types import norm_locale_date_fmt
+
+
+class TestNormLocaleDateFmt:
+    def test_single_d_padded(self):
+        assert norm_locale_date_fmt("d/M/yy") == "dd/MM/yyyy"
+
+    def test_space_separated_no_leading_zeros(self):
+        # Regression for issue #369: some macOS locales produce "d M yyyy"
+        assert norm_locale_date_fmt("d M yyyy") == "dd MM yyyy"
+
+    def test_already_padded_unchanged(self):
+        assert norm_locale_date_fmt("dd.MM.yyyy") == "dd.MM.yyyy"
+
+    def test_two_digit_year_expanded(self):
+        assert norm_locale_date_fmt("MM/dd/yy") == "MM/dd/yyyy"
+
+    def test_abbreviated_weekday_untouched(self):
+        # ddd is an abbreviated weekday — must not become dddd
+        assert norm_locale_date_fmt("ddd, d MMM yyyy") == "ddd, dd MMM yyyy"
+
+    def test_full_month_name_untouched(self):
+        # MMMM is the full month name — must not become MMMMM
+        assert norm_locale_date_fmt("d MMMM yyyy") == "dd MMMM yyyy"
+
+    def test_four_digit_year_unchanged(self):
+        assert norm_locale_date_fmt("d/M/yyyy") == "dd/MM/yyyy"


### PR DESCRIPTION
## Summary

- `QLocale::ShortFormat` on some macOS locales returns format patterns like `d M yyyy`, which produce dates without leading zeros (e.g. `23 6 2026` instead of `23 06 2026`).
- Added `norm_locale_date_fmt()` in `utils/types.py` — a pure function that expands single `d→dd`, `M→MM`, and `yy→yyyy` using regex lookahead/lookbehind, so `ddd`/`MMMM` weekday/month names are left untouched.
- Applied the fix in all four LOCALE-path call sites: `cache_table._format_date`, `cache_detail._format_date`, `org_cache_detail._format_date`, and `filter_dialog._show_where_info`.

Closes #369