### PR TITLE
Distance Computation - deprecate the feature flag

### DIFF
--- a/docs/architecture/distance-computation.md
+++ b/docs/architecture/distance-computation.md
@@ -4,13 +4,13 @@
 
 ## Problem with the legacy approach
 
-Before this flag, distance was recomputed on **every `_refresh_cache_list()` call** — which fires on every filter change, sort change, search keystroke, import, and dialog close. For a database with tens of thousands of caches this meant running the same Haversine batch dozens of times per session, even when neither the cache coordinates nor the centre point had changed.
+Previously, distance was recomputed on **every `_refresh_cache_list()` call** — which fires on every filter change, sort change, search keystroke, import, and dialog close. For a database with tens of thousands of caches this meant running the same Haversine batch dozens of times per session, even when neither the cache coordinates nor the centre point had changed.
 
 There was also a secondary inefficiency: when the sort column was `distance`, `apply_filters()` computed it a second time in a per-row scalar loop independently of the vectorised batch already computed by the table model.
 
 ---
 
-## New design (flag ON)
+## Design
 
 ### One write per centre-point change, zero writes per refresh
 
@@ -37,11 +37,9 @@ user changes centre point
 
 ### SQL-level sort
 
-When the flag is ON, `_sql_order_expr("distance")` returns `COALESCE(caches.distance, 99999.0)`, so `apply_filters()` can push `ORDER BY distance` into SQLite instead of sorting in Python after loading all rows.
+`_sql_order_expr("distance")` returns `COALESCE(caches.distance, 99999.0)`, so `apply_filters()` pushes `ORDER BY distance` into SQLite instead of sorting in Python after loading all rows.
 
 ### Table model
-
-`CacheTableModel._update_distances()` dispatches on the flag:
 
 `CacheTableModel._update_distances()` reads `cache.distance` / `cache.bearing` from the already-loaded ORM objects — no recomputation on refresh.
 
@@ -75,8 +73,8 @@ Vincenty does not vectorise cleanly (it is iterative), so the batch form is a pl
 ### Dispatcher
 
 ```python
-distance_km(lat1, lon1, lat2, lon2)         # scalar — reads flag + setting
-distance_km_batch(lat0, lon0, lats, lons)   # batch  — reads flag + setting
+distance_km(lat1, lon1, lat2, lon2)         # scalar — reads distance_method setting
+distance_km_batch(lat0, lon0, lats, lons)   # batch  — reads distance_method setting
 ```
 
 Both read `AppSettings.distance_method` and dispatch accordingly.
@@ -95,7 +93,6 @@ Both read `AppSettings.distance_method` and dispatch accordingly.
 | `src/opensak/gui/dialogs/settings_dialog.py` | Added "Distance Calculation" group in Advanced tab |
 | `src/opensak/lang/en.py` + all others | Added `settings_group_distance`, `settings_distance_method_label`, `settings_distance_haversine`, `settings_distance_vincenty`, `settings_distance_hint` |
 | `tests/unit-tests/test_distance.py` | Added Vincenty tests, dispatcher tests, `recalculate_distances()` tests |
-| `tests/unit-tests/test_flags.py` | Added `TestDistanceComputation` class; updated default-flags assertions |
 
 ---
 

--- a/features.json
+++ b/features.json
@@ -1,5 +1,4 @@
 {
   "update-location": false,
-  "reverse-geocoding": false,
-  "distance-computation": true
+  "reverse-geocoding": false
 }

--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -138,8 +138,7 @@ def vincenty_km_batch(lat0: float, lon0: float, lats, lons):
 def distance_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Scalar distance (km) dispatched by the user's distance_method setting."""
     from opensak.gui.settings import get_settings
-    from opensak.utils import flags
-    if flags.distance_computation and get_settings().distance_method == "vincenty":
+    if get_settings().distance_method == "vincenty":
         return _vincenty_km(lat1, lon1, lat2, lon2)
     return _haversine_km(lat1, lon1, lat2, lon2)
 
@@ -147,8 +146,7 @@ def distance_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 def distance_km_batch(lat0: float, lon0: float, lats, lons):
     """Batch distance (km) dispatched by the user's distance_method setting."""
     from opensak.gui.settings import get_settings
-    from opensak.utils import flags
-    if flags.distance_computation and get_settings().distance_method == "vincenty":
+    if get_settings().distance_method == "vincenty":
         return vincenty_km_batch(lat0, lon0, lats, lons)
     return haversine_km_batch(lat0, lon0, lats, lons)
 
@@ -1150,12 +1148,10 @@ def _sql_order_expr(field: str):
     reproduces the Python key exactly (COALESCE for the ``x or default``
     fallbacks). Text fields are deliberately excluded — SQLite's lower() is
     ASCII-only and would diverge from Python's Unicode str.lower() on accented
-    values. When the distance-computation flag is ON, distance is stored in the
-    DB column and can be ordered in SQL; otherwise it stays in Python.
+    values. Distance is stored in the DB column and ordered in SQL via COALESCE.
     """
-    from opensak.utils import flags
     from sqlalchemy import func
-    distance_expr = func.coalesce(Cache.distance, 99999.0) if flags.distance_computation else None
+    distance_expr = func.coalesce(Cache.distance, 99999.0)
     exprs = {
         # Numeric (mirror "x or 0.0/0/999999")
         "difficulty":      func.coalesce(Cache.difficulty, 0.0),
@@ -1383,17 +1379,12 @@ def apply_filters(
     # Python filter pass below preserves row order, so a SQL-ordered result
     # stays ordered. A trailing Cache.id keeps the order identical to Python's
     # stable sort (ties retain the id-ascending load order).
-    # When distance-computation flag is ON the DB column is pre-populated so
-    # distance sort is also pushed to SQL via _sql_order_expr; otherwise it
-    # falls back to the Python scalar loop further below.
-    from opensak.utils import flags as _flags
     sql_sorted = False
-    if not (sort.field == "distance" and distance_from and not _flags.distance_computation):
-        order_expr = _sql_order_expr(sort.field)
-        if order_expr is not None:
-            direction = order_expr.asc() if sort.ascending else order_expr.desc()
-            query = query.order_by(direction, Cache.id.asc())
-            sql_sorted = True
+    order_expr = _sql_order_expr(sort.field)
+    if order_expr is not None:
+        direction = order_expr.asc() if sort.ascending else order_expr.desc()
+        query = query.order_by(direction, Cache.id.asc())
+        sql_sorted = True
 
     all_caches = query.all()
 
@@ -1403,16 +1394,9 @@ def apply_filters(
     else:
         results = list(all_caches)
 
-    # Sort in Python only for fields not handled by SQL above.
-    # Distance stays in Python only when the flag is OFF (legacy path).
+    # Sort in Python only for fields not handled by SQL.
     if not sql_sorted:
-        if sort.field == "distance" and distance_from and not _flags.distance_computation:
-            lat, lon = distance_from
-            results.sort(
-                key=lambda c: _haversine_km(lat, lon, c.latitude or 0, c.longitude or 0),
-                reverse=not sort.ascending,
-            )
-        elif sort.field in SORT_FIELDS:
+        if sort.field in SORT_FIELDS:
             results.sort(key=SORT_FIELDS[sort.field], reverse=not sort.ascending)
 
     if limit:

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -15,7 +15,7 @@ from PySide6.QtGui import QColor, QFont
 from PySide6.QtWidgets import QTableView, QHeaderView, QAbstractItemView, QMenu, QApplication
 
 from opensak.db.models import Cache
-from opensak.filters.engine import _haversine_km, haversine_km_batch
+from opensak.filters.engine import _haversine_km
 from opensak.gui.settings import get_settings
 from opensak.coords import format_coords, format_lat, format_lon, format_lat, format_lon
 from opensak.lang import tr
@@ -521,35 +521,13 @@ class CacheTableModel(QAbstractTableModel):
         self.endResetModel()
 
     def _update_distances(self) -> None:
-        from opensak.utils import flags as _flags
         self._distances = {}
         self._bearings = {}
-
-        if _flags.distance_computation:
-            # Flag ON: distance and bearing are pre-computed in the DB by
-            # recalculate_distances(); just read from the already-loaded objects.
-            for c in self._caches:
-                if c.distance is not None:
-                    self._distances[c.id] = float(c.distance)
-                if c.bearing is not None:
-                    self._bearings[c.id] = float(c.bearing)
-            return
-
-        # Flag OFF (legacy): vectorised on-the-fly computation per refresh.
-        settings = get_settings()
-        valid = [
-            c for c in self._caches
-            if c.latitude is not None and c.longitude is not None
-        ]
-        if not valid:
-            return
-        lats = [c.latitude for c in valid]
-        lons = [c.longitude for c in valid]
-        dists = haversine_km_batch(settings.home_lat, settings.home_lon, lats, lons)
-        bears = _bearing_deg_batch(settings.home_lat, settings.home_lon, lats, lons)
-        for i, c in enumerate(valid):
-            self._distances[c.id] = float(dists[i])
-            self._bearings[c.id] = float(bears[i])
+        for c in self._caches:
+            if c.distance is not None:
+                self._distances[c.id] = float(c.distance)
+            if c.bearing is not None:
+                self._bearings[c.id] = float(c.bearing)
 
     def cache_at(self, row: int) -> Optional[Cache]:
         if 0 <= row < len(self._caches):

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -443,28 +443,25 @@ class SettingsDialog(QDialog):
 
         layout.addWidget(update_group)
 
-        # ── Distance calculation (only when distance-computation flag is ON) ──
-        if flags.distance_computation:
-            dist_group = QGroupBox(tr("settings_group_distance"))
-            dist_layout = QVBoxLayout(dist_group)
+        # ── Distance calculation ───────────────────────────────────────────────
+        dist_group = QGroupBox(tr("settings_group_distance"))
+        dist_layout = QVBoxLayout(dist_group)
 
-            method_row = QHBoxLayout()
-            method_row.addWidget(QLabel(tr("settings_distance_method_label")))
-            self._distance_method_combo: QComboBox | None = QComboBox()
-            self._distance_method_combo.addItem(tr("settings_distance_haversine"), "haversine")
-            self._distance_method_combo.addItem(tr("settings_distance_vincenty"),  "vincenty")
-            method_row.addWidget(self._distance_method_combo)
-            method_row.addStretch()
-            dist_layout.addLayout(method_row)
+        method_row = QHBoxLayout()
+        method_row.addWidget(QLabel(tr("settings_distance_method_label")))
+        self._distance_method_combo: QComboBox = QComboBox()
+        self._distance_method_combo.addItem(tr("settings_distance_haversine"), "haversine")
+        self._distance_method_combo.addItem(tr("settings_distance_vincenty"),  "vincenty")
+        method_row.addWidget(self._distance_method_combo)
+        method_row.addStretch()
+        dist_layout.addLayout(method_row)
 
-            dist_hint = QLabel(tr("settings_distance_hint"))
-            dist_hint.setWordWrap(True)
-            dist_hint.setStyleSheet("color: gray; font-size: 10px;")
-            dist_layout.addWidget(dist_hint)
+        dist_hint = QLabel(tr("settings_distance_hint"))
+        dist_hint.setWordWrap(True)
+        dist_hint.setStyleSheet("color: gray; font-size: 10px;")
+        dist_layout.addWidget(dist_hint)
 
-            layout.addWidget(dist_group)
-        else:
-            self._distance_method_combo = None
+        layout.addWidget(dist_group)
 
         layout.addStretch()
         return tab
@@ -949,9 +946,8 @@ class SettingsDialog(QDialog):
         if self._nominatim_cb is not None:
             self._nominatim_cb.setChecked(s.nominatim_enabled)
         self._update_check_cb.setChecked(s.updates_check_enabled)
-        if self._distance_method_combo is not None:
-            idx = self._distance_method_combo.findData(s.distance_method)
-            self._distance_method_combo.setCurrentIndex(idx if idx >= 0 else 0)
+        idx = self._distance_method_combo.findData(s.distance_method)
+        self._distance_method_combo.setCurrentIndex(idx if idx >= 0 else 0)
         # Opdater GC-status
         self._refresh_gc_status_on_open()
 
@@ -992,8 +988,7 @@ class SettingsDialog(QDialog):
         if self._nominatim_cb is not None:
             s.nominatim_enabled = self._nominatim_cb.isChecked()
         s.updates_check_enabled = self._update_check_cb.isChecked()
-        if self._distance_method_combo is not None:
-            s.distance_method = self._distance_method_combo.currentData()
+        s.distance_method = self._distance_method_combo.currentData()
         s.sync()
 
         # Database-mappe — kun gem og advar hvis brugeren faktisk har ændret den

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -1267,11 +1267,8 @@ class MainWindow(QMainWindow):
                 s.set_active_home(point)
                 # Pan kort til ny lokation — INGEN HTML reload
                 self._map_widget.pan_to_location(point.lat, point.lon, point.name)
-                # When flag is ON: write distances to DB once; table reads the column.
-                from opensak.utils import flags as _flags
-                if _flags.distance_computation:
-                    from opensak.db.database import recalculate_distances
-                    recalculate_distances(point.lat, point.lon)
+                from opensak.db.database import recalculate_distances
+                recalculate_distances(point.lat, point.lon)
                 # Opdater distances i cache-listen
                 self._refresh_cache_list()
                 self._update_info_bar()
@@ -1282,12 +1279,10 @@ class MainWindow(QMainWindow):
 
     def _initial_load(self) -> None:
         """Første load ved opstart — vent på kort hvis ikke klar."""
-        from opensak.utils import flags as _flags
-        if _flags.distance_computation:
-            s = get_settings()
-            if s.home_lat and s.home_lon:
-                from opensak.db.database import recalculate_distances
-                recalculate_distances(s.home_lat, s.home_lon)
+        s = get_settings()
+        if s.home_lat and s.home_lon:
+            from opensak.db.database import recalculate_distances
+            recalculate_distances(s.home_lat, s.home_lon)
         if not self._map_widget.is_ready():
             self._map_widget.set_pending_refresh(self._refresh_cache_list)
         else:

--- a/src/opensak/gui/settings.py
+++ b/src/opensak/gui/settings.py
@@ -232,7 +232,6 @@ class AppSettings:
     def distance_method(self) -> str:
         """Distance calculation method — 'haversine' (default) or 'vincenty'.
 
-        Only used when the distance-computation feature flag is ON.
         Haversine matches Groundspeak's behaviour; Vincenty WGS84 is more
         accurate (~0.3 % improvement for long distances).
         """

--- a/src/opensak/utils/flags.py
+++ b/src/opensak/utils/flags.py
@@ -30,7 +30,6 @@ _FEATURES_FILE: Path = Path(__file__).parent.parent.parent.parent / "features.js
 _RELEASE_DEFAULTS: dict[str, bool] = {
     "update-location": False,
     "reverse-geocoding": False,
-    "distance-computation": False,
 }
 
 
@@ -73,4 +72,3 @@ _flags = _load()
 
 update_location: bool      = _flags["update-location"]
 reverse_geocoding: bool    = _flags["reverse-geocoding"]
-distance_computation: bool = _flags["distance-computation"]

--- a/tests/unit-tests/test_distance.py
+++ b/tests/unit-tests/test_distance.py
@@ -3,7 +3,7 @@
 Batch (numpy) haversine/bearing must match the scalar versions, and the bbox
 pre-narrow must return the same caches as the exact Python filter.
 Also covers Vincenty accuracy, distance_km_batch dispatcher, and
-recalculate_distances() DB population (distance-computation feature flag).
+recalculate_distances() DB population.
 """
 
 import math
@@ -176,8 +176,7 @@ def test_vincenty_coincident_points():
 
 # ── distance_km / distance_km_batch dispatcher ────────────────────────────────
 
-def test_dispatcher_uses_haversine_by_default(patch_features_file, monkeypatch):
-    patch_features_file({"distance-computation": True})
+def test_dispatcher_uses_haversine_by_default(monkeypatch):
     from opensak.gui import settings as smod
     monkeypatch.setattr(smod.get_settings(), "distance_method", "haversine")
     d = distance_km(55.6761, 12.5683, 56.1629, 10.2039)
@@ -185,22 +184,11 @@ def test_dispatcher_uses_haversine_by_default(patch_features_file, monkeypatch):
     assert d == pytest.approx(expected, abs=1e-9)
 
 
-def test_dispatcher_uses_vincenty_when_set(patch_features_file, monkeypatch):
-    patch_features_file({"distance-computation": True})
+def test_dispatcher_uses_vincenty_when_set(monkeypatch):
     from opensak.gui import settings as smod
     monkeypatch.setattr(smod.get_settings(), "distance_method", "vincenty")
     d = distance_km(55.6761, 12.5683, 56.1629, 10.2039)
     expected = _vincenty_km(55.6761, 12.5683, 56.1629, 10.2039)
-    assert d == pytest.approx(expected, abs=1e-9)
-
-
-def test_dispatcher_ignores_method_when_flag_off(patch_features_file, monkeypatch):
-    patch_features_file({"distance-computation": False})
-    from opensak.gui import settings as smod
-    monkeypatch.setattr(smod.get_settings(), "distance_method", "vincenty")
-    # Flag is OFF → always Haversine regardless of method setting
-    d = distance_km(55.6761, 12.5683, 56.1629, 10.2039)
-    expected = _haversine_km(55.6761, 12.5683, 56.1629, 10.2039)
     assert d == pytest.approx(expected, abs=1e-9)
 
 

--- a/tests/unit-tests/test_flags.py
+++ b/tests/unit-tests/test_flags.py
@@ -11,7 +11,6 @@ class TestLoad:
         assert flags_module._flags == {
             "update-location": False,
             "reverse-geocoding": False,
-            "distance-computation": False,
         }
 
     def test_present_file_overrides_defaults(self, patch_features_file):
@@ -26,7 +25,6 @@ class TestLoad:
         assert result == {
             "update-location": False,
             "reverse-geocoding": False,
-            "distance-computation": False,
         }
 
     def test_unknown_keys_in_file_are_ignored(self, patch_features_file):
@@ -52,19 +50,6 @@ class TestReverseGeocoding:
     def test_false_when_explicitly_disabled_in_file(self, patch_features_file):
         patch_features_file({"reverse-geocoding": False})
         assert flags_module.reverse_geocoding is False
-
-
-class TestDistanceComputation:
-    def test_false_by_default_when_file_absent(self, no_features_file):
-        assert flags_module.distance_computation is False
-
-    def test_true_when_enabled_in_file(self, patch_features_file):
-        patch_features_file({"distance-computation": True})
-        assert flags_module.distance_computation is True
-
-    def test_false_when_explicitly_disabled_in_file(self, patch_features_file):
-        patch_features_file({"distance-computation": False})
-        assert flags_module.distance_computation is False
 
 
 # ── _parse_argv() ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Remove the `distance-computation` feature flag entirely. The new distance engine is now unconditional.

## Changes

**Deleted references (10 files):**
- `features.json` — removed `"distance-computation"` entry
- `src/opensak/utils/flags.py` — removed from `_RELEASE_DEFAULTS` and public attribute
- `src/opensak/filters/engine.py` — removed flag guards in `distance_km`, `distance_km_batch`, `_sql_order_expr`, and `apply_filters`; deleted the legacy Python scalar sort path for distance
- `src/opensak/gui/mainwindow.py` — `recalculate_distances()` is now called unconditionally in `_on_home_changed()` and `_initial_load()`
- `src/opensak/gui/cache_table.py` — `_update_distances()` always reads from the ORM column; removed legacy Haversine batch path and unused `haversine_km_batch` import
- `src/opensak/gui/settings.py` — removed flag caveat from `distance_method` docstring
- `src/opensak/gui/dialogs/settings_dialog.py` — Distance Calculation group is always rendered; removed `None` guards in load/save
- `tests/unit-tests/test_distance.py` — removed `patch_features_file` calls from dispatcher tests; deleted `test_dispatcher_ignores_method_when_flag_off`
- `tests/unit-tests/test_flags.py` — removed `TestDistanceComputation` class and `distance-computation` entries from default-flags assertions
- `docs/architecture/distance-computation.md` — removed all flag-conditional language

Closes #363