### PR TITLE
Improvement: Expand text size setting to apply to the cache grid, not just the header area

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -596,10 +596,12 @@ class CacheTableModel(QAbstractTableModel):
             return Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
 
         if role == Qt.ItemDataRole.FontRole:
+            text_size = getattr(get_settings(), "text_size", TextSize.MEDIUM)
+            font = QFont()
+            font.setPointSize(TEXT_SIZE_MAP[text_size]["grid"])
             if cache.found:
-                font = QFont()
                 font.setItalic(True)
-                return font
+            return font
 
         if role == Qt.ItemDataRole.ToolTipRole:
             if col == "cache_type":
@@ -938,7 +940,8 @@ class CacheTableView(QTableView):
         self.setSortingEnabled(True)
         self.verticalHeader().setVisible(False)
         self.setWordWrap(False)
-        self.verticalHeader().setDefaultSectionSize(24)
+        text_size = getattr(get_settings(), "text_size", TextSize.MEDIUM)
+        self.verticalHeader().setDefaultSectionSize(TEXT_SIZE_MAP[text_size]["row_height"])
         self._applying_widths = False
         self._apply_column_widths()
         self.horizontalHeader().setSortIndicatorShown(True)
@@ -1346,12 +1349,11 @@ class CacheTableView(QTableView):
 
     def refresh_visuals(self) -> None:
         """Re-paint all visible cells after UI size change (font-size, etc.)."""
-        # Opdatér SizeBarDelegate icon-størrelse
+        text_size = getattr(get_settings(), "text_size", TextSize.MEDIUM)
+        sizes = TEXT_SIZE_MAP[text_size]
         if hasattr(self, "_size_bar_delegate"):
-            text_size = getattr(get_settings(), 'text_size', TextSize.MEDIUM)
-            sizes = TEXT_SIZE_MAP[text_size]
             self._size_bar_delegate.set_icon_size(sizes["icon"])
-        # Genrender alle celler
+        self.verticalHeader().setDefaultSectionSize(sizes["row_height"])
         self._model.refresh_visuals()
 
     def row_count(self) -> int:

--- a/src/opensak/utils/types.py
+++ b/src/opensak/utils/types.py
@@ -62,20 +62,22 @@ def norm_locale_date_fmt(raw: str) -> str:
 
 
 class TextSize(StrEnum):
-    """Text and icon sizes for UI elements (issue #286/#288/#290)."""
-    SMALL  = "small"   # Kompakt: 5/9/8 pt
-    MEDIUM = "medium"  # Standard: 7/13/10 pt (default)
-    LARGE  = "large"   # Stor: 10/18/14 pt
+    """Text and icon sizes for UI elements (issue #286/#288/#290/#375)."""
+    SMALL  = "small"   # Kompakt: 5/9/8/8 pt, 20 px rows
+    MEDIUM = "medium"  # Standard: 7/13/10/10 pt, 24 px rows (default)
+    LARGE  = "large"   # Stor: 10/18/14/13 pt, 30 px rows
 
 
 # Font sizes (pt) for each TextSize level. Maps to:
-#   icon_pt (type icon in cache grid)
-#   label_pt (info label in detail panel)
-#   secondary_pt (corrected coords, hints label)
+#   icon_pt       — type icon in cache grid (SizeBarDelegate)
+#   label_pt      — info label in detail panel
+#   secondary_pt  — corrected coords, hints label
+#   grid_pt       — cell text in the cache grid
+#   row_height    — vertical section size (px) in the cache grid
 TEXT_SIZE_MAP = {
-    TextSize.SMALL:  {"icon": 5, "label": 9,  "secondary": 8},
-    TextSize.MEDIUM: {"icon": 7, "label": 13, "secondary": 10},
-    TextSize.LARGE:  {"icon": 10, "label": 18, "secondary": 14},
+    TextSize.SMALL:  {"icon": 5,  "label": 9,  "secondary": 8,  "grid": 8,  "row_height": 20},
+    TextSize.MEDIUM: {"icon": 7,  "label": 13, "secondary": 10, "grid": 10, "row_height": 24},
+    TextSize.LARGE:  {"icon": 10, "label": 18, "secondary": 14, "grid": 13, "row_height": 30},
 }
 
 

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -23,7 +23,7 @@ from opensak.gui.cache_table import (
     _gc_sort_key,
 )
 from opensak.db.models import Cache, UserNote
-from opensak.utils.types import CoordFormat, DateFormat
+from opensak.utils.types import CoordFormat, DateFormat, TextSize, TEXT_SIZE_MAP
 
 ALL_COLUMNS = [
     "gc_code", "name", "cache_type", "difficulty", "terrain", "container",
@@ -278,6 +278,24 @@ class TestDataRoles:
         model.load([_cache(found=True)])
         font = model.data(model.index(0, 0), Qt.ItemDataRole.FontRole)
         assert font is not None and font.italic()
+
+    def test_font_role_uses_grid_pt(self, model, fake_settings):
+        # FontRole always returns a font sized to the current text_size grid_pt.
+        for size in TextSize:
+            fake_settings.text_size = size
+            model.load([_cache(found=False)])
+            font = model.data(model.index(0, 0), Qt.ItemDataRole.FontRole)
+            assert font is not None
+            assert font.pointSize() == TEXT_SIZE_MAP[size]["grid"]
+
+    def test_font_role_found_italic_keeps_grid_pt(self, model, fake_settings):
+        # Found caches: italic AND correct point size.
+        fake_settings.text_size = TextSize.LARGE
+        model.load([_cache(found=True)])
+        font = model.data(model.index(0, 0), Qt.ItemDataRole.FontRole)
+        assert font is not None
+        assert font.italic()
+        assert font.pointSize() == TEXT_SIZE_MAP[TextSize.LARGE]["grid"]
 
     def test_tooltip_cache_type(self, model):
         model.load([_cache(cache_type="Unknown Cache")])
@@ -838,3 +856,10 @@ class TestView:
         view.load_caches([])
         from PySide6.QtCore import QPoint
         view._show_context_menu(QPoint(0, 0))  # indexAt -> invalid -> early return
+
+    def test_refresh_visuals_updates_row_height(self, view, fake_settings):
+        # refresh_visuals must sync row height with the current text_size setting.
+        for size in TextSize:
+            fake_settings.text_size = size
+            view.refresh_visuals()
+            assert view.verticalHeader().defaultSectionSize() == TEXT_SIZE_MAP[size]["row_height"]


### PR DESCRIPTION
The text size setting (Small/Medium/Large) now scales both the cache grid and the detail panel, not just the header area.

Changes:
- `TEXT_SIZE_MAP` gains two new keys per level: `grid` (cell font pt) and `row_height` (vertical section height in px)
- `CacheTableModel.data()` returns a font sized to `grid_pt` for every `FontRole` call; found caches still get italic on top
- `CacheTableView._setup_ui()` initialises the row height from `row_height` instead of the hardcoded 24 px
- `CacheTableView.refresh_visuals()` updates row height on every settings change, alongside the existing icon-size update

Sizes chosen: Small 8 pt / 20 px, Medium 10 pt / 24 px (preserves current default), Large 13 pt / 30 px.

Closes #375