### PR TITLE
Improvement: Add parent GC code to the Waypoints table

### DIFF
--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -62,7 +62,7 @@ _migrated_paths: set = set()  # undgår at køre migrationer to gange på samme 
 # bumped to the highest migration number whenever a new migration is added
 # below — _run_migrations() skips the whole block when the database already
 # reports this version, so a stale constant means new migrations never run.
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 
 def init_db(db_path: Path | None = None) -> Engine:
@@ -415,6 +415,27 @@ def _run_migrations(engine: Engine) -> None:
         if added:
             conn.commit()
             print(f"Migration: tilføjede provenance-kolonner til caches: {', '.join(added)}")
+
+        # ── Migration 13: parent_gc_code on waypoints (issue #376) ───────────
+        # Stores the parent cache's GC code directly on the waypoint row —
+        # mirrors cParent in GSAK and enables JOIN-free filter queries.
+        existing_wpts = [
+            row[1]
+            for row in conn.execute(text("PRAGMA table_info(waypoints)")).fetchall()
+        ]
+        if "parent_gc_code" not in existing_wpts:
+            conn.execute(text(
+                "ALTER TABLE waypoints ADD COLUMN parent_gc_code VARCHAR(16)"
+            ))
+            # Back-fill from the caches table via the existing FK.
+            conn.execute(text("""
+                UPDATE waypoints
+                SET parent_gc_code = (
+                    SELECT gc_code FROM caches WHERE caches.id = waypoints.cache_id
+                )
+            """))
+            conn.commit()
+            print("Migration: tilføjede waypoints.parent_gc_code")
 
         # ── Stamp the schema version so the next launch skips the probes ─────
         # PRAGMA does not accept bind parameters; SCHEMA_VERSION is a trusted

--- a/src/opensak/db/models.py
+++ b/src/opensak/db/models.py
@@ -197,6 +197,9 @@ class Waypoint(Base):
     latitude: Mapped[Optional[float]] = mapped_column(Float)   # None = coordinates not yet known
     longitude: Mapped[Optional[float]] = mapped_column(Float)
 
+    # GC code of the parent cache (issue #376 — mirrors cParent in GSAK)
+    parent_gc_code: Mapped[Optional[str]] = mapped_column(String(16), nullable=True, index=True)
+
     # Relationships
     cache: Mapped["Cache"] = relationship("Cache", back_populates="waypoints")
 

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -1073,23 +1073,24 @@ def _link_extra_waypoints(
         return 0
 
     # Build an ends-with index: for each suffix length present, map the cache's
-    # trailing chars of that length → cache_id (first match wins, matching the
-    # old .first() semantics).
+    # trailing chars of that length → (cache_id, gc_code).
     lengths = {len(s) for s in extra if s}
-    tail_index: dict[int, dict[str, int]] = {n: {} for n in lengths}
+    tail_index: dict[int, dict[str, tuple[int, str]]] = {n: {} for n in lengths}
     for cid, gc in session.query(Cache.id, Cache.gc_code):
         if not gc:
             continue
         for n in lengths:
             if len(gc) >= n:
-                tail_index[n].setdefault(gc[-n:], cid)
+                tail_index[n].setdefault(gc[-n:], (cid, gc))
 
-    # Resolve each suffix to a cache_id once.
+    # Resolve each suffix to a (cache_id, gc_code) pair once.
     resolved: dict[str, int] = {}
+    resolved_gc: dict[str, str] = {}
     for suffix in extra:
-        cid = tail_index.get(len(suffix), {}).get(suffix)
-        if cid is not None:
-            resolved[suffix] = cid
+        pair = tail_index.get(len(suffix), {}).get(suffix)
+        if pair is not None:
+            resolved[suffix] = pair[0]
+            resolved_gc[suffix] = pair[1]
 
     if not resolved:
         return 0
@@ -1108,9 +1109,11 @@ def _link_extra_waypoints(
         cache_id = resolved.get(suffix)
         if cache_id is None:
             continue
+        parent_gc = resolved_gc.get(suffix)
         for wp in wpts:
             session.add(Waypoint(
                 cache_id=cache_id,
+                parent_gc_code=parent_gc,
                 prefix=wp["prefix"],
                 wp_type=wp["wp_type"],
                 name=wp["name"],

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -529,11 +529,13 @@ def _insert_extra_wpts(session: Session, extra_wpts: list, commit_every: int = 5
     ``DELETE ... WHERE cache_id IN (...)`` rather than one fetch-sync DELETE per
     suffix. Commits to disk every *commit_every* caches to keep RAM flat.
     """
-    # Build suffix→cache_id once (suffix == gc_code without the 2-char prefix).
+    # Build suffix→cache_id and suffix→gc_code once.
     suffix_to_cache_id: dict[str, int] = {}
+    suffix_to_gc_code: dict[str, str] = {}
     for cache_id, gc_code in session.query(Cache.id, Cache.gc_code):
         if gc_code and len(gc_code) > 2:
             suffix_to_cache_id[gc_code[2:]] = cache_id
+            suffix_to_gc_code[gc_code[2:]] = gc_code
 
     # Group waypoints per suffix.
     wpts_by_suffix: dict[str, list] = {}
@@ -559,9 +561,11 @@ def _insert_extra_wpts(session: Session, extra_wpts: list, commit_every: int = 5
         if cache_id is None:
             continue
 
+        parent_gc = suffix_to_gc_code.get(suffix)
         for wp in wps:
             session.add(Waypoint(
                 cache_id=cache_id,
+                parent_gc_code=parent_gc,
                 prefix=wp["prefix"],
                 wp_type=wp["wp_type"],
                 name=wp["name"],

--- a/tests/unit-tests/test_db.py
+++ b/tests/unit-tests/test_db.py
@@ -421,3 +421,37 @@ class TestLocationProvenanceColumns:
         }
         for col in provenance:
             assert col in cols, f"migration 12 did not restore column: {col}"
+
+    def test_migration_13_adds_parent_gc_code_to_waypoints(self, tmp_path):
+        # Create a v13 DB, drop parent_gc_code, rewind to v12, re-run init_db —
+        # migration 13 must add the column and back-fill it from caches.
+        import sqlite3 as _sql
+        from opensak.db.database import _migrated_paths
+        from opensak.db.models import Cache, Waypoint
+
+        db_file = tmp_path / "m13.db"
+        _migrated_paths.discard(db_file)
+        init_db(db_path=db_file)
+
+        from opensak.db.database import get_session
+        with get_session() as s:
+            cache = Cache(gc_code="GCTEST1", name="Test", cache_type="Traditional Cache",
+                          latitude=55.0, longitude=12.0)
+            s.add(cache)
+            s.flush()
+            s.add(Waypoint(cache_id=cache.id, parent_gc_code="GCTEST1",
+                           prefix="PK", wp_type="Parking Area"))
+            s.commit()
+
+        with _sql.connect(db_file) as con:
+            con.execute("ALTER TABLE waypoints DROP COLUMN parent_gc_code")
+            con.execute("PRAGMA user_version = 12")
+
+        _migrated_paths.discard(db_file)
+        init_db(db_path=db_file)
+
+        with _sql.connect(db_file) as con:
+            wpt_cols = {row[1] for row in con.execute("PRAGMA table_info(waypoints)").fetchall()}
+            assert "parent_gc_code" in wpt_cols, "migration 13 did not add waypoints.parent_gc_code"
+            gc = con.execute("SELECT parent_gc_code FROM waypoints LIMIT 1").fetchone()[0]
+            assert gc == "GCTEST1", f"back-fill failed: got {gc!r}"

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -129,6 +129,7 @@ def test_import_with_companion_wpts(tmp_db, gpx_file, wpts_file):
         assert wp.prefix == "PK"
         assert wp.latitude == pytest.approx(55.6762)
         assert wp.comment == "Park here and walk 200m south."
+        assert wp.parent_gc_code == "GC12345"
 
 
 # ── ZIP import tests ──────────────────────────────────────────────────────────
@@ -266,6 +267,7 @@ def test_import_gpx_inline_extra_waypoints(tmp_db, tmp_path):
         assert wp.prefix == "PK"
         assert wp.wp_type == "Parking Area"
         assert wp.comment == "Street parking available."
+        assert wp.parent_gc_code == "GC12345"
 
 
 # ── ImportResult.__str__ ──────────────────────────────────────────────────────


### PR DESCRIPTION
Adds `parent_gc_code` (VARCHAR 16, indexed) to the `waypoints` table, mirroring GSAK's `cParent` column. This makes it possible to write filter queries that join caches and waypoints by GC code without going through the surrogate `cache_id` FK.

Schema migration 13 adds the column to existing databases and back-fills it from the `caches` table via the existing FK, so users don't need to re-import.

The importer (both the inline-waypoint path via `_insert_extra_wpts` and the companion-file path via `_link_extra_waypoints`) now sets `parent_gc_code` on every new `Waypoint` row.

Closes #376