### PR TITLE
Improvement: Visual indication in the grid when a cache has child waypoints

### DIFF
--- a/src/opensak/db/database.py
+++ b/src/opensak/db/database.py
@@ -62,7 +62,7 @@ _migrated_paths: set = set()  # undgår at køre migrationer to gange på samme 
 # bumped to the highest migration number whenever a new migration is added
 # below — _run_migrations() skips the whole block when the database already
 # reports this version, so a stale constant means new migrations never run.
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 
 def init_db(db_path: Path | None = None) -> Engine:
@@ -436,6 +436,26 @@ def _run_migrations(engine: Engine) -> None:
             """))
             conn.commit()
             print("Migration: tilføjede waypoints.parent_gc_code")
+
+        # ── Migration 14: waypoint_count on caches (issue #377) ──────────────
+        # Cached count of child waypoints so the grid can show a visual cue
+        # without loading the noload'ed waypoints relationship.
+        existing_caches_14 = [
+            row[1]
+            for row in conn.execute(text("PRAGMA table_info(caches)")).fetchall()
+        ]
+        if "waypoint_count" not in existing_caches_14:
+            conn.execute(text(
+                "ALTER TABLE caches ADD COLUMN waypoint_count INTEGER NOT NULL DEFAULT 0"
+            ))
+            conn.execute(text("""
+                UPDATE caches
+                SET waypoint_count = (
+                    SELECT COUNT(*) FROM waypoints WHERE waypoints.cache_id = caches.id
+                )
+            """))
+            conn.commit()
+            print("Migration: tilføjede caches.waypoint_count")
 
         # ── Stamp the schema version so the next launch skips the probes ─────
         # PRAGMA does not accept bind parameters; SCHEMA_VERSION is a trusted

--- a/src/opensak/db/models.py
+++ b/src/opensak/db/models.py
@@ -132,6 +132,12 @@ class Cache(Base):
     # without loading the noload'ed logs relationship. Updated on import.
     last_log_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
+    # ── Issue #377: Cached waypoint count ────────────────────────────────────
+    # Number of child waypoints (parking, stages, etc.), cached so the grid
+    # can show a visual cue without loading the noload'ed waypoints relation.
+    # Updated on import in _insert_extra_wpts() and _link_extra_waypoints().
+    waypoint_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
     # Custom waypoint link (issue #141)
     # For CW... entries: optionally links to a parent geocache's gc_code.
     # NULL for all real geocaches imported from GPX/PQ.

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -601,6 +601,8 @@ class CacheTableModel(QAbstractTableModel):
             font.setPointSize(TEXT_SIZE_MAP[text_size]["grid"])
             if cache.found:
                 font.setItalic(True)
+            if col == "name" and (cache.waypoint_count or 0) > 0:
+                font.setBold(True)
             return font
 
         if role == Qt.ItemDataRole.ToolTipRole:

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -1141,7 +1141,10 @@ def _link_extra_waypoints(
             count += 1
 
     # Refresh waypoint_count for every matched cache in one SQL pass.
+    # flush() is required because autoflush=False; the subquery must see the
+    # newly added Waypoint rows before the UPDATE executes.
     if target_ids:
+        session.flush()
         for i in range(0, len(target_ids), 500):
             chunk = target_ids[i:i + 500]
             placeholders = ", ".join(str(cid) for cid in chunk)

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -582,6 +582,21 @@ def _insert_extra_wpts(session: Session, extra_wpts: list, commit_every: int = 5
             session.expunge_all()
 
     session.commit()
+
+    # Refresh waypoint_count for every affected cache in one SQL pass.
+    if target_ids:
+        for i in range(0, len(target_ids), 500):
+            chunk = target_ids[i:i + 500]
+            placeholders = ", ".join(str(cid) for cid in chunk)
+            session.execute(_sa_text(f"""
+                UPDATE caches
+                SET waypoint_count = (
+                    SELECT COUNT(*) FROM waypoints WHERE waypoints.cache_id = caches.id
+                )
+                WHERE id IN ({placeholders})
+            """))
+        session.commit()
+
     return count
 
 
@@ -734,6 +749,7 @@ def _upsert_cache(
         session.query(Attribute).filter_by(cache_id=cache.id).delete(synchronize_session=False)
         session.query(Trackable).filter_by(cache_id=cache.id).delete(synchronize_session=False)
         session.query(Waypoint).filter_by(cache_id=cache.id).delete(synchronize_session=False)
+        cache.waypoint_count = 0
         session.flush()
 
     # Scalar fields
@@ -1123,6 +1139,20 @@ def _link_extra_waypoints(
                 longitude=wp["longitude"],
             ))
             count += 1
+
+    # Refresh waypoint_count for every matched cache in one SQL pass.
+    if target_ids:
+        for i in range(0, len(target_ids), 500):
+            chunk = target_ids[i:i + 500]
+            placeholders = ", ".join(str(cid) for cid in chunk)
+            session.execute(_sa_text(f"""
+                UPDATE caches
+                SET waypoint_count = (
+                    SELECT COUNT(*) FROM waypoints WHERE waypoints.cache_id = caches.id
+                )
+                WHERE id IN ({placeholders})
+            """))
+        session.commit()
 
     return count
 

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -297,6 +297,30 @@ class TestDataRoles:
         assert font.italic()
         assert font.pointSize() == TEXT_SIZE_MAP[TextSize.LARGE]["grid"]
 
+    def test_font_role_bold_name_when_has_waypoints(self, model):
+        # Name column must be bold when waypoint_count > 0.
+        c = _cache(waypoint_count=2)
+        model.load([c])
+        name_col = ALL_COLUMNS.index("name")
+        font = model.data(model.index(0, name_col), Qt.ItemDataRole.FontRole)
+        assert font is not None and font.bold()
+
+    def test_font_role_no_bold_name_without_waypoints(self, model):
+        # Name column must not be bold when waypoint_count == 0.
+        c = _cache(waypoint_count=0)
+        model.load([c])
+        name_col = ALL_COLUMNS.index("name")
+        font = model.data(model.index(0, name_col), Qt.ItemDataRole.FontRole)
+        assert font is not None and not font.bold()
+
+    def test_font_role_other_col_not_bold_with_waypoints(self, model):
+        # Non-name columns must not be bold even when waypoints exist.
+        c = _cache(waypoint_count=3)
+        model.load([c])
+        gc_col = ALL_COLUMNS.index("gc_code")
+        font = model.data(model.index(0, gc_col), Qt.ItemDataRole.FontRole)
+        assert font is not None and not font.bold()
+
     def test_tooltip_cache_type(self, model):
         model.load([_cache(cache_type="Unknown Cache")])
         tip = model.data(model.index(0, ALL_COLUMNS.index("cache_type")),

--- a/tests/unit-tests/test_db.py
+++ b/tests/unit-tests/test_db.py
@@ -455,3 +455,37 @@ class TestLocationProvenanceColumns:
             assert "parent_gc_code" in wpt_cols, "migration 13 did not add waypoints.parent_gc_code"
             gc = con.execute("SELECT parent_gc_code FROM waypoints LIMIT 1").fetchone()[0]
             assert gc == "GCTEST1", f"back-fill failed: got {gc!r}"
+
+    def test_migration_14_adds_waypoint_count_to_caches(self, tmp_path):
+        # Create a v14 DB, drop waypoint_count, rewind to v13, re-run init_db —
+        # migration 14 must add the column and back-fill it from waypoints.
+        import sqlite3 as _sql
+        from opensak.db.database import _migrated_paths
+        from opensak.db.models import Cache, Waypoint
+
+        db_file = tmp_path / "m14.db"
+        _migrated_paths.discard(db_file)
+        init_db(db_path=db_file)
+
+        from opensak.db.database import get_session
+        with get_session() as s:
+            cache = Cache(gc_code="GCWPT01", name="Test", cache_type="Traditional Cache",
+                          latitude=55.0, longitude=12.0)
+            s.add(cache)
+            s.flush()
+            s.add(Waypoint(cache_id=cache.id, parent_gc_code="GCWPT01",
+                           prefix="PK", wp_type="Parking Area"))
+            s.commit()
+
+        with _sql.connect(db_file) as con:
+            con.execute("ALTER TABLE caches DROP COLUMN waypoint_count")
+            con.execute("PRAGMA user_version = 13")
+
+        _migrated_paths.discard(db_file)
+        init_db(db_path=db_file)
+
+        with _sql.connect(db_file) as con:
+            cache_cols = {row[1] for row in con.execute("PRAGMA table_info(caches)").fetchall()}
+            assert "waypoint_count" in cache_cols, "migration 14 did not add caches.waypoint_count"
+            cnt = con.execute("SELECT waypoint_count FROM caches WHERE gc_code='GCWPT01'").fetchone()[0]
+            assert cnt == 1, f"back-fill failed: got {cnt!r}"

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -132,6 +132,44 @@ def test_import_with_companion_wpts(tmp_db, gpx_file, wpts_file):
         assert wp.parent_gc_code == "GC12345"
 
 
+def test_waypoint_count_set_after_companion_import(tmp_db, gpx_file, wpts_file):
+    # waypoint_count on the Cache row must reflect companion waypoints after import.
+    with get_session() as s:
+        import_gpx(gpx_file, s, wpts_path=wpts_file)
+
+    with get_session() as s:
+        cache = s.query(Cache).filter_by(gc_code="GC12345").one()
+        assert cache.waypoint_count == 1
+        no_wpts = s.query(Cache).filter_by(gc_code="GC99999").one()
+        assert no_wpts.waypoint_count == 0
+
+
+def test_waypoint_count_set_after_inline_import(tmp_db, tmp_path):
+    # waypoint_count must be set when waypoints are embedded in the same GPX.
+    gpx = write_gpx(tmp_path, "inline.gpx", make_gpx_with_inline_wpt())
+    import_gpx(gpx)
+
+    with get_session() as s:
+        cache = s.query(Cache).filter_by(gc_code="GC12345").one()
+        assert cache.waypoint_count == 1
+
+
+def test_waypoint_count_reset_on_reimport_without_wpts(tmp_db, gpx_file, wpts_file, tmp_path):
+    # Re-importing a cache without waypoints must zero out waypoint_count.
+    with get_session() as s:
+        import_gpx(gpx_file, s, wpts_path=wpts_file)
+
+    with get_session() as s:
+        assert s.query(Cache).filter_by(gc_code="GC12345").one().waypoint_count == 1
+
+    # Re-import the same GPX without the companion file.
+    with get_session() as s:
+        import_gpx(gpx_file, s)
+
+    with get_session() as s:
+        assert s.query(Cache).filter_by(gc_code="GC12345").one().waypoint_count == 0
+
+
 # ── ZIP import tests ──────────────────────────────────────────────────────────
 
 def test_import_zip(tmp_db, zip_file):


### PR DESCRIPTION
Adds a bold name in the cache grid when one or more child waypoints exist for that cache — matching GSAK's behaviour.

A new `waypoint_count` column on `Cache` (migration 14) caches the count so the grid can check it without loading the `noload`'d waypoints relationship. The column is maintained on import in both the inline and companion waypoints paths, and reset to 0 when a cache is re-imported without waypoints.

Closes #377