### PR TITLE
Edit personal notes in the cache detail view

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -402,7 +402,8 @@ class CacheDetailPanel(QWidget):
             self.corrected_coords_changed.emit(self._current_gc_code)
 
     def eventFilter(self, obj, event) -> bool:
-        if obj is self._note_editor and event.type() == QEvent.Type.FocusOut:
+        note_editor = getattr(self, "_note_editor", None)
+        if note_editor is not None and obj is note_editor and event.type() == QEvent.Type.FocusOut:
             self._save_note()
         return super().eventFilter(obj, event)
 

--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -9,11 +9,11 @@ import re
 import webbrowser
 from datetime import datetime
 from opensak.utils.constants import LOG_COLOURS
-from PySide6.QtCore import Qt, QUrl, Signal, QDate, QLocale
+from PySide6.QtCore import Qt, QUrl, Signal, QDate, QLocale, QEvent
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QTextBrowser, QTabWidget, QFrame, QSizePolicy,
-    QPushButton
+    QPushButton, QPlainTextEdit
 )
 from PySide6.QtGui import QFont
 from PySide6.QtWebEngineWidgets import QWebEngineView
@@ -288,6 +288,15 @@ class CacheDetailPanel(QWidget):
         wp_layout.addWidget(self._wp_browser)
         self._tabs.addTab(wp_widget, tr("detail_tab_waypoints"))
 
+        note_widget = QWidget()
+        note_layout = QVBoxLayout(note_widget)
+        note_layout.setContentsMargins(0, 4, 0, 0)
+        self._note_editor = QPlainTextEdit()
+        self._note_editor.setPlaceholderText(tr("detail_note_placeholder"))
+        self._note_editor.installEventFilter(self)
+        note_layout.addWidget(self._note_editor)
+        self._tabs.addTab(note_widget, tr("detail_tab_notes"))
+
         layout.addWidget(self._tabs)
         self._tabs.currentChanged.connect(self._on_tab_changed)
 
@@ -392,6 +401,30 @@ class CacheDetailPanel(QWidget):
         if self._current_gc_code:
             self.corrected_coords_changed.emit(self._current_gc_code)
 
+    def eventFilter(self, obj, event) -> bool:
+        if obj is self._note_editor and event.type() == QEvent.Type.FocusOut:
+            self._save_note()
+        return super().eventFilter(obj, event)
+
+    def _save_note(self) -> None:
+        if not self._current_gc_code:
+            return
+        from opensak.db.database import get_session
+        from opensak.db.models import Cache as CacheModel, UserNote
+        text = self._note_editor.toPlainText().strip() or None
+        with get_session() as s:
+            cache_row = s.query(CacheModel).filter_by(gc_code=self._current_gc_code).one_or_none()
+            if cache_row is None:
+                return
+            note = cache_row.user_note
+            if note is None:
+                s.flush()
+                note = UserNote(cache_id=cache_row.id)
+                s.add(note)
+                s.flush()
+                cache_row.user_note = note
+            note.note = text
+
     def _update_corrected_ui(self) -> None:
         """Opdater visningen af korrigerede koordinater."""
         has_corrected = self._corrected_lat is not None
@@ -453,6 +486,7 @@ class CacheDetailPanel(QWidget):
         self._hint_browser.setPlainText("")
         self._log_browser.setHtml("")
         self._wp_browser.setPlainText("")
+        self._note_editor.setPlainText("")
         self._tabs.setTabText(3, tr("detail_tab_waypoints"))
         self._hint_plain = ""
         self._hint_cipher = ""
@@ -559,6 +593,11 @@ class CacheDetailPanel(QWidget):
         self._decode_btn.setText(tr("detail_decode_btn"))
         self._hint_browser.setPlainText(
             self._hint_cipher if self._hint_cipher else tr("detail_no_hint")
+        )
+
+        # Personal note
+        self._note_editor.setPlainText(
+            (cache.user_note.note or "") if cache.user_note else ""
         )
 
         # Logs — viser alle (sorteret efter dato, nyeste først)

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -548,6 +548,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypointy",
     "detail_tab_waypoints_count":   "Waypointy ({count})",
     "detail_no_waypoints":          "(Žádné podřízené waypointy)",
+    "detail_tab_notes":             "Poznámky",
+    "detail_note_placeholder":      "Přidat osobní poznámku k tomuto cache…",
     "detail_wp_no_coords":          "(Žádné souřadnice)",
     "detail_decode_btn":            "🔓  Dekódovat nápovědu (ROT13)",
     "detail_encode_btn":            "🔒  Kódovat nápovědu (ROT13)",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -547,6 +547,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Ingen underordnede waypoints)",
+    "detail_tab_notes":             "Noter",
+    "detail_note_placeholder":      "Tilføj en personlig note til denne cache…",
     "detail_wp_no_coords":          "(Ingen koordinater)",
     "detail_decode_btn":            "🔓  Dekod hint (ROT13)",
     "detail_encode_btn":            "🔒  Kodér hint (ROT13)",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -547,6 +547,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Wegpunkte",
     "detail_tab_waypoints_count":   "Wegpunkte ({count})",
     "detail_no_waypoints":          "(Keine untergeordneten Wegpunkte)",
+    "detail_tab_notes":             "Notizen",
+    "detail_note_placeholder":      "Persönliche Notiz für diesen Cache hinzufügen…",
     "detail_wp_no_coords":          "(Keine Koordinaten)",
     "detail_decode_btn":            "🔓  Hinweis dekodieren (ROT13)",
     "detail_encode_btn":            "🔒  Hinweis kodieren (ROT13)",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -546,6 +546,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(No child waypoints)",
+    "detail_tab_notes":             "Notes",
+    "detail_note_placeholder":      "Add a personal note for this cache…",
     "detail_wp_no_coords":          "(No coordinates)",
     "detail_decode_btn":            "🔓  Decode hint (ROT13)",
     "detail_encode_btn":            "🔒  Encode hint (ROT13)",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -547,6 +547,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Points de passage",
     "detail_tab_waypoints_count":   "Points de passage ({count})",
     "detail_no_waypoints":          "(Aucun point de passage enfant)",
+    "detail_tab_notes":             "Notes",
+    "detail_note_placeholder":      "Ajouter une note personnelle pour ce cache…",
     "detail_wp_no_coords":          "(Pas de coordonnées)",
     "detail_decode_btn":            "🔓  Decoder l'indice (ROT13)",
     "detail_encode_btn":            "🔒  Encoder l'indice (ROT13)",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -551,6 +551,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Geen onderliggende waypoints)",
+    "detail_tab_notes":             "Notities",
+    "detail_note_placeholder":      "Voeg een persoonlijke notitie toe voor deze cache…",
     "detail_wp_no_coords":          "(Geen coördinaten)",
     "detail_decode_btn":            "🔓  Hint decoderen (ROT13)",
     "detail_encode_btn":            "🔒  Hint coderen (ROT13)",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -548,6 +548,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Sem waypoints filhos)",
+    "detail_tab_notes":             "Notas",
+    "detail_note_placeholder":      "Adicionar uma nota pessoal para este cache…",
     "detail_wp_no_coords":          "(Sem coordenadas)",
     "detail_decode_btn":            "🔓  Descodificar dica (ROT13)",
     "detail_encode_btn":            "🔒  Codificar dica (ROT13)",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -547,6 +547,8 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Inga underordnade waypoints)",
+    "detail_tab_notes":             "Anteckningar",
+    "detail_note_placeholder":      "Lägg till en personlig anteckning för denna cache…",
     "detail_wp_no_coords":          "(Inga koordinater)",
     "detail_decode_btn":            "🔓  Avkoda ledtråd (ROT13)",
     "detail_encode_btn":            "🔒  Koda ledtråd (ROT13)",

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -192,3 +192,128 @@ def test_clear_emits_waypoints_hidden(monkeypatch, qapp):
     panel.waypoints_tab_hidden.connect(lambda: hidden.append(True))
     panel.clear()
     assert hidden == [True]
+
+
+# ── Notes tab tests (issue #390) ──────────────────────────────────────────────
+
+import textwrap
+from opensak.db.database import get_session, init_db
+from opensak.importer import import_gpx
+
+
+def _write_gpx(tmp_path, content: str):
+    p = tmp_path / "test.gpx"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _minimal_gpx(gsak_ext: str = "") -> str:
+    return textwrap.dedent(f"""\
+        <?xml version="1.0" encoding="utf-8"?>
+        <gpx xmlns="http://www.topografix.com/GPX/1/0"
+             xmlns:groundspeak="http://www.groundspeak.com/cache/1/0/1"
+             xmlns:gsak="http://www.gsak.net/xmlv1/6"
+             version="1.0" creator="GSAK">
+          <wpt lat="55.0000" lon="10.0000">
+            <time>2024-01-01T00:00:00</time>
+            <n>GCNOTES1</n>
+            <desc>Notes Cache by Owner, Traditional Cache (2/2)</desc>
+            <type>Geocache|Traditional Cache</type>
+            <groundspeak:cache id="1" archived="False" available="True">
+              <groundspeak:name>Notes Cache</groundspeak:name>
+              <groundspeak:placed_by>Owner</groundspeak:placed_by>
+              <groundspeak:owner id="1">Owner</groundspeak:owner>
+              <groundspeak:type>Traditional Cache</groundspeak:type>
+              <groundspeak:container>Small</groundspeak:container>
+              <groundspeak:difficulty>2.0</groundspeak:difficulty>
+              <groundspeak:terrain>2.0</groundspeak:terrain>
+              <groundspeak:country>Denmark</groundspeak:country>
+              <groundspeak:state>Zealand</groundspeak:state>
+              <groundspeak:encoded_hints></groundspeak:encoded_hints>
+              <groundspeak:logs></groundspeak:logs>
+            </groundspeak:cache>
+            {gsak_ext}
+          </wpt>
+        </gpx>
+    """)
+
+
+def test_notes_tab_exists_at_index_4(monkeypatch, qapp):
+    # The Notes tab must be the fifth tab (index 4).
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    assert panel._tabs.tabText(4) == tr("detail_tab_notes")
+
+
+def test_notes_tab_loads_existing_note(monkeypatch, tmp_path, qapp):
+    # When a cache with a UserNote is shown, the editor is pre-filled.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    db_path = tmp_path / "notes_load.db"
+    init_db(db_path=db_path)
+    gpx = _minimal_gpx("""
+        <gsak:wptExtension>
+          <gsak:UserNote>Pre-loaded note text.</gsak:UserNote>
+        </gsak:wptExtension>
+    """)
+    import_gpx(_write_gpx(tmp_path, gpx), db_path)
+
+    from opensak.db.models import Cache as CacheModel
+    from sqlalchemy.orm import joinedload
+    with get_session() as s:
+        cache = (
+            s.query(CacheModel)
+            .options(
+                joinedload(CacheModel.user_note),
+                joinedload(CacheModel.logs),
+                joinedload(CacheModel.waypoints),
+            )
+            .filter_by(gc_code="GCNOTES1")
+            .one()
+        )
+        s.expunge_all()
+
+    panel = CacheDetailPanel()
+    panel.show_cache(cache)
+    assert panel._note_editor.toPlainText() == "Pre-loaded note text."
+
+
+def test_notes_tab_save_roundtrip(monkeypatch, tmp_path, qapp):
+    # Typing a note and calling _save_note() persists it to the DB.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    db_path = tmp_path / "notes_save.db"
+    init_db(db_path=db_path)
+    import_gpx(_write_gpx(tmp_path, _minimal_gpx()), db_path)
+
+    from opensak.db.models import Cache as CacheModel
+    from sqlalchemy.orm import joinedload
+    with get_session() as s:
+        cache = (
+            s.query(CacheModel)
+            .options(
+                joinedload(CacheModel.user_note),
+                joinedload(CacheModel.logs),
+                joinedload(CacheModel.waypoints),
+            )
+            .filter_by(gc_code="GCNOTES1")
+            .one()
+        )
+        s.expunge_all()
+
+    panel = CacheDetailPanel()
+    panel.show_cache(cache)
+    panel._note_editor.setPlainText("My personal note.")
+    panel._save_note()
+
+    with get_session() as s:
+        cache2 = s.query(CacheModel).filter_by(gc_code="GCNOTES1").one()
+        assert cache2.user_note is not None
+        assert cache2.user_note.note == "My personal note."
+
+
+def test_notes_tab_clear_resets_editor(monkeypatch, qapp):
+    # clear() must empty the note editor.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._note_editor.setPlainText("Some text")
+    panel.clear()
+    assert panel._note_editor.toPlainText() == ""


### PR DESCRIPTION
## Summary

- Adds a **Notes** tab (index 4) to the cache detail panel with a `QPlainTextEdit`
- Loads `user_note.note` when a cache is selected; shows a placeholder when empty
- Saves to the DB on focus-out; creates the `UserNote` row if it does not exist yet
- Clears the editor when `clear()` is called (e.g. when no cache is selected)
- Two new lang keys: `detail_tab_notes` and `detail_note_placeholder`

Closes #390