### PR TITLE
Export personal notes to GPX

### DIFF
--- a/src/opensak/gps/garmin.py
+++ b/src/opensak/gps/garmin.py
@@ -253,6 +253,7 @@ def generate_gpx(caches: list, filename: str = "opensak_export", progress_cb=Non
     gpx.set("creator", "OpenSAK")
     gpx.set("xmlns", "http://www.topografix.com/GPX/1/1")
     gpx.set("xmlns:groundspeak", "http://www.groundspeak.com/cache/1/0/1")
+    gpx.set("xmlns:gsak", "http://www.gsak.net/xmlv1/6")
     gpx.set("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
 
     # Metadata
@@ -359,6 +360,14 @@ def generate_gpx(caches: list, filename: str = "opensak_export", progress_cb=Non
                 gs_text = SubElement(gs_log, "groundspeak:text")
                 gs_text.set("encoded", "False")
                 gs_text.text = (log.text or "")[:500]
+
+        # GSAK personal note
+        note = getattr(cache, "user_note", None)
+        note_text = getattr(note, "note", None) if note else None
+        if note_text:
+            gsak_ext = SubElement(extensions, "gsak:wptExtension")
+            gsak_note = SubElement(gsak_ext, "gsak:UserNote")
+            gsak_note.text = note_text
 
     _indent(gpx)
     return '<?xml version="1.0" encoding="utf-8"?>\n' + ET.tostring(

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -310,7 +310,9 @@ def _parse_wpt(wpt_el) -> Optional[dict]:
     gsak_user_note: Optional[str] = None
 
     for gsak_uri in _GSAK_NAMESPACES:
-        gsak_ext = wpt_el.find(f"{{{gsak_uri}}}wptExtension")
+        # Search descendants: gsak:wptExtension may be a direct <wpt> child (GSAK
+        # format) or nested inside <extensions> (OpenSAK GPX 1.1 export).
+        gsak_ext = wpt_el.find(f".//{{{gsak_uri}}}wptExtension")
         if gsak_ext is not None:
             ftf_el = gsak_ext.find(f"{{{gsak_uri}}}FirstToFind")
             if ftf_el is not None and ftf_el.text:

--- a/tests/unit-tests/test_export_import_roundtrip.py
+++ b/tests/unit-tests/test_export_import_roundtrip.py
@@ -1,10 +1,11 @@
-"""tests/unit-tests/test_export_import_roundtrip.py — exported GPX must re-import.
+# tests/unit-tests/test_export_import_roundtrip.py — exported GPX must re-import.
+# Regression: exports wrap groundspeak:cache in <extensions> (GPX 1.1); the importer
+# once read it only as a direct <wpt> child, so re-import gave 0 caches.
 
-Regression: exports wrap groundspeak:cache in <extensions> (GPX 1.1); the importer once read it only as a direct <wpt> child, so re-import gave 0 caches.
-"""
+from types import SimpleNamespace
 
 from opensak.db.database import init_db, get_session, reload_caches_full
-from opensak.db.models import Cache
+from opensak.db.models import Cache, UserNote
 from opensak.importer import import_gpx
 from opensak.gps.garmin import generate_gpx
 from tests.data import SAMPLE_GPX, write_gpx
@@ -75,3 +76,31 @@ def test_exported_gpx_reimports_with_full_data(tmp_path):
         assert rows["GC12345"].cache_type == "Traditional Cache"
         assert rows["GC12345"].encoded_hints == "Under a rock."
         assert len(rows["GC12345"].logs) == 2
+
+
+def test_personal_note_survives_gpx_roundtrip(tmp_path):
+    # Build a minimal cache stub with a personal note attached.
+    note = SimpleNamespace(is_corrected=False, corrected_lat=None, corrected_lon=None, note="My field note")
+    cache = SimpleNamespace(
+        id=1, gc_code="GCNOTE1", name="Note Cache", cache_type="Traditional Cache",
+        latitude=55.0, longitude=12.0, difficulty=1.5, terrain=2.0,
+        placed_by="Owner", available=True, archived=False, country="Denmark",
+        encoded_hints=None, hidden_date=None, logs=[], user_note=note, container="Regular",
+    )
+
+    exported = generate_gpx([cache], "note_roundtrip")
+    assert "gsak:UserNote" in exported
+    assert "My field note" in exported
+
+    out = tmp_path / "note_roundtrip.gpx"
+    out.write_text(exported, encoding="utf-8")
+
+    init_db(db_path=tmp_path / "dst.db")
+    with get_session() as s:
+        result = import_gpx(out, s)
+
+    assert result.created == 1
+    with get_session() as s:
+        c = s.query(Cache).filter_by(gc_code="GCNOTE1").one()
+        assert c.user_note is not None
+        assert c.user_note.note == "My field note"

--- a/tests/unit-tests/test_garmin.py
+++ b/tests/unit-tests/test_garmin.py
@@ -81,11 +81,12 @@ def _log(log_id="1", log_type="Found it", finder="Tester", text="TFTC", log_date
     )
 
 
-def _note(is_corrected=True, corrected_lat=55.0, corrected_lon=12.0):
+def _note(is_corrected=True, corrected_lat=55.0, corrected_lon=12.0, note=None):
     return SimpleNamespace(
         is_corrected=is_corrected,
         corrected_lat=corrected_lat,
         corrected_lon=corrected_lon,
+        note=note,
     )
 
 
@@ -207,6 +208,26 @@ class TestGenerateGpx:
         result = generate_gpx([c])
         assert "Original" in result
         assert "55.000000" in result
+
+    def test_user_note_emitted_as_gsak_element(self):
+        n = _note(is_corrected=False, note="My personal note")
+        result = generate_gpx([_cache(user_note=n)])
+        assert "gsak:UserNote" in result
+        assert "My personal note" in result
+
+    def test_gsak_namespace_declared_when_note_present(self):
+        n = _note(is_corrected=False, note="A note")
+        result = generate_gpx([_cache(user_note=n)])
+        assert "http://www.gsak.net/xmlv1/6" in result
+
+    def test_no_gsak_extension_when_note_absent(self):
+        result = generate_gpx([_cache(user_note=None)])
+        assert "gsak:wptExtension" not in result
+
+    def test_no_gsak_extension_when_note_is_empty_string(self):
+        n = _note(is_corrected=False, note="")
+        result = generate_gpx([_cache(user_note=n)])
+        assert "gsak:wptExtension" not in result
 
     def test_empty_cache_list_produces_valid_gpx(self):
         result = generate_gpx([])


### PR DESCRIPTION
`generate_gpx()` was silently dropping personal notes on export. Notes entered in OpenSAK would disappear when the file was re-imported into GSAK.

The fix has two parts:

**Exporter (`garmin.py`):** declare `xmlns:gsak="http://www.gsak.net/xmlv1/6"` on the GPX root and emit `<gsak:wptExtension><gsak:UserNote>` when `cache.user_note.note` is non-empty.

**Importer (`importer/__init__.py`):** the `gsak:wptExtension` search used `find(...)` (direct children only), so it already missed the element when re-importing OpenSAK's own GPX 1.1 output (where the extension sits inside `<extensions>`). Changed to `find(".//..")` to handle both the GSAK format (direct `<wpt>` child) and the OpenSAK GPX 1.1 format (nested inside `<extensions>`).

Closes #391