### PR TITLE
Improvement: Show count of active filters in the filter box

### DIFF
--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -891,7 +891,7 @@ class MainWindow(QMainWindow):
         if self._active_filter_name:
             filter_name = self._active_filter_name
         elif len(self._current_filterset) > 0:
-            filter_name = tr("infobar_filter_active")
+            filter_name = tr("infobar_filter_active", count=len(self._current_filterset))
         else:
             filter_name = ""
 

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -922,7 +922,7 @@ STRINGS: dict[str, str] = {
     # ── Issue #116: Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filtr",
     "infobar_filter_none":               "Žádný",
-    "infobar_filter_active":             "Aktivní",
+    "infobar_filter_active":             "{count} aktivní",
     "infobar_total":                     "keší v databázi",
     "infobar_center":                    "Středový bod",
     "infobar_count_label":               "Počet:",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -926,7 +926,7 @@ STRINGS: dict[str, str] = {
     # ── Issue #116: Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filter",
     "infobar_filter_none":               "Ingen",
-    "infobar_filter_active":             "Aktiv",
+    "infobar_filter_active":             "{count} aktive",
     "infobar_total":                     "caches i database",
     "infobar_center":                    "Centerpunkt",
     "infobar_count_label":               "Antal:",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -926,7 +926,7 @@ STRINGS: dict[str, str] = {
     # ── Issue #116: Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filter",
     "infobar_filter_none":               "Keiner",
-    "infobar_filter_active":             "Aktiv",
+    "infobar_filter_active":             "{count} aktiv",
     "infobar_total":                     "Caches in Datenbank",
     "infobar_center":                    "Mittelpunkt",
     "infobar_count_label":               "Anzahl:",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -925,7 +925,7 @@ STRINGS: dict[str, str] = {
     # ── Issue #116: Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filter",
     "infobar_filter_none":               "None",
-    "infobar_filter_active":             "Active",
+    "infobar_filter_active":             "{count} active",
     "infobar_total":                     "caches in database",
     "infobar_center":                    "Center point",
     "infobar_count_label":               "Count:",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -926,7 +926,7 @@ STRINGS: dict[str, str] = {
     # ── Issue #116: Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filtre",
     "infobar_filter_none":               "Aucun",
-    "infobar_filter_active":             "Actif",
+    "infobar_filter_active":             "{count} actif",
     "infobar_total":                     "caches dans la base",
     "infobar_center":                    "Point central",
     "infobar_count_label":               "Total :",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -924,7 +924,7 @@ STRINGS: dict[str, str] = {
     # ── Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filter",
     "infobar_filter_none":               "Geen",
-    "infobar_filter_active":             "Actief",
+    "infobar_filter_active":             "{count} actief",
     "infobar_total":                     "caches in database",
     "infobar_center":                    "Middelpunt",
     "infobar_count_label":               "Aantal:",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -927,7 +927,7 @@ STRINGS: dict[str, str] = {
     # ── Issue #116: Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filtro",
     "infobar_filter_none":               "Nenhum",
-    "infobar_filter_active":             "Ativo",
+    "infobar_filter_active":             "{count} ativo",
     "infobar_total":                     "caches na base de dados",
     "infobar_center":                    "Ponto central",
     "infobar_count_label":               "Total:",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -926,7 +926,7 @@ STRINGS: dict[str, str] = {
     # ── Issue #116: Info bar (GSAK-style status bar) ────────────────────
     "infobar_filter":                    "Filter",
     "infobar_filter_none":               "Inget",
-    "infobar_filter_active":             "Aktiv",
+    "infobar_filter_active":             "{count} aktiv",
     "infobar_total":                     "cacher i databasen",
     "infobar_center":                    "Mittpunkt",
     "infobar_count_label":               "Antal:",

--- a/tests/e2e-tests/test_e2e_mainwindow.py
+++ b/tests/e2e-tests/test_e2e_mainwindow.py
@@ -227,6 +227,18 @@ class TestCacheList:
     def test_update_info_bar(self, seeded_window):
         seeded_window._update_info_bar()
 
+    def test_infobar_shows_filter_count(self, seeded_window):
+        # regression for #373: infobar must show count, not generic "Active"
+        from opensak.filters.engine import FilterSet, GcCodeFilter, CacheTypeFilter
+        fs = FilterSet(mode="AND")
+        fs.add(GcCodeFilter("GC12345"))
+        fs.add(CacheTypeFilter(["Traditional Cache"]))
+        seeded_window._current_filterset = fs
+        seeded_window._update_info_bar()
+        text = seeded_window._info_bar._filter_lbl.text()
+        assert "2" in text
+        assert "Active" not in text and "Aktiv" not in text
+
     def test_update_info_bar_with_owner(self, seeded_window, iso_settings):
         from opensak.gui.settings import get_settings
         get_settings().gc_username = "TestOwner"


### PR DESCRIPTION
The infobar filter label now shows the exact number of active filters (e.g. "Filter: 2 active") instead of the generic "Filter: Active" when no named profile is applied. Updated all 8 language files to carry the `{count}` placeholder.

Closes #373