### PR TITLE
Bug: Text/icon size setting doesn't take effect until a new cache is selected

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -418,7 +418,10 @@ class CacheDetailPanel(QWidget):
         font.setBold(True)
         self._corrected_lbl.setFont(font)
         
-        self._title.update()  # Force repaint
+        self._title.update()
+
+    def refresh_sizes(self) -> None:
+        self._apply_ui_sizes()
 
     def clear(self) -> None:
         self._current_gc_code: str | None = None

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -1201,15 +1201,16 @@ class MainWindow(QMainWindow):
         from opensak.gui.dialogs.settings_dialog import SettingsDialog
         dlg = SettingsDialog(self)
         if dlg.exec():
+            prev_cache = self._cache_table.selected_cache()
             self._reload_home_combo()
             self._map_widget.reload_map(self._refresh_cache_list)
             self._refresh_cache_list()
-            self._cache_table.refresh_visuals()  # Re-paint icons/text after size change
-            cache = self._cache_table.selected_cache()
-            if cache:
-                full = self._load_full_cache(cache.gc_code)
-                if full:
-                    self._detail_panel.show_cache(full)
+            self._cache_table.refresh_visuals()
+            full = self._load_full_cache(prev_cache.gc_code) if prev_cache else None
+            if full:
+                self._detail_panel.show_cache(full)
+            else:
+                self._detail_panel.refresh_sizes()
 
     def _reload_home_combo(self) -> None:
         """Genindlæs hjemmepunkts-dropdown fra settings."""

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -9,11 +9,11 @@ pytest.importorskip("pytestqt")
 
 from opensak.gui import cache_detail as cd
 from opensak.gui.cache_detail import CacheDetailPanel
-from opensak.utils.types import DateFormat
+from opensak.utils.types import DateFormat, TEXT_SIZE_MAP, TextSize
 
 
-def _fake_settings(fmt: DateFormat) -> SimpleNamespace:
-    return SimpleNamespace(date_format=fmt)
+def _fake_settings(fmt: DateFormat = DateFormat.DMY, text_size: TextSize = TextSize.MEDIUM) -> SimpleNamespace:
+    return SimpleNamespace(date_format=fmt, text_size=text_size)
 
 
 @pytest.mark.parametrize("fmt, expected", [
@@ -26,6 +26,19 @@ def test_format_date_respects_settings(monkeypatch, qapp, fmt, expected):
     monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(fmt))
     result = cd._format_date(datetime(2024, 12, 25))
     assert result == expected
+
+
+def test_refresh_sizes_updates_title_font(monkeypatch, qapp):
+    # Regression for #371: text size change in Settings had no effect until a
+    # new cache was selected because _apply_ui_sizes() was never called.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(text_size=TextSize.SMALL))
+    panel = CacheDetailPanel()
+    panel.refresh_sizes()
+    assert panel._title.font().pointSize() == TEXT_SIZE_MAP[TextSize.SMALL]["label"]
+
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(text_size=TextSize.LARGE))
+    panel.refresh_sizes()
+    assert panel._title.font().pointSize() == TEXT_SIZE_MAP[TextSize.LARGE]["label"]
 
 
 def test_decode_no_hint_shows_no_hint_label(qapp):


### PR DESCRIPTION
`_refresh_cache_list()` calls `load_caches()`, which clears the table selection. The code that followed tried to call `selected_cache()` after the refresh, always got `None`, and therefore never reached `show_cache()` (which calls `_apply_ui_sizes()`). The new size was silently dropped until the user clicked a different cache.

Fix: capture the previously-selected cache before `_refresh_cache_list()`, then re-show it afterwards so `_apply_ui_sizes()` runs. `CacheDetailPanel.refresh_sizes()` is added as a fallback for the no-cache case (the "Select a cache" placeholder title should also pick up the new font immediately).

Closes #371