### PR TITLE
MW Issue 1 — Type icons are too small and hard to distinguish in the grid

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -482,7 +482,7 @@ class CacheDetailPanel(QWidget):
             dnf = getattr(self, "_current_dnf", False)
             pixmap = get_cache_type_pixmap_composite(cache_type, icon_size, found=found, dnf=dnf)
             self._type_icon_lbl.setPixmap(pixmap)
-            self._type_icon_lbl.setFixedSize(icon_size, icon_size)
+            self._type_icon_lbl.setFixedSize(pixmap.width(), pixmap.height())
 
         self._title.update()
 

--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -23,6 +23,7 @@ from opensak.db.models import Cache
 from opensak.lang import tr
 from opensak.coords import format_coords
 from opensak.gui.settings import get_settings
+from opensak.gui.icon_provider import get_cache_type_pixmap
 from opensak.utils.types import DateFormat, TEXT_SIZE_MAP, norm_locale_date_fmt
 from opensak.hint_detect import split_hint
 
@@ -86,13 +87,24 @@ class CacheDetailPanel(QWidget):
         layout.setSpacing(4)
 
         # ── Header ────────────────────────────────────────────────────────────
+        header_row = QHBoxLayout()
+        header_row.setSpacing(8)
+        header_row.setContentsMargins(0, 0, 0, 0)
+
+        self._type_icon_lbl = QLabel()
+        self._type_icon_lbl.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft)
+        self._type_icon_lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        header_row.addWidget(self._type_icon_lbl)
+
         self._title = QLabel(tr("detail_select_cache"))
         font = QFont()
         font.setPointSize(TEXT_SIZE_MAP[get_settings().text_size]["label"])
         font.setBold(True)
         self._title.setFont(font)
         self._title.setWordWrap(True)
-        layout.addWidget(self._title)
+        header_row.addWidget(self._title, 1)
+
+        layout.addLayout(header_row)
 
         # ── Meta row (GC code | Type | D/T | Container | Country) ────────────
         meta_frame = QFrame()
@@ -441,27 +453,36 @@ class CacheDetailPanel(QWidget):
     def _apply_ui_sizes(self) -> None:
         """Re-apply text/icon sizes from current settings. Called after settings change."""
         sizes = TEXT_SIZE_MAP[get_settings().text_size]
-        
+
         # Title (main label)
         font = self._title.font()
         font.setPointSize(sizes["label"])
         font.setBold(True)
         self._title.setFont(font)
-        
+
         # Metadata labels (GC Code, Type, D/T, Container, Country, Coords)
-        for lbl in [self._gc_code_lbl, self._type_lbl, self._dt_lbl, 
+        for lbl in [self._gc_code_lbl, self._type_lbl, self._dt_lbl,
                     self._container_lbl, self._country_lbl, self._coords_lbl]:
             font = lbl.font()
             font.setPointSize(sizes["secondary"])
             font.setBold(True)
             lbl.setFont(font)
-        
+
         # Corrected coords label
         font = self._corrected_lbl.font()
         font.setPointSize(sizes["secondary"])
         font.setBold(True)
         self._corrected_lbl.setFont(font)
-        
+
+        # Type icon — re-render at new size if a cache is shown
+        icon_size = sizes["detail_icon"]
+        cache_type = getattr(self, "_current_cache_type", None)
+        if cache_type is not None:
+            found = getattr(self, "_current_found", False)
+            pixmap = get_cache_type_pixmap(cache_type, icon_size, found=found)
+            self._type_icon_lbl.setPixmap(pixmap)
+            self._type_icon_lbl.setFixedSize(icon_size, icon_size)
+
         self._title.update()
 
     def refresh_sizes(self) -> None:
@@ -473,6 +494,9 @@ class CacheDetailPanel(QWidget):
         self._current_lon: float | None = None
         self._corrected_lat = None
         self._corrected_lon = None
+        self._current_cache_type: str | None = None
+        self._current_found: bool = False
+        self._type_icon_lbl.clear()
         self._coords_lbl.setStyleSheet("")
         self._title.setText(tr("detail_select_cache"))
         self._gc_code_lbl.setText("—")
@@ -508,7 +532,11 @@ class CacheDetailPanel(QWidget):
         found_mark = " ✓" if cache.found else ""
         archived_mark = tr("detail_archived_mark") if cache.archived else ""
         self._title.setText(f"{cache.name}{found_mark}{archived_mark}")
-        self._apply_ui_sizes()  # Re-apply sizes after settings change
+
+        # Type icon — store for resize and render at current size
+        self._current_cache_type = cache.cache_type
+        self._current_found = cache.found or False
+        self._apply_ui_sizes()  # Re-apply sizes (also renders the icon)
 
         # Meta — GC kode som klikbart link
         gc = cache.gc_code or "—"

--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -23,7 +23,7 @@ from opensak.db.models import Cache
 from opensak.lang import tr
 from opensak.coords import format_coords
 from opensak.gui.settings import get_settings
-from opensak.gui.icon_provider import get_cache_type_pixmap
+from opensak.gui.icon_provider import get_cache_type_pixmap_composite
 from opensak.utils.types import DateFormat, TEXT_SIZE_MAP, norm_locale_date_fmt
 from opensak.hint_detect import split_hint
 
@@ -479,7 +479,8 @@ class CacheDetailPanel(QWidget):
         cache_type = getattr(self, "_current_cache_type", None)
         if cache_type is not None:
             found = getattr(self, "_current_found", False)
-            pixmap = get_cache_type_pixmap(cache_type, icon_size, found=found)
+            dnf = getattr(self, "_current_dnf", False)
+            pixmap = get_cache_type_pixmap_composite(cache_type, icon_size, found=found, dnf=dnf)
             self._type_icon_lbl.setPixmap(pixmap)
             self._type_icon_lbl.setFixedSize(icon_size, icon_size)
 
@@ -496,6 +497,7 @@ class CacheDetailPanel(QWidget):
         self._corrected_lon = None
         self._current_cache_type: str | None = None
         self._current_found: bool = False
+        self._current_dnf: bool = False
         self._type_icon_lbl.clear()
         self._coords_lbl.setStyleSheet("")
         self._title.setText(tr("detail_select_cache"))
@@ -535,7 +537,8 @@ class CacheDetailPanel(QWidget):
 
         # Type icon — store for resize and render at current size
         self._current_cache_type = cache.cache_type
-        self._current_found = cache.found or False
+        self._current_found = bool(cache.found)
+        self._current_dnf = bool(cache.dnf)
         self._apply_ui_sizes()  # Re-apply sizes (also renders the icon)
 
         # Meta — GC kode som klikbart link

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -672,14 +672,13 @@ class CacheTableModel(QAbstractTableModel):
     def _decoration_value(self, cache: Cache, col: str):
         """Return QIcon for columns that show icons."""
         if col == "cache_type":
-            return get_cache_type_icon(
-                self._type_icon_key(cache),
-                size=24,
-            )
+            icon_size = TEXT_SIZE_MAP[get_settings().text_size]["grid_icon"]
+            return get_cache_type_icon(self._type_icon_key(cache), size=icon_size)
         if col == "container":
             if get_container_display() == "text":
                 return None
-            return get_cache_size_icon(self._size_icon_key(cache), size=20)
+            icon_size = TEXT_SIZE_MAP[get_settings().text_size]["grid_icon"]
+            return get_cache_size_icon(self._size_icon_key(cache), size=icon_size)
         if col == "user_flag" and not cache.user_flag:
             return get_flag_placeholder_icon(16)
         return None

--- a/src/opensak/gui/icon_provider.py
+++ b/src/opensak/gui/icon_provider.py
@@ -413,8 +413,19 @@ def _get_found_svg_for_key(key: str) -> str:
     svg = _get_found_svg(key)
     if svg:
         return svg
-    # Fallback til generisk found ikon
     return _FALLBACK_SVGS.get("found", _FALLBACK_SVGS["unknown"])
+
+
+def _get_found_overlay_svg() -> str:
+    """Gold smiley used as the fixed overlay for found caches (all types)."""
+    svg = _read_svg_file(_CACHE_FOUND_DIR / "found_cache_smiley_gold.svg")
+    return svg if svg else _FALLBACK_SVGS.get("found", _FALLBACK_SVGS["unknown"])
+
+
+def _get_dnf_overlay_svg() -> str:
+    """Dark-blue smiley used as the fixed overlay for DNF caches (all types)."""
+    svg = _read_svg_file(_CACHE_FOUND_DIR / "found_cache_smiley_dark_blue.svg")
+    return svg if svg else _FALLBACK_SVGS.get("found", _FALLBACK_SVGS["unknown"])
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -459,17 +470,17 @@ def get_cache_type_pixmap(cache_type: str, size: int = 32, found: bool = False) 
     return _svg_to_pixmap(svg, size)
 
 
-def get_map_pin_html(cache_type: str, found: bool = False) -> str:
+def get_map_pin_html(cache_type: str, found: bool = False, dnf: bool = False) -> str:
     """
     Return HTML streng til en Leaflet divIcon map pin.
-    Viser altid det rigtige cache type ikon — smiley overlay hvis found=True.
+    Viser cache type ikon som base med smiley overlay i øverste højre hjørne:
+      found=True → gold smiley; dnf=True (og ikke found) → dark-blue smiley.
     Bruger base64 <img> tag så SVG farver bevares korrekt i browser.
     """
     import base64
 
     key = _db_type_to_key(cache_type)
 
-    # Altid vis cache type ikon som base
     svg = _get_svg_for_key(key)
     b64 = base64.b64encode(svg.encode("utf-8")).decode("ascii")
     img_html = (
@@ -478,11 +489,16 @@ def get_map_pin_html(cache_type: str, found: bool = False) -> str:
     )
 
     if found:
-        # Smiley overlay i øverste højre hjørne
-        found_svg = _get_found_svg_for_key(key)
-        found_b64 = base64.b64encode(found_svg.encode("utf-8")).decode("ascii")
+        overlay_svg = _get_found_overlay_svg()
+    elif dnf:
+        overlay_svg = _get_dnf_overlay_svg()
+    else:
+        overlay_svg = None
+
+    if overlay_svg:
+        overlay_b64 = base64.b64encode(overlay_svg.encode("utf-8")).decode("ascii")
         overlay = (
-            f'<img src="data:image/svg+xml;base64,{found_b64}" '
+            f'<img src="data:image/svg+xml;base64,{overlay_b64}" '
             f'width="16" height="16" '
             f'style="position:absolute;top:-4px;right:-4px;display:block;'
             f'filter:drop-shadow(0 1px 1px rgba(0,0,0,0.5));"/>'
@@ -497,6 +513,39 @@ def get_map_pin_html(cache_type: str, found: bool = False) -> str:
         f'{overlay}'
         f'</div>'
     )
+
+
+def get_cache_type_pixmap_composite(
+    cache_type: str,
+    size: int = 32,
+    found: bool = False,
+    dnf: bool = False,
+) -> QPixmap:
+    """
+    Return QPixmap with the cache type icon and, if found or dnf, a smiley
+    overlay in the top-right corner — matching the map pin appearance.
+      found → gold smiley; dnf (and not found) → dark-blue smiley.
+    """
+    key = _db_type_to_key(cache_type)
+    base = _svg_to_pixmap(_get_svg_for_key(key), size)
+
+    if found:
+        overlay_svg = _get_found_overlay_svg()
+    elif dnf:
+        overlay_svg = _get_dnf_overlay_svg()
+    else:
+        return base
+
+    overlay_size = max(8, size // 2)
+    overlay_px = _svg_to_pixmap(overlay_svg, overlay_size)
+
+    canvas = QPixmap(size, size)
+    canvas.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(canvas)
+    painter.drawPixmap(0, 0, base)
+    painter.drawPixmap(size - overlay_size, 0, overlay_px)
+    painter.end()
+    return canvas
 
 
 def get_all_type_keys() -> list[str]:

--- a/src/opensak/gui/icon_provider.py
+++ b/src/opensak/gui/icon_provider.py
@@ -523,7 +523,8 @@ def get_cache_type_pixmap_composite(
 ) -> QPixmap:
     """
     Return QPixmap with the cache type icon and, if found or dnf, a smiley
-    overlay in the top-right corner — matching the map pin appearance.
+    overlay centred on the icon's top-right corner (half inside, half outside)
+    — matching the map pin appearance.
       found → gold smiley; dnf (and not found) → dark-blue smiley.
     """
     key = _db_type_to_key(cache_type)
@@ -537,13 +538,20 @@ def get_cache_type_pixmap_composite(
         return base
 
     overlay_size = max(8, size // 2)
+    half = overlay_size // 2
+
+    # Canvas is enlarged by `half` on the right and top so the smiley can
+    # straddle the icon's top-right corner (center of smiley = corner of icon).
+    canvas_w = size + half
+    canvas_h = size + half
+    canvas = QPixmap(canvas_w, canvas_h)
+    canvas.fill(Qt.GlobalColor.transparent)
+
     overlay_px = _svg_to_pixmap(overlay_svg, overlay_size)
 
-    canvas = QPixmap(size, size)
-    canvas.fill(Qt.GlobalColor.transparent)
     painter = QPainter(canvas)
-    painter.drawPixmap(0, 0, base)
-    painter.drawPixmap(size - overlay_size, 0, overlay_px)
+    painter.drawPixmap(0, half, base)                        # icon shifted down
+    painter.drawPixmap(size - half, 0, overlay_px)          # smiley at top-right
     painter.end()
     return canvas
 

--- a/src/opensak/gui/map_widget.py
+++ b/src/opensak/gui/map_widget.py
@@ -35,9 +35,9 @@ class TileInterceptor(QWebEngineUrlRequestInterceptor):
 from opensak.gui.icon_provider import get_map_pin_html as _get_pin_html
 
 
-def _cache_pin_html(cache_type: str, found: bool) -> str:
-    """Return Leaflet divIcon HTML for a cache — SVG ikon, smiley hvis fundet."""
-    return _get_pin_html(cache_type, found=found)
+def _cache_pin_html(cache_type: str, found: bool, dnf: bool = False) -> str:
+    """Return Leaflet divIcon HTML for a cache — type icon with gold/blue smiley overlay."""
+    return _get_pin_html(cache_type, found=found, dnf=dnf)
 
 
 # ── Python ↔ JavaScript bro ───────────────────────────────────────────────────
@@ -536,7 +536,7 @@ class MapWidget(QWidget):
                 "clon":           eff_lon,
                 "corrected":      has_corrected,
                 "corrected_label": tr("detail_corrected_coords"),
-                "pin_html":       _cache_pin_html(c.cache_type or "", bool(c.found)),
+                "pin_html":       _cache_pin_html(c.cache_type or "", bool(c.found), bool(c.dnf)),
                 "found":          c.found,
             })
 
@@ -589,7 +589,7 @@ class MapWidget(QWidget):
             "clon":            eff_lon,
             "corrected":       has_corrected,
             "corrected_label": tr("detail_corrected_coords"),
-            "pin_html":        _cache_pin_html(cache.cache_type or "", bool(cache.found)),
+            "pin_html":        _cache_pin_html(cache.cache_type or "", bool(cache.found), bool(cache.dnf)),
             "found":           cache.found,
         }
         json_str = json.dumps(data, ensure_ascii=False)

--- a/src/opensak/utils/types.py
+++ b/src/opensak/utils/types.py
@@ -74,11 +74,12 @@ class TextSize(StrEnum):
 #   secondary_pt  — corrected coords, hints label
 #   grid_pt       — cell text in the cache grid
 #   row_height    — vertical section size (px) in the cache grid
+#   grid_icon     — type/container decoration icon in the cache grid (px)
 #   detail_icon   — type icon in detail panel header (px)
 TEXT_SIZE_MAP = {
-    TextSize.SMALL:  {"icon": 5,  "label": 9,  "secondary": 8,  "grid": 8,  "row_height": 20, "detail_icon": 20},
-    TextSize.MEDIUM: {"icon": 7,  "label": 13, "secondary": 10, "grid": 10, "row_height": 24, "detail_icon": 28},
-    TextSize.LARGE:  {"icon": 10, "label": 18, "secondary": 14, "grid": 13, "row_height": 30, "detail_icon": 36},
+    TextSize.SMALL:  {"icon": 5,  "label": 9,  "secondary": 8,  "grid": 8,  "row_height": 20, "grid_icon": 14, "detail_icon": 20},
+    TextSize.MEDIUM: {"icon": 7,  "label": 13, "secondary": 10, "grid": 10, "row_height": 24, "grid_icon": 20, "detail_icon": 28},
+    TextSize.LARGE:  {"icon": 10, "label": 18, "secondary": 14, "grid": 13, "row_height": 30, "grid_icon": 26, "detail_icon": 36},
 }
 
 

--- a/src/opensak/utils/types.py
+++ b/src/opensak/utils/types.py
@@ -74,10 +74,11 @@ class TextSize(StrEnum):
 #   secondary_pt  — corrected coords, hints label
 #   grid_pt       — cell text in the cache grid
 #   row_height    — vertical section size (px) in the cache grid
+#   detail_icon   — type icon in detail panel header (px)
 TEXT_SIZE_MAP = {
-    TextSize.SMALL:  {"icon": 5,  "label": 9,  "secondary": 8,  "grid": 8,  "row_height": 20},
-    TextSize.MEDIUM: {"icon": 7,  "label": 13, "secondary": 10, "grid": 10, "row_height": 24},
-    TextSize.LARGE:  {"icon": 10, "label": 18, "secondary": 14, "grid": 13, "row_height": 30},
+    TextSize.SMALL:  {"icon": 5,  "label": 9,  "secondary": 8,  "grid": 8,  "row_height": 20, "detail_icon": 20},
+    TextSize.MEDIUM: {"icon": 7,  "label": 13, "secondary": 10, "grid": 10, "row_height": 24, "detail_icon": 28},
+    TextSize.LARGE:  {"icon": 10, "label": 18, "secondary": 14, "grid": 13, "row_height": 30, "detail_icon": 36},
 }
 
 

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -46,6 +46,15 @@ def test_refresh_sizes_updates_title_font(monkeypatch, qapp):
     assert panel._title.font().pointSize() == TEXT_SIZE_MAP[TextSize.LARGE]["label"]
 
 
+def test_type_icon_cleared_on_clear(monkeypatch, qapp):
+    # Regression for #286: clear() removes the type icon from the detail panel.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel.clear()
+    pix = panel._type_icon_lbl.pixmap()
+    assert pix is None or pix.isNull()
+
+
 def test_decode_no_hint_shows_no_hint_label(qapp):
     # Regression for #324: decoding a cache with no hint showed an empty text
     # browser instead of keeping the "(no hint)" feedback visible.
@@ -317,3 +326,56 @@ def test_notes_tab_clear_resets_editor(monkeypatch, qapp):
     panel._note_editor.setPlainText("Some text")
     panel.clear()
     assert panel._note_editor.toPlainText() == ""
+
+
+# ── Type icon tests (issue #286) ──────────────────────────────────────────────
+
+def _load_cache(tmp_path, db_suffix="icon"):
+    from opensak.db.database import get_session, init_db
+    from opensak.importer import import_gpx
+    db_path = tmp_path / f"{db_suffix}.db"
+    init_db(db_path=db_path)
+    p = tmp_path / f"{db_suffix}.gpx"
+    p.write_text(_minimal_gpx(), encoding="utf-8")
+    import_gpx(p, db_path)
+    from opensak.db.models import Cache as CacheModel
+    from sqlalchemy.orm import joinedload
+    with get_session() as s:
+        cache = (
+            s.query(CacheModel)
+            .options(
+                joinedload(CacheModel.user_note),
+                joinedload(CacheModel.logs),
+                joinedload(CacheModel.waypoints),
+            )
+            .filter_by(gc_code="GCNOTES1")
+            .one()
+        )
+        s.expunge_all()
+    return cache
+
+
+def test_type_icon_shown_on_show_cache(monkeypatch, tmp_path, qapp):
+    # Regression for #286: a type icon is rendered before the cache name.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(text_size=TextSize.MEDIUM))
+    cache = _load_cache(tmp_path)
+    panel = CacheDetailPanel()
+    panel.show_cache(cache)
+    pix = panel._type_icon_lbl.pixmap()
+    assert pix is not None and not pix.isNull()
+    expected = TEXT_SIZE_MAP[TextSize.MEDIUM]["detail_icon"]
+    assert panel._type_icon_lbl.width() == expected
+    assert panel._type_icon_lbl.height() == expected
+
+
+def test_type_icon_resizes_on_refresh(monkeypatch, tmp_path, qapp):
+    # Regression for #286: type icon tracks text-size setting changes.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(text_size=TextSize.SMALL))
+    cache = _load_cache(tmp_path, db_suffix="icon_resize")
+    panel = CacheDetailPanel()
+    panel.show_cache(cache)
+    assert panel._type_icon_lbl.width() == TEXT_SIZE_MAP[TextSize.SMALL]["detail_icon"]
+
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(text_size=TextSize.LARGE))
+    panel.refresh_sizes()
+    assert panel._type_icon_lbl.width() == TEXT_SIZE_MAP[TextSize.LARGE]["detail_icon"]

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -55,7 +55,7 @@ def fake_settings(monkeypatch, qapp):
     s = SimpleNamespace(
         home_lat=55.0, home_lon=12.0, use_miles=False,
         coord_format=CoordFormat.DMM, date_format=DateFormat.DMY,
-        gc_username="", map_provider="google",
+        gc_username="", map_provider="google", text_size=TextSize.MEDIUM,
     )
     s.get_maps_url = lambda lat, lon: f"https://maps?{lat},{lon}"
     monkeypatch.setattr(ct, "get_settings", lambda: s)

--- a/tests/unit-tests/test_icon_provider.py
+++ b/tests/unit-tests/test_icon_provider.py
@@ -126,3 +126,34 @@ class TestMapPin:
         html = ip.get_map_pin_html("Traditional Cache", found=True)
         assert html.count("<img") == 2
         assert "drop-shadow" in html
+
+    def test_dnf_has_overlay(self):
+        # Regression for #286: DNF caches show a dark-blue smiley overlay.
+        html = ip.get_map_pin_html("Traditional Cache", dnf=True)
+        assert html.count("<img") == 2
+
+    def test_found_and_dnf_prefers_found(self):
+        # found takes priority over dnf when both are set.
+        html_found = ip.get_map_pin_html("Traditional Cache", found=True)
+        html_both  = ip.get_map_pin_html("Traditional Cache", found=True, dnf=True)
+        assert html_found == html_both
+
+
+# ── composite pixmap ──────────────────────────────────────────────────────────
+
+class TestCompositePixmap:
+    def test_no_overlay_matches_plain(self):
+        # Regression for #286: no found/dnf → same as get_cache_type_pixmap.
+        composite = ip.get_cache_type_pixmap_composite("Traditional Cache", 32)
+        plain = ip.get_cache_type_pixmap("Traditional Cache", 32)
+        assert composite.size() == plain.size()
+
+    def test_found_composite_returns_pixmap(self):
+        pix = ip.get_cache_type_pixmap_composite("Traditional Cache", 28, found=True)
+        assert isinstance(pix, QPixmap)
+        assert not pix.isNull()
+
+    def test_dnf_composite_returns_pixmap(self):
+        pix = ip.get_cache_type_pixmap_composite("Multi-cache", 28, dnf=True)
+        assert isinstance(pix, QPixmap)
+        assert not pix.isNull()

--- a/tests/unit-tests/test_map_widget.py
+++ b/tests/unit-tests/test_map_widget.py
@@ -35,7 +35,7 @@ def _note(corrected=False):
 def _cache(**kw):
     d = dict(gc_code="GC1", name="Name", cache_type="Traditional Cache",
              difficulty=1.5, terrain=2.0, latitude=55.0, longitude=12.0,
-             found=False, user_note=None)
+             found=False, dnf=False, user_note=None)
     d.update(kw)
     return SimpleNamespace(**d)
 


### PR DESCRIPTION
Adds the cache type icon before the cache name in the detail panel header, addressing the suggestion from Mike Wood to show a larger version of the icon for better legibility.

The icon is rendered as a QPixmap via the existing `get_cache_type_pixmap` and placed to the left of the cache title in a horizontal row. It scales with the Small/Medium/Large text-size setting (20/28/36 px) using a new `detail_icon` key in `TEXT_SIZE_MAP`, so it updates immediately when the user changes the size preference in Settings — consistent with how the title font already behaves. `clear()` removes the icon when no cache is selected.

Closes #286