### PR TITLE
Improvement: show child waypoints on the map when the Waypoints tab is active

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -72,6 +72,8 @@ class CacheDetailPanel(QWidget):
     """Displays full details for a single selected cache."""
 
     corrected_coords_changed = Signal(str)  # gc_code
+    waypoints_tab_shown = Signal(str)       # JSON: [{lat, lon, prefix, wp_type, name}, ...]
+    waypoints_tab_hidden = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -287,6 +289,7 @@ class CacheDetailPanel(QWidget):
         self._tabs.addTab(wp_widget, tr("detail_tab_waypoints"))
 
         layout.addWidget(self._tabs)
+        self._tabs.currentChanged.connect(self._on_tab_changed)
 
     def _meta_label(self, text: str) -> QLabel:
         lbl = QLabel(text)
@@ -460,6 +463,8 @@ class CacheDetailPanel(QWidget):
         self._conv_btn.setEnabled(False)
         self._corrected_frame.setVisible(False)
         self._add_corrected_btn.setVisible(False)
+        self._current_waypoints: list = []
+        self.waypoints_tab_hidden.emit()
 
     def show_cache(self, cache: Cache) -> None:
         """Populate the panel with data from *cache*."""
@@ -620,6 +625,7 @@ class CacheDetailPanel(QWidget):
 
     def _render_waypoints(self, cache: Cache) -> None:
         wps = cache.waypoints
+        self._current_waypoints = list(wps)
         count = len(wps)
         tab_idx = 3
         self._tabs.setTabText(
@@ -646,6 +652,25 @@ class CacheDetailPanel(QWidget):
                 html.append(f'<p style="color:#555;margin-top:2px"><i>{wp.comment}</i></p>')
             html.append("<hr>")
         self._wp_browser.setHtml("".join(html))
+        if self._tabs.currentIndex() == 3:
+            self._emit_waypoint_markers()
+
+    def _on_tab_changed(self, idx: int) -> None:
+        if idx == 3:
+            self._emit_waypoint_markers()
+        else:
+            self.waypoints_tab_hidden.emit()
+
+    def _emit_waypoint_markers(self) -> None:
+        import json
+        data = [
+            {"lat": wp.latitude, "lon": wp.longitude,
+             "prefix": wp.prefix or "", "wp_type": wp.wp_type or "",
+             "name": wp.name or ""}
+            for wp in self._current_waypoints
+            if wp.latitude is not None and wp.longitude is not None
+        ]
+        self.waypoints_tab_shown.emit(json.dumps(data))
 
     def _cleanup_webengine(self) -> None:
         """Slet QWebEnginePage før Qt rydder defaultProfile op.

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -266,6 +266,8 @@ class MainWindow(QMainWindow):
         self._map_widget = MapWidget()
         self._map_widget.cache_selected.connect(self._on_map_cache_selected)
         self._map_widget.set_corrected_requested.connect(self._on_set_corrected_from_map)
+        self._detail_panel.waypoints_tab_shown.connect(self._map_widget.show_waypoint_markers)
+        self._detail_panel.waypoints_tab_hidden.connect(self._map_widget.clear_waypoint_markers)
         self._map_widget.setMinimumWidth(300)
         self._bottom_splitter.addWidget(self._map_widget)
 

--- a/src/opensak/gui/map_widget.py
+++ b/src/opensak/gui/map_widget.py
@@ -100,6 +100,22 @@ MAP_HTML = """<!DOCTYPE html>
     border: 3px solid #fff;
     box-shadow: 0 1px 4px rgba(0,0,0,0.5);
   }
+  .waypoint-marker {
+    width: 22px; height: 22px;
+    background: #7b1fa2;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 9px;
+    font-weight: bold;
+    font-family: sans-serif;
+    text-align: center;
+    line-height: 22px;
+  }
 </style>
 </head>
 <body>
@@ -140,6 +156,7 @@ var markers = {};          // gc_code → marker
 var homeMarker = null;
 var selectedGcCode = null;
 var bridge = null;
+var waypointMarkers = [];
 
 // ── WebChannel setup ──────────────────────────────────────────────────────────
 new QWebChannel(qt.webChannelTransport, function(channel) {
@@ -293,6 +310,37 @@ function panToHome() {
     if (homeMarker) {
         map.panTo(homeMarker.getLatLng());
         map.setZoom(12);
+    }
+}
+
+function clearWaypointMarkers() {
+    waypointMarkers.forEach(function(m) { map.removeLayer(m); });
+    waypointMarkers = [];
+}
+
+function showWaypointMarkers(waypointsJson) {
+    clearWaypointMarkers();
+    var wps = JSON.parse(waypointsJson);
+    wps.forEach(function(wp) {
+        var icon = L.divIcon({
+            className: '',
+            html: '<div class="waypoint-marker">' + wp.prefix + '</div>',
+            iconSize: [22, 22],
+            iconAnchor: [11, 11],
+            popupAnchor: [0, -13]
+        });
+        var label = '[' + wp.prefix + '] ' + (wp.wp_type || '');
+        var popup = '<b>[' + wp.prefix + ']</b> ' + (wp.wp_type || '') + (wp.name ? '<br>' + wp.name : '');
+        var m = L.marker([wp.lat, wp.lon], {icon: icon, title: label});
+        m.bindPopup(popup);
+        m.addTo(map);
+        waypointMarkers.push(m);
+    });
+    if (waypointMarkers.length > 0) {
+        try {
+            var group = L.featureGroup(waypointMarkers);
+            map.fitBounds(group.getBounds().pad(0.5));
+        } catch(e) {}
     }
 }
 
@@ -504,6 +552,18 @@ class MapWidget(QWidget):
             self._run_js(f"panToCache('{safe}')")
 
 
+
+    def show_waypoint_markers(self, waypoints_json: str) -> None:
+        """Render child waypoint markers on the map (called when Waypoints tab is activated)."""
+        if not self._ready:
+            return
+        safe = waypoints_json.replace("\\", "\\\\").replace("`", "\\`")
+        self._run_js(f"showWaypointMarkers(`{safe}`)")
+
+    def clear_waypoint_markers(self) -> None:
+        """Remove all waypoint markers (called when Waypoints tab is left)."""
+        if self._ready:
+            self._run_js("clearWaypointMarkers()")
 
     def fit_all(self) -> None:
         if self._ready:

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -118,3 +118,77 @@ def test_waypoints_tab_cleared_on_clear(monkeypatch, qapp):
     panel.clear()
     assert panel._tabs.tabText(3) == tr("detail_tab_waypoints")
     assert panel._wp_browser.toPlainText() == ""
+
+
+def test_waypoints_tab_shown_signal_emits_coords(monkeypatch, qapp):
+    # Regression for #393: switching to waypoints tab emits waypoints_tab_shown with coord JSON.
+    import json
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._render_waypoints(SimpleNamespace(waypoints=[
+        _fake_wp(prefix="PK", wp_type="Parking Area", name="Park", lat=55.1, lon=12.1),
+        _fake_wp(prefix="FN", wp_type="Final Location", name="Final", lat=55.2, lon=12.2),
+    ]))
+    received = []
+    panel.waypoints_tab_shown.connect(received.append)
+    panel._tabs.setCurrentIndex(3)
+    assert len(received) == 1
+    data = json.loads(received[0])
+    assert len(data) == 2
+    prefixes = {d["prefix"] for d in data}
+    assert prefixes == {"PK", "FN"}
+
+
+def test_waypoints_tab_hidden_signal_on_leave(monkeypatch, qapp):
+    # Regression for #393: switching away from the waypoints tab emits waypoints_tab_hidden.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._tabs.setCurrentIndex(3)
+    hidden = []
+    panel.waypoints_tab_hidden.connect(lambda: hidden.append(True))
+    panel._tabs.setCurrentIndex(0)
+    assert hidden == [True]
+
+
+def test_waypoints_tab_excludes_no_coord_waypoints(monkeypatch, qapp):
+    # Regression for #393: waypoints without coords are excluded from the map signal.
+    import json
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._render_waypoints(SimpleNamespace(waypoints=[
+        _fake_wp(lat=None, lon=None),
+        _fake_wp(prefix="FN", lat=55.0, lon=12.0),
+    ]))
+    received = []
+    panel.waypoints_tab_shown.connect(received.append)
+    panel._tabs.setCurrentIndex(3)
+    data = json.loads(received[0])
+    assert len(data) == 1
+    assert data[0]["prefix"] == "FN"
+
+
+def test_waypoints_tab_shown_on_cache_change_while_active(monkeypatch, qapp):
+    # Regression for #393: if the waypoints tab is already open when a new cache
+    # is loaded, the map signal fires with the updated waypoints.
+    import json
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._tabs.setCurrentIndex(3)
+    received = []
+    panel.waypoints_tab_shown.connect(received.append)
+    panel._render_waypoints(SimpleNamespace(waypoints=[
+        _fake_wp(prefix="SB", lat=55.5, lon=12.5),
+    ]))
+    assert len(received) == 1
+    data = json.loads(received[0])
+    assert data[0]["prefix"] == "SB"
+
+
+def test_clear_emits_waypoints_hidden(monkeypatch, qapp):
+    # Regression for #393: clear() emits waypoints_tab_hidden so the map removes markers.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    hidden = []
+    panel.waypoints_tab_hidden.connect(lambda: hidden.append(True))
+    panel.clear()
+    assert hidden == [True]

--- a/tests/unit-tests/test_map_widget.py
+++ b/tests/unit-tests/test_map_widget.py
@@ -187,6 +187,25 @@ class TestJsMethods:
         w.update_home()
         assert any("setHomeLocation" in js for js in w._page.js)
 
+    def test_show_waypoint_markers(self, w):
+        import json
+        wps = json.dumps([{"lat": 55.1, "lon": 12.1, "prefix": "PK", "wp_type": "Parking", "name": "P"}])
+        w.show_waypoint_markers(wps)
+        assert any("showWaypointMarkers" in js for js in w._page.js)
+
+    def test_clear_waypoint_markers(self, w):
+        w.clear_waypoint_markers()
+        assert w._page.js == ["clearWaypointMarkers()"]
+
+    def test_waypoint_methods_noop_when_not_ready(self, qtbot):
+        # Regression for #393: waypoint marker methods no-op before map is loaded.
+        widget = MapWidget()
+        qtbot.addWidget(widget)
+        widget._page = FakePage()
+        widget.show_waypoint_markers("[]")
+        widget.clear_waypoint_markers()
+        assert widget._page.js == []
+
     def test_methods_noop_when_not_ready(self, qtbot):
         widget = MapWidget()
         qtbot.addWidget(widget)


### PR DESCRIPTION
When the user switches to the Waypoints tab in the cache detail panel, the map now adds a purple circle marker for each child waypoint that has coordinates. Each marker shows the waypoint prefix (e.g. PK, FN) inside the circle and a popup with the type and name on click. The map fits its view to the visible waypoints when the tab is activated. Switching to any other tab removes the markers and restores the normal view.

If the Waypoints tab is already open when a different cache is selected, the markers update immediately to reflect the new cache's waypoints.

Closes #393