### PR TITLE
Bug: Import progress bar fills too quickly relative to actual progress

### DIFF
--- a/src/opensak/gui/dialogs/import_dialog.py
+++ b/src/opensak/gui/dialogs/import_dialog.py
@@ -27,6 +27,7 @@ class ImportWorker(QThread):
     file_finished = Signal(int, object)  # (index, ImportResult)
     file_error    = Signal(int, str)     # (index, error message)
     progress      = Signal(int)          # cache count within current file
+    total         = Signal(int)          # total wpt count for current file (-1 = unknown)
     # Completion is reported via QThread.finished (emitted after run() returns
     # and isRunning() is already false), NOT a custom signal emitted from inside
     # run(). Emitting from run()'s tail let the dialog proceed — and tests tear
@@ -41,7 +42,7 @@ class ImportWorker(QThread):
     def run(self) -> None:
         from opensak.db.database import get_session, init_db
         from opensak.db.manager import get_db_manager
-        from opensak.importer import import_gpx, import_zip
+        from opensak.importer import import_gpx, import_zip, _count_wpts
         from opensak.utils.utils import get_import_type, ImportType
 
         # Switch to target DB if different from active
@@ -64,6 +65,14 @@ class ImportWorker(QThread):
                         ImportType.ZIP: import_zip,
                     }
                     import_func = importers[import_type]
+
+                    if import_type == ImportType.GPX:
+                        try:
+                            self.total.emit(_count_wpts(path))
+                        except Exception:
+                            self.total.emit(-1)
+                    else:
+                        self.total.emit(-1)
 
                     with get_session() as session:
                         result = import_func(
@@ -269,6 +278,7 @@ class ImportDialog(QDialog):
         self._worker.file_finished.connect(self._on_file_finished)
         self._worker.file_error.connect(self._on_file_error)
         self._worker.progress.connect(self._on_progress)
+        self._worker.total.connect(self._on_total)
         # React to QThread.finished (thread already stopped) rather than a signal
         # emitted from inside run(). Connect _on_all_done before deleteLater so it
         # runs first; both are queued, and by the time they run isRunning() is
@@ -283,12 +293,22 @@ class ImportDialog(QDialog):
             item.setText(f"🔄  {name}")
         self._file_list.scrollToItem(self._file_list.item(index))
         self._append_log(tr("import_running_file", name=name))
+        self._progress.setRange(0, 0)  # indeterminate while pre-counting
+
+    def _on_total(self, total: int) -> None:
+        if total > 0:
+            self._progress.setRange(0, total)
+            self._progress.setValue(0)
+        else:
+            self._progress.setRange(0, 0)
 
     def _on_progress(self, count: int) -> None:
         if count < 0:
             self._replace_last_log_line(f"  {tr('import_saving')}")
         elif count % 100 == 0 and count > 0:
             self._replace_last_log_line(f"  {tr('import_progress', count=count)}")
+        if count >= 0 and self._progress.maximum() > 0:
+            self._progress.setValue(count)
 
     def _on_file_finished(self, index: int, result) -> None:
         path = self._selected_paths[index]

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -1204,6 +1204,15 @@ def _parse_gpx_to_data(
     return caches, extra_wpts, companion_data, errors
 
 
+def _count_wpts(gpx_path: Path) -> int:
+    count = 0
+    for _, elem in etree.iterparse(str(gpx_path), events=("end",)):
+        if etree.QName(elem).localname == "wpt":
+            count += 1
+        elem.clear()
+    return count
+
+
 def import_gpx(
     gpx_path: Path,
     session: Session | None = None,

--- a/tests/unit-tests/test_import_dialog.py
+++ b/tests/unit-tests/test_import_dialog.py
@@ -150,6 +150,7 @@ class TestImportDialog:
                 self.file_finished = MagicMock()
                 self.file_error = MagicMock()
                 self.progress = MagicMock()
+                self.total = MagicMock()
                 self.finished = MagicMock()
                 self.deleteLater = MagicMock()
                 self.isRunning = MagicMock(return_value=False)
@@ -261,3 +262,77 @@ class TestImportDialog:
         assert "second" in dlg._log.toPlainText()
         dlg._replace_last_log_line("replaced")
         assert "replaced" in dlg._log.toPlainText()
+
+    # ── Progress bar determinism (#372) ─────────────────────────────────────────
+
+    def test_on_total_positive_makes_bar_determinate(self, dlg):
+        dlg._on_total(50)
+        assert dlg._progress.maximum() == 50
+        assert dlg._progress.value() == 0
+
+    def test_on_total_negative_keeps_bar_indeterminate(self, dlg):
+        dlg._on_total(-1)
+        assert dlg._progress.maximum() == 0
+
+    def test_on_progress_drives_bar_when_determinate(self, dlg):
+        dlg._on_total(100)
+        dlg._on_progress(42)
+        assert dlg._progress.value() == 42
+
+    def test_on_progress_no_setValue_when_indeterminate(self, dlg):
+        # indeterminate bar: maximum is 0, setValue must not change that
+        assert dlg._progress.maximum() == 0
+        dlg._on_progress(42)
+        assert dlg._progress.maximum() == 0
+
+    def test_on_file_started_resets_bar_to_indeterminate(self, dlg):
+        dlg.add_files([Path("/a.gpx")])
+        dlg._on_total(200)  # bar goes determinate
+        assert dlg._progress.maximum() == 200
+        dlg._on_file_started(0, "a.gpx")  # must reset to indeterminate
+        assert dlg._progress.maximum() == 0
+
+
+class TestImportWorkerTotal:
+    def _patch(self, monkeypatch, import_type_val, active_path=Path("/active.db")):
+        monkeypatch.setattr("opensak.db.manager.get_db_manager",
+                            lambda: SimpleNamespace(active_path=active_path))
+        monkeypatch.setattr("opensak.db.database.get_session", _fake_session)
+        monkeypatch.setattr("opensak.importer.import_gpx",
+                            lambda p, s, progress_cb=None: _result())
+        monkeypatch.setattr("opensak.importer.import_zip",
+                            lambda p, s, progress_cb=None: _result(created=5))
+        from opensak.utils.utils import ImportType
+        monkeypatch.setattr("opensak.utils.utils.get_import_type",
+                            lambda p: import_type_val)
+        return ImportType
+
+    def test_emits_total_count_for_gpx(self, monkeypatch):
+        from opensak.utils.utils import ImportType
+        self._patch(monkeypatch, ImportType.GPX)
+        monkeypatch.setattr("opensak.importer._count_wpts", lambda p: 42)
+        w = ImportWorker([Path("/a.gpx")])
+        totals = []
+        w.total.connect(lambda t: totals.append(t))
+        w.run()
+        assert totals == [42]
+
+    def test_emits_minus1_for_zip(self, monkeypatch):
+        from opensak.utils.utils import ImportType
+        self._patch(monkeypatch, ImportType.ZIP)
+        w = ImportWorker([Path("/a.zip")])
+        totals = []
+        w.total.connect(lambda t: totals.append(t))
+        w.run()
+        assert totals == [-1]
+
+    def test_emits_minus1_when_count_raises(self, monkeypatch):
+        from opensak.utils.utils import ImportType
+        self._patch(monkeypatch, ImportType.GPX)
+        monkeypatch.setattr("opensak.importer._count_wpts",
+                            lambda p: (_ for _ in ()).throw(RuntimeError("oops")))
+        w = ImportWorker([Path("/a.gpx")])
+        totals = []
+        w.total.connect(lambda t: totals.append(t))
+        w.run()
+        assert totals == [-1]

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from opensak.db.database import get_session, init_db
 from opensak.db.models import Cache
-from opensak.importer import import_gpx, import_zip, ImportResult
+from opensak.importer import import_gpx, import_zip, ImportResult, _count_wpts
 
 from tests.data import (
     SAMPLE_GPX, SAMPLE_WPTS_GPX, EMPTY_GPX,
@@ -335,3 +335,15 @@ def test_import_zip_no_gpx_in_archive(tmp_path):
     z = make_zip(tmp_path, "no_gpx.zip", {"readme.txt": "hello"})
     result = import_zip(z)
     assert any("No .gpx" in e for e in result.errors)
+
+
+def test_count_wpts(tmp_path):
+    # _count_wpts must return the exact number of <wpt> elements without importing
+    gpx = build_gpx(cache_wpt("GC0001"), cache_wpt("GC0002"), cache_wpt("GC0003"))
+    f = write_gpx(tmp_path, "count_test.gpx", gpx)
+    assert _count_wpts(f) == 3
+
+
+def test_count_wpts_empty(tmp_path):
+    f = write_gpx(tmp_path, "empty.gpx", '<?xml version="1.0"?><gpx version="1.0"></gpx>')
+    assert _count_wpts(f) == 0


### PR DESCRIPTION
For GPX imports the progress bar was permanently indeterminate (cycling animation), giving no indication of how much work remained. The bar now switches to a deterministic fill once the total cache count is known.

Changes:
- `_count_wpts(gpx_path)` added to the importer — a fast streaming pre-scan that counts `<wpt>` elements without touching the database.
- `ImportWorker` emits a new `total` signal before each file's import begins: the actual count for GPX files, -1 for ZIP (total unknown ahead of time).
- `ImportDialog` resets the bar to indeterminate in `_on_file_started` (while pre-counting runs), switches to determinate in `_on_total`, and drives `setValue` in `_on_progress`.
- If the pre-scan fails for any reason (corrupt file, permissions) the bar stays indeterminate — no regression for edge cases.

Closes #372