### PR TITLE
Detect unused translation keys via test

### DIFF
--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -151,7 +151,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":         "✓ {count} keší načteno — kliknutím zobrazíte mapu",
     "import_log_placeholder":       "Výsledky importu se zobrazí zde…",
     "import_all_done":            "✓ Všech {count} souborů bylo zpracováno.",
-    "import_geocode_checkbox":      "🌍  Geokódovat chybějící okres / kraj / zemi po importu",
     "import_geocode_running":       "📍  Geokóduji chybějící údaje o poloze…",
     
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -220,10 +219,8 @@ STRINGS: dict[str, str] = {
 
     # ── Settings dialog ───────────────────────────────────────────────────────
     "settings_dialog_title":        "Nastavení",
-    "settings_group_location":      "Domácí souřadnice",
     "settings_group_user_locations":                "Uživatelská místa",
     "settings_group_display":       "Zobrazení",
-    "settings_use_miles":           "Zobrazovat vzdálenosti v mílích (místo km)",
 
 
     "settings_map_label":           "Mapová aplikace:",
@@ -395,11 +392,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Hotovo — {updated} aktualizováno, {skipped} přeskočeno, {errors} chyb",
     "update_loc_cancelled":         "Zrušeno — {updated} aktualizováno doposud",
     "update_loc_log_placeholder":   "Výsledky se zobrazí zde…",
-    "update_loc_no_db":             "Žádná databáze není otevřena.",
     "update_loc_nothing_to_do":     "Žádné kešky k aktualizaci s vybraným rozsahem.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: chyba — {msg}",
-    "update_loc_row_skipped":       "{gc_code}: přeskočeno (žádné souřadnice)",
 
     # ── Boundary packs dialogs ────────────────────────────────────────────────
     "boundary_dl_title":            "Download Boundary Packs",
@@ -565,7 +560,6 @@ STRINGS: dict[str, str] = {
     # ── Toolbar extras ────────────────────────────────────────────────────────
 
     # ── Cache table columns ───────────────────────────────────────────────────
-    "col_status_icon":  "Ikona stavu",
     "col_gc_code":      "GC kód",
     "col_name":         "Název",
     "col_type":         "Typ",
@@ -708,7 +702,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Opravené souřadnice",
     "corrected_dialog_heading":     "Opravené souřadnice — {gc_code}",
-    "corrected_dialog_hint":        "Zadejte vyřešené souřadnice ve formátu DMM, DMS nebo DD. Budou použity pro export do GPS a zobrazeny na mapě.",
     "corrected_dialog_input_label": "Souřadnice:",
     "corrected_dialog_original":    "Původní souřadnice:",
     "corrected_dialog_corrected":   "Opravené souřadnice:",
@@ -817,8 +810,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terén (nejsnazší první)",
     "trip_sort_hidden_date":        "Datum umístění (nejnovější první)",
     "trip_sort_name":               "Název (A–Z)",
-    "trip_cb_not_found":            "Pouze keše, které jsem nenašel",
-    "trip_cb_available":            "Pouze dostupné (nearhivované)",
     "trip_preview_group":           "Náhled",
     "trip_result_label":            "{count} keší vybráno pro výlet",
     "trip_btn_export_gps":          "📤  Odeslat do GPS…",
@@ -834,13 +825,11 @@ STRINGS: dict[str, str] = {
     "toolbar_home_tooltip":         "Přesunout mapu na domácí bod",
 
     "trip_center_info":             "📍 Poloměr je počítán od vašeho středového bodu (nastavte v Nastavení). Nastavte poloměr na 0 pro zobrazení všech keší bez omezení vzdálenosti.",
-    "trip_found_hint":              "Vyžaduje, abyste spustili 'Aktualizovat nálezy' (menu Nástroje), aby byly nalezené keše správně označeny.",
     "trip_no_center_warning":       "⚠️  Středový bod není nastaven — přejděte do Nastavení a zadejte domácí bod, nebo nastavte poloměr na 0.",
 
     # ── Hjemmepunkter i indstillinger ────────────────────────────────────────
     "settings_hp_col_lat":                     "Zeměpisná šířka",
     "settings_hp_col_lon":                     "Zeměpisná délka",
-    "settings_hp_activate":                    "★ Aktivovat",
     "settings_hp_add_group":                   "Přidat / upravit bod",
     "settings_hp_name_label":                  "Název:",
     "settings_hp_name_placeholder":            "např. Domov, Chata…",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -151,7 +151,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":         "✓ {count} caches indlæst — klik på en cache for at se kortet",
     "import_log_placeholder":       "Import-resultat vises her…",
     "import_all_done":            "✓ Alle {count} filer er behandlet.",
-    "import_geocode_checkbox":      "🌍  Geokod manglende amt / region / land efter import",
     "import_geocode_running":       "📍  Geokoder manglende lokationsdata…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -220,10 +219,8 @@ STRINGS: dict[str, str] = {
 
     # ── Indstillinger dialog ──────────────────────────────────────────────────
     "settings_dialog_title":        "Indstillinger",
-    "settings_group_location":      "Hjemkoordinat",
     "settings_group_user_locations":                "Brugerplaceringer",
     "settings_group_display":       "Visning",
-    "settings_use_miles":           "Vis afstande i miles (i stedet for km)",
 
 
     "settings_map_label":           "Kortapp:",
@@ -395,11 +392,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Færdig — {updated} opdateret, {skipped} sprunget over, {errors} fejl",
     "update_loc_cancelled":         "Annulleret — {updated} opdateret indtil videre",
     "update_loc_log_placeholder":   "Resultater vises her…",
-    "update_loc_no_db":             "Ingen database åben.",
     "update_loc_nothing_to_do":     "Ingen caches at opdatere med det valgte omfang.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: fejl — {msg}",
-    "update_loc_row_skipped":       "{gc_code}: sprunget over (ingen koordinater)",
 
     # ── Grænsefladedata-dialoger ──────────────────────────────────────────────
     "boundary_dl_title":            "Download grænsefladedata",
@@ -564,7 +559,6 @@ STRINGS: dict[str, str] = {
     # ── Toolbar ekstra ────────────────────────────────────────────────────────
 
     # ── Cache tabel kolonner ──────────────────────────────────────────────────
-    "col_status_icon":  "Status ikon",
     "col_gc_code":      "GC Kode",
     "col_name":         "Navn",
     "col_type":         "Type",
@@ -707,7 +701,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Korrigerede koordinater",
     "corrected_dialog_heading":     "Korrigerede koordinater — {gc_code}",
-    "corrected_dialog_hint":        "Indtast de løste koordinater i DMM, DMS eller DD format. De bruges ved GPS export og vises på kortet.",
     "corrected_dialog_input_label": "Koordinater:",
     "corrected_dialog_original":    "Originale koordinater:",
     "corrected_dialog_corrected":   "Korrigerede koordinater:",
@@ -817,8 +810,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terræn (lettest først)",
     "trip_sort_hidden_date":        "Udgivelsesdato (nyeste først)",
     "trip_sort_name":               "Navn (A–Z)",
-    "trip_cb_not_found":            "Kun caches jeg ikke har fundet",
-    "trip_cb_available":            "Kun tilgængelige (ikke arkiverede)",
     "trip_preview_group":           "Forhåndsvisning",
     "trip_result_label":            "{count} caches valgt til turen",
     "trip_btn_export_gps":          "📤  Send til GPS…",
@@ -835,14 +826,12 @@ STRINGS: dict[str, str] = {
 
 
     "trip_center_info":                        "📍 Radius beregnes fra dit centerpunkt (sat under Indstillinger). Sæt radius til 0 for at se alle caches uden afstandsfilter.",
-    "trip_found_hint":                         "Kræver at du har kørt \"Opdater fund\" (Funktioner-menuen) for at funde caches er markeret korrekt.",
     "trip_no_center_warning":                  "⚠️  Centerpunkt er ikke sat — gå til Indstillinger og angiv dit hjemmepunkt, eller sæt radius til 0.",
 
 
     # ── Hjemmepunkter i indstillinger ────────────────────────────────────────
     "settings_hp_col_lat":                     "Breddegrad",
     "settings_hp_col_lon":                     "Længdegrad",
-    "settings_hp_activate":                    "★ Aktivér",
     "settings_hp_add_group":                   "Tilføj / rediger punkt",
     "settings_hp_name_label":                  "Navn:",
     "settings_hp_name_placeholder":            "f.eks. Hjem, Sommerhus…",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -151,7 +151,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":         "✓ {count} Caches geladen — einen Cache anklicken, um ihn auf der Karte anzusehen",
     "import_log_placeholder":       "Importergebnisse werden hier angezeigt…",
     "import_all_done":            "✓ Alle {count} Dateien verarbeitet.",
-    "import_geocode_checkbox":      "🌍  Fehlende Landkreis / Bundesland / Land nach Import ermitteln",
     "import_geocode_running":       "📍  Fehlende Standortdaten werden ermittelt…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -220,10 +219,8 @@ STRINGS: dict[str, str] = {
 
     # ── Settings dialog ───────────────────────────────────────────────────────
     "settings_dialog_title":        "Einstellungen",
-    "settings_group_location":      "Heimat-Koordinaten",
     "settings_group_user_locations":                "Benutzerstandorte",
     "settings_group_display":       "Anzeige",
-    "settings_use_miles":           "Entfernungen in Meilen anzeigen (anstelle von km)",
 
 
     "settings_map_label":           "Karten-App:",
@@ -395,11 +392,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Fertig — {updated} aktualisiert, {skipped} übersprungen, {errors} Fehler",
     "update_loc_cancelled":         "Abgebrochen — {updated} bisher aktualisiert",
     "update_loc_log_placeholder":   "Ergebnisse erscheinen hier…",
-    "update_loc_no_db":             "Keine Datenbank geöffnet.",
     "update_loc_nothing_to_do":     "Keine Caches mit dem gewählten Umfang zu aktualisieren.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: Fehler — {msg}",
-    "update_loc_row_skipped":       "{gc_code}: übersprungen (keine Koordinaten)",
 
     # ── Grenzpolygon-Dialoge ──────────────────────────────────────────────────
     "boundary_dl_title":            "Grenzpolygon-Pakete herunterladen",
@@ -564,7 +559,6 @@ STRINGS: dict[str, str] = {
     # ── Toolbar extras ────────────────────────────────────────────────────────
 
     # ── Cache table columns ───────────────────────────────────────────────────
-    "col_status_icon":  "Status-Icon",
     "col_gc_code":      "GC-Code",
     "col_name":         "Name",
     "col_type":         "Typ",
@@ -707,7 +701,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Korrigierte Koordinaten",
     "corrected_dialog_heading":     "Korrigierte Koordinaten — {gc_code}",
-    "corrected_dialog_hint":        "Gib die berechneten Koordinaten im DMM-, DMS- oder DD-Format ein. Diese werden für den GPS-Export verwendet und auf der Karte angezeigt.",
     "corrected_dialog_input_label": "Koordinaten:",
     "corrected_dialog_original":    "Originalkoordinaten:",
     "corrected_dialog_corrected":   "Korrigierte Koordinaten:",
@@ -817,8 +810,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terrain (Einfachster zuerst)",
     "trip_sort_hidden_date":        "Versteckdatum (Neuester zuerst)",
     "trip_sort_name":               "Name (A–Z)",
-    "trip_cb_not_found":            "Nur noch nicht gefundene Caches",
-    "trip_cb_available":            "Nur verfügbar (nicht archiviert)",
     "trip_preview_group":           "Vorschau",
     "trip_result_label":            "{count} Caches ausgewählt für diesen Ausflug",
     "trip_btn_export_gps":          "📤  An GPS senden…",
@@ -835,14 +826,12 @@ STRINGS: dict[str, str] = {
 
 
     "trip_center_info":                        "📍 Der Radius wird von deinem Mittelpunkt aus berechnet (festgelegt in den Einstellungen). Stelle den Radius auf 0 ein, um alle Caches ohne Entfernungsfilter anzuzeigen.",
-    "trip_found_hint":                         "Voraussetzung ist, dass Sie die Option \"Funde aktualisieren\" (Menü „Tools“) ausgeführt haben, damit die gefundenen Caches korrekt markiert werden.",
     "trip_no_center_warning":                  "⚠️  Der Mittelpunkt ist nicht festgelegt – gehe zu Einstellungen und gib deinen Startpunkt ein oder stelle den Radius auf 0 ein.",
 
 
     # ── Hjemmepunkter i indstillinger ────────────────────────────────────────
     "settings_hp_col_lat":                     "Breite",
     "settings_hp_col_lon":                     "Länge",
-    "settings_hp_activate":                    "★ Aktivieren",
     "settings_hp_add_group":                   "Punkt hinzufügen / bearbeiten",
     "settings_hp_name_label":                  "Name:",
     "settings_hp_name_placeholder":            "z.B. Heimat, Hütte…",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -151,7 +151,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":         "✓ {count} caches loaded — click a cache to view on map",
     "import_log_placeholder":       "Import results will appear here…",
     "import_all_done":            "✓ All {count} files processed.",
-    "import_geocode_checkbox":      "🌍  Geocode missing county / state / country after import",
     "import_geocode_running":       "📍  Looking up missing location data (offline)…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -220,10 +219,8 @@ STRINGS: dict[str, str] = {
 
     # ── Settings dialog ───────────────────────────────────────────────────────
     "settings_dialog_title":        "Settings",
-    "settings_group_location":      "Home coordinates",
     "settings_group_user_locations":                "User locations",
     "settings_group_display":       "Display",
-    "settings_use_miles":           "Show distances in miles (instead of km)",
 
 
     "settings_map_label":           "Map app:",
@@ -394,11 +391,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Done — {updated} updated, {skipped} skipped, {errors} errors",
     "update_loc_cancelled":         "Cancelled — {updated} updated so far",
     "update_loc_log_placeholder":   "Results will appear here…",
-    "update_loc_no_db":             "No database open.",
     "update_loc_nothing_to_do":     "No waypoints to update with the selected scope.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: error — {msg}",
-    "update_loc_row_skipped":       "{gc_code}: skipped (no coordinates)",
 
     # ── Boundary packs dialogs ────────────────────────────────────────────────
     "boundary_dl_title":            "Download Boundary Packs",
@@ -563,7 +558,6 @@ STRINGS: dict[str, str] = {
     # ── Toolbar extras ────────────────────────────────────────────────────────
 
     # ── Cache table columns ───────────────────────────────────────────────────
-    "col_status_icon":  "Status icon",
     "col_gc_code":      "GC Code",
     "col_name":         "Name",
     "col_type":         "Type",
@@ -706,7 +700,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Corrected Coordinates",
     "corrected_dialog_heading":     "Corrected coordinates — {gc_code}",
-    "corrected_dialog_hint":        "Enter the solved coordinates in DMM, DMS or DD format. These will be used for GPS export and shown on the map.",
     "corrected_dialog_input_label": "Coordinates:",
     "corrected_dialog_original":    "Original coordinates:",
     "corrected_dialog_corrected":   "Corrected coordinates:",
@@ -816,8 +809,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terrain (easiest first)",
     "trip_sort_hidden_date":        "Placed date (newest first)",
     "trip_sort_name":               "Name (A–Z)",
-    "trip_cb_not_found":            "Only caches I have not found",
-    "trip_cb_available":            "Only available (not archived)",
     "trip_preview_group":           "Preview",
     "trip_result_label":            "{count} caches selected for the trip",
     "trip_btn_export_gps":          "📤  Send to GPS…",
@@ -834,14 +825,12 @@ STRINGS: dict[str, str] = {
 
 
     "trip_center_info":                        "📍 Radius is calculated from your centre point (set under Settings). Set radius to 0 to see all caches without distance filtering.",
-    "trip_found_hint":                         "Requires that you have run \"Update finds\" (Tools menu) for found caches to be marked correctly.",
     "trip_no_center_warning":                  "⚠️  Centre point is not set — go to Settings and enter your home point, or set radius to 0.",
 
 
     # ── Hjemmepunkter i indstillinger ────────────────────────────────────────
     "settings_hp_col_lat":                     "Latitude",
     "settings_hp_col_lon":                     "Longitude",
-    "settings_hp_activate":                    "★ Activate",
     "settings_hp_add_group":                   "Add / edit point",
     "settings_hp_name_label":                  "Name:",
     "settings_hp_name_placeholder":            "e.g. Home, Cottage…",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -151,7 +151,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":         "✓ {count} caches chargées — cliquez sur un cache pour voir la carte",
     "import_log_placeholder":       "Les résultats d'importation s'afficheront ici…",
     "import_all_done":            "✓ Les {count} fichiers ont été traités.",
-    "import_geocode_checkbox":      "🌍  Géocoder le département / région / pays manquants après l'import",
     "import_geocode_running":       "📍  Géocodage des données de localisation manquantes…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -220,10 +219,8 @@ STRINGS: dict[str, str] = {
 
     # ── Settings dialog ───────────────────────────────────────────────────────
     "settings_dialog_title":        "Paramètres",
-    "settings_group_location":      "Coordonnées de base",
     "settings_group_user_locations":                "Emplacements utilisateur",
     "settings_group_display":       "Affichage",
-    "settings_use_miles":           "Afficher les distances en miles (au lieu de km)",
 
 
     "settings_map_label":           "Application de carte:",
@@ -395,11 +392,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Terminé — {updated} mis à jour, {skipped} ignorés, {errors} erreurs",
     "update_loc_cancelled":         "Annulé — {updated} mis à jour jusqu'ici",
     "update_loc_log_placeholder":   "Les résultats apparaîtront ici…",
-    "update_loc_no_db":             "Aucune base de données ouverte.",
     "update_loc_nothing_to_do":     "Aucun cache à mettre à jour avec le périmètre sélectionné.",
     "update_loc_row":               "{gc_code} : {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code} : erreur — {msg}",
-    "update_loc_row_skipped":       "{gc_code} : ignoré (pas de coordonnées)",
 
     # ── Boîtes de dialogue packs de frontières ────────────────────────────────
     "boundary_dl_title":            "Télécharger les packs de frontières",
@@ -564,7 +559,6 @@ STRINGS: dict[str, str] = {
     # ── Toolbar extras ────────────────────────────────────────────────────────
 
     # ── Cache table columns ───────────────────────────────────────────────────
-    "col_status_icon":  "Icone de statut",
     "col_gc_code":      "Code GC",
     "col_name":         "Nom",
     "col_type":         "Type",
@@ -707,7 +701,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Coordonnées corrigées",
     "corrected_dialog_heading":     "Coordonnées corrigées — {gc_code}",
-    "corrected_dialog_hint":        "Saisir les coordonnées résolues au format DMM, DMS ou DD. Elles seront utilisées pour l'export GPS et affichées sur la carte.",
     "corrected_dialog_input_label": "Coordonnées :",
     "corrected_dialog_original":    "Coordonnées d'origine :",
     "corrected_dialog_corrected":   "Coordonnées corrigées :",
@@ -817,8 +810,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terrain (plus facile en premier)",
     "trip_sort_hidden_date":        "Date de pose (plus récente en premier)",
     "trip_sort_name":               "Nom (A–Z)",
-    "trip_cb_not_found":            "Uniquement les caches non trouvées",
-    "trip_cb_available":            "Uniquement disponibles (non archivées)",
     "trip_preview_group":           "Aperçu",
     "trip_result_label":            "{count} caches sélectionnées pour la sortie",
     "trip_btn_export_gps":          "📤  Envoyer vers GPS…",
@@ -835,14 +826,12 @@ STRINGS: dict[str, str] = {
 
 
     "trip_center_info":                        "📍 Le rayon est calculé depuis votre point central (défini dans les Paramètres). Mettez le rayon à 0 pour voir toutes les caches sans filtre de distance.",
-    "trip_found_hint":                         "Nécessite que vous ayez exécuté \"Mettre à jour les trouvailles\" (menu Outils) pour que les caches trouvées soient correctement marquées.",
     "trip_no_center_warning":                  "⚠️  Le point central n'est pas défini — allez dans Paramètres et saisissez votre point de départ, ou mettez le rayon à 0.",
 
 
     # ── Hjemmepunkter i indstillinger ────────────────────────────────────────
     "settings_hp_col_lat":                     "Latitude",
     "settings_hp_col_lon":                     "Longitude",
-    "settings_hp_activate":                    "★ Activer",
     "settings_hp_add_group":                   "Ajouter / modifier un point",
     "settings_hp_name_label":                  "Nom :",
     "settings_hp_name_placeholder":            "ex. Domicile, Résidence…",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -154,7 +154,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":          "✓ {count} caches geladen — klik op een cache om op de kaart te zien",
     "import_log_placeholder":       "Importresultaten verschijnen hier…",
     "import_all_done":              "✓ Alle {count} bestanden verwerkt.",
-    "import_geocode_checkbox":      "🌍  Ontbrekende gemeente / provincie / land opzoeken na import",
     "import_geocode_running":       "📍  Ontbrekende locatiegegevens opzoeken (offline)…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -223,10 +222,8 @@ STRINGS: dict[str, str] = {
 
     # ── Settings dialog ───────────────────────────────────────────────────────
     "settings_dialog_title":        "Instellingen",
-    "settings_group_location":      "Thuiscoördinaten",
     "settings_group_user_locations":                "Gebruikerslocaties",
     "settings_group_display":       "Weergave",
-    "settings_use_miles":           "Afstanden weergeven in mijlen (in plaats van km)",
 
 
     "settings_map_label":           "Kaartapp:",
@@ -398,11 +395,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Klaar — {updated} bijgewerkt, {skipped} overgeslagen, {errors} fouten",
     "update_loc_cancelled":         "Geannuleerd — {updated} tot nu toe bijgewerkt",
     "update_loc_log_placeholder":   "Resultaten verschijnen hier…",
-    "update_loc_no_db":             "Geen database geopend.",
     "update_loc_nothing_to_do":     "Geen waypoints om bij te werken met het geselecteerde bereik.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: fout — {msg}",
-    "update_loc_row_skipped":       "{gc_code}: overgeslagen (geen coördinaten)",
 
     # ── Grenspakket-dialoogvensters ───────────────────────────────────────────
     "boundary_dl_title":            "Grenspakketten downloaden",
@@ -566,7 +561,6 @@ STRINGS: dict[str, str] = {
     "detail_no_logs_match":         "(Geen logs gevonden voor '{text}')",
 
     # ── Cache table columns ───────────────────────────────────────────────────
-    "col_status_icon":  "Statuspictogram",
     "col_gc_code":      "GC-code",
     "col_name":         "Naam",
     "col_type":         "Type",
@@ -709,7 +703,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Gecorrigeerde coördinaten",
     "corrected_dialog_heading":     "Gecorrigeerde coördinaten — {gc_code}",
-    "corrected_dialog_hint":        "Voer de opgeloste coördinaten in DMM-, DMS- of DD-formaat in. Deze worden gebruikt voor GPS-export en weergegeven op de kaart.",
     "corrected_dialog_input_label": "Coördinaten:",
     "corrected_dialog_original":    "Originele coördinaten:",
     "corrected_dialog_corrected":   "Gecorrigeerde coördinaten:",
@@ -818,8 +811,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terrein (makkelijkste eerst)",
     "trip_sort_hidden_date":        "Verborgen datum (nieuwste eerst)",
     "trip_sort_name":               "Naam (A–Z)",
-    "trip_cb_not_found":            "Alleen caches die ik nog niet heb gevonden",
-    "trip_cb_available":            "Alleen beschikbaar (niet gearchiveerd)",
     "trip_preview_group":           "Voorbeeld",
     "trip_result_label":            "{count} caches geselecteerd voor de reis",
     "trip_btn_export_gps":          "📤  Naar GPS sturen…",
@@ -835,13 +826,11 @@ STRINGS: dict[str, str] = {
     "toolbar_home_tooltip":         "Kaart centreren op thuispunt",
 
     "trip_center_info":                        "📍 Straal wordt berekend vanuit jouw middelpunt (ingesteld onder Instellingen). Stel straal in op 0 om alle caches zonder afstandsfilter te zien.",
-    "trip_found_hint":                         "Vereist dat je 'Vondsten bijwerken' hebt uitgevoerd (menu Extra's) zodat gevonden caches correct zijn gemarkeerd.",
     "trip_no_center_warning":                  "⚠️  Middelpunt is niet ingesteld — ga naar Instellingen en voer je thuispunt in, of stel straal in op 0.",
 
     # ── Home points in settings ────────────────────────────────────────────
     "settings_hp_col_lat":                     "Breedtegraad",
     "settings_hp_col_lon":                     "Lengtegraad",
-    "settings_hp_activate":                    "★ Activeren",
     "settings_hp_add_group":                   "Punt toevoegen / bewerken",
     "settings_hp_name_label":                  "Naam:",
     "settings_hp_name_placeholder":            "bijv. Thuis, Vakantiehuisje…",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -151,7 +151,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":         "✓ {count} caches carregadas — clique numa cache para ver o mapa",
     "import_log_placeholder":       "Os resultados da importação aparecerão aqui…",
     "import_all_done":            "✓ Todos os {count} ficheiros foram processados.",
-    "import_geocode_checkbox":      "🌍  Geocodificar concelho / estado / país em falta após importação",
     "import_geocode_running":       "📍  A geocodificar dados de localização em falta…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -220,10 +219,8 @@ STRINGS: dict[str, str] = {
 
     # ── Settings dialog ───────────────────────────────────────────────────────
     "settings_dialog_title":        "Configurações",
-    "settings_group_location":      "Coordenadas de casa",
     "settings_group_user_locations":                "Localizações do utilizador",
     "settings_group_display":       "Mostrar",
-    "settings_use_miles":           "Mostrar distâncias em milhas (em vez de km)",
 
 
     "settings_map_label":           "Mapa:",
@@ -395,11 +392,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Concluído — {updated} atualizados, {skipped} ignorados, {errors} erros",
     "update_loc_cancelled":         "Cancelado — {updated} atualizados até agora",
     "update_loc_log_placeholder":   "Os resultados aparecerão aqui…",
-    "update_loc_no_db":             "Nenhuma base de dados aberta.",
     "update_loc_nothing_to_do":     "Nenhuma cache para atualizar com o âmbito selecionado.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: erro — {msg}",
-    "update_loc_row_skipped":       "{gc_code}: ignorado (sem coordenadas)",
 
     # ── Diálogos de pacotes de fronteiras ─────────────────────────────────────
     "boundary_dl_title":            "Transferir pacotes de fronteiras",
@@ -565,7 +560,6 @@ STRINGS: dict[str, str] = {
     # ── Toolbar extras ────────────────────────────────────────────────────────
 
     # ── Cache table columns ───────────────────────────────────────────────────
-    "col_status_icon":  "Ícone de estado",
     "col_gc_code":      "Código GC",
     "col_name":         "Nome",
     "col_type":         "Tipo",
@@ -708,7 +702,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Coordenadas Corrigidas",
     "corrected_dialog_heading":     "Coordenadas corrigidas — {gc_code}",
-    "corrected_dialog_hint":        "Introduza as coordenadas resolvidas no formato DMM, DMS ou DD. Estas serão utilizadas para a exportação GPS e mostradas no mapa.",
     "corrected_dialog_input_label": "Coordenadas:",
     "corrected_dialog_original":    "Coordenadas originais:",
     "corrected_dialog_corrected":   "Coordenadas corrigidas:",
@@ -818,8 +811,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terreno (mais fácil primeiro)",
     "trip_sort_hidden_date":        "Data de colocação (mais recente primeiro)",
     "trip_sort_name":               "Nome (A-Z)",
-    "trip_cb_not_found":            "Apenas caches que não encontrei",
-    "trip_cb_available":            "Apenas disponíveis (não arquivadas)",
     "trip_preview_group":           "Pré-visualização",
     "trip_result_label":            "{count} caches selecionadas para a viagem",
     "trip_btn_export_gps":          "📤  Enviar para GPS…",
@@ -836,14 +827,12 @@ STRINGS: dict[str, str] = {
 
 
     "trip_center_info":                        "📍 O raio é calculado a partir do seu ponto central (definido nas Configurações). Defina o raio como 0 para ver todas as caches sem filtragem por distância.",
-    "trip_found_hint":                         "Requer que tenha executado \"Atualizar encontrados\" (menu Ferramentas) para que as caches encontradas sejam marcadas corretamente.",
     "trip_no_center_warning":                  "⚠️  O ponto central não está definido — vá às Configurações e insira o seu ponto de casa, ou defina o raio para 0.",
 
 
     # ── Hjemmepunkter i indstillinger ────────────────────────────────────────
     "settings_hp_col_lat":                     "Latitude",
     "settings_hp_col_lon":                     "Longitude",
-    "settings_hp_activate":                    "★ Ativar",
     "settings_hp_add_group":                   "Adicionar / editar ponto",
     "settings_hp_name_label":                  "Nome:",
     "settings_hp_name_placeholder":            "ex: Casa, Refúgio…",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -151,7 +151,6 @@ STRINGS: dict[str, str] = {
     "import_table_loaded":         "✓ {count} cacher laddade — klicka på en cache för att se den på kartan",
     "import_log_placeholder":       "Resultatet av importen visas här…",
     "import_all_done":            "✓ Alla {count} filer har bearbetats.",
-    "import_geocode_checkbox":      "🌍  Geokoda saknad kommun / län / land efter import",
     "import_geocode_running":       "📍  Geokoderar saknade platsdata…",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
@@ -220,10 +219,8 @@ STRINGS: dict[str, str] = {
 
     # ── Settings dialog ───────────────────────────────────────────────────────
     "settings_dialog_title":        "Inställningar",
-    "settings_group_location":      "Hemkoordinater",
     "settings_group_user_locations":                "Användarplatser",
     "settings_group_display":       "Visa",
-    "settings_use_miles":           "Visa avstånd i miles (i stället för km)",
 
 
     "settings_map_label":           "Kart app:",
@@ -395,11 +392,9 @@ STRINGS: dict[str, str] = {
     "update_loc_done":              "✓ Klart — {updated} uppdaterade, {skipped} hoppade över, {errors} fel",
     "update_loc_cancelled":         "Avbrutet — {updated} uppdaterade hittills",
     "update_loc_log_placeholder":   "Resultaten visas här…",
-    "update_loc_no_db":             "Ingen databas är öppen.",
     "update_loc_nothing_to_do":     "Inga cacher att uppdatera med det valda omfånget.",
     "update_loc_row":               "{gc_code}: {country} / {state} / {county}",
     "update_loc_row_error":         "{gc_code}: fel — {msg}",
-    "update_loc_row_skipped":       "{gc_code}: hoppades över (inga koordinater)",
 
     # ── Gränspaket-dialoger ───────────────────────────────────────────────────
     "boundary_dl_title":            "Ladda ner gränspaket",
@@ -564,7 +559,6 @@ STRINGS: dict[str, str] = {
     # ── Toolbar extras ────────────────────────────────────────────────────────
     
     # ── Cache table columns ───────────────────────────────────────────────────
-    "col_status_icon":  "Status ikon",
     "col_gc_code":      "GC Kod",
     "col_name":         "Namn",
     "col_type":         "Typ",
@@ -707,7 +701,6 @@ STRINGS: dict[str, str] = {
 
     "corrected_dialog_title":       "Korrigerade koordinater",
     "corrected_dialog_heading":     "Korrigerade koordinater — {gc_code}",
-    "corrected_dialog_hint":        "Ange lösta koordinater i DMM, DMS or DD format. Dessa används vid export till GPS och visas på kartan.",
     "corrected_dialog_input_label": "Koordinater:",
     "corrected_dialog_original":    "Ursprungliga koordinater:",
     "corrected_dialog_corrected":   "Korrigerade koordinater:",
@@ -817,8 +810,6 @@ STRINGS: dict[str, str] = {
     "trip_sort_terrain":            "Terräng (lättast först)",
     "trip_sort_hidden_date":        "Utlagt datum (nyast först)",
     "trip_sort_name":               "Namn (A–Z)",
-    "trip_cb_not_found":            "Bara cacher som jag inte har hittat",
-    "trip_cb_available":            "Bara tillgängliga (inte arkiverade)",
     "trip_preview_group":           "Förhandsvisning",
     "trip_result_label":            "{count} cacher valda för resan",
     "trip_btn_export_gps":          "📤  Skicka till GPS…",
@@ -835,14 +826,12 @@ STRINGS: dict[str, str] = {
 
 
     "trip_center_info":                        "📍 Radien beräknas från din centrumpunkt (ställs in under Inställningar). Ange radien som 0 för att se alla cacher utan avståndsfiltrering.",
-    "trip_found_hint":                         "Kräver att du har kört \"Uppdatera hittade\" (Verktygsmeny) för att hittade cacher ska flaggas rätt.",
     "trip_no_center_warning":                  "⚠️  Centrum är inte satt - gå till Inställning och ange din hemmapunkt eller sätt radien till 0.",
 
 
     # ── Hjemmepunkter i indstillinger ────────────────────────────────────────
     "settings_hp_col_lat":                     "Latitud",
     "settings_hp_col_lon":                     "Longitud",
-    "settings_hp_activate":                    "★ Aktivera",
     "settings_hp_add_group":                   "Lägg till / editera punkt",
     "settings_hp_name_label":                  "Namn:",
     "settings_hp_name_placeholder":            "e.g. Hem, Stugan…",

--- a/tests/unit-tests/test_languages.py
+++ b/tests/unit-tests/test_languages.py
@@ -5,6 +5,7 @@ import pytest
 import ast
 
 LANG_DIR = pathlib.Path("src/opensak/lang")
+SRC_DIR = pathlib.Path("src/opensak")
 REFERENCE_LANG = "en"  # reference language file
 
 def load_strings(file_path: pathlib.Path):
@@ -115,4 +116,40 @@ def test_no_globally_redundant_values():
         "The following key pairs have identical translations in every language "
         "and should be merged into a single key:\n"
         + "\n".join(f"  '{k1}' == '{k2}'  ({repr(v)})" for k1, k2, v in redundant_pairs)
+    )
+
+
+def _collect_string_literals(src_dir: pathlib.Path) -> set[str]:
+    """Return all string literal values found in Python source under src_dir (via AST)."""
+    literals: set[str] = set()
+    for f in sorted(src_dir.rglob("*.py")):
+        if f.parent.name == "lang":
+            continue
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                literals.add(node.value)
+    return literals
+
+
+def test_no_unused_keys():
+    """Every key defined in the reference language file must appear at least once
+    as a string literal in the application source (outside the lang/ package).
+
+    Unused keys are dead translations that bloat every language file and mislead
+    contributors who maintain translations.  Remove the key from all language files
+    (and from this test's assertion message) when it genuinely has no caller.
+    """
+    all_keys = set(ref_strings.keys())
+    used_literals = _collect_string_literals(SRC_DIR)
+    unused = all_keys - used_literals
+
+    assert not unused, (
+        f"{len(unused)} translation key(s) defined in {REFERENCE_LANG}.py are never "
+        "used as string literals in the application source.  Either add a tr() call "
+        "or remove the key from every language file:\n"
+        + "\n".join(f"  {k!r}" for k in sorted(unused))
     )


### PR DESCRIPTION
## Summary

- Adds `test_no_unused_keys` to `test_languages.py`: walks the AST of every non-lang Python source file and fails if any key from `en.py` is never referenced as a string literal anywhere in the application.
- Uses `ast.parse` rather than regex to avoid false positives caused by inter-literal character spans (a regex scanning `"foo"), bar("baz"` would match the span between the two literals as a spurious string).
- Removes the 11 dead keys the test immediately surfaced: `col_status_icon`, `corrected_dialog_hint`, `import_geocode_checkbox`, `settings_group_location`, `settings_hp_activate`, `settings_use_miles`, `trip_cb_available`, `trip_cb_not_found`, `trip_found_hint`, `update_loc_no_db`, `update_loc_row_skipped`.

Closes #397