### PR TITLE
All caches not imported

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -152,8 +152,8 @@ def _gc_sort_key(gc_code: GcCode) -> str:
 #
 #   Group 2: Empty bars + letter (sorted alphabetically by the letter)
 #            EarthCache  → 'E'
-#            Lab Cache   → 'L'
 #            Other       → 'O'
+#            Lab Cache   → 'V'  (shown as Virtual)
 #            Virtual     → 'V'
 #
 #   Group 3: Empty bars, no letter
@@ -185,7 +185,7 @@ _CONTAINER_PHYSICAL_ORDER = {
 # types can be added here and they'll slot in alphabetically by their letter.
 _NON_PHYSICAL_TYPE_LETTERS = {
     "earthcache":                   "E",
-    "lab cache":                    "L",
+    "lab cache":                    "V",
     "virtual cache":                "V",
     "locationless (reverse) cache": "R",
 }
@@ -205,7 +205,7 @@ _CONTAINER_TEXT_LABELS: dict[str, str] = {
 _NON_PHYSICAL_TEXT_LABELS: dict[str, str] = {
     "virtual cache": "Virtual",
     "earthcache":    "Earth",
-    "lab cache":     "Lab",
+    "lab cache":     "Virtual",
 }
 
 
@@ -270,7 +270,7 @@ class SizeBarDelegate(QStyledItemDelegate):
       Other         → 'O'   (ukendt fysisk størrelse)
       Virtual Cache → 'V'   (ingen fysisk container — by cache_type)
       EarthCache    → 'E'   (ingen fysisk container — by cache_type)
-      Lab Cache     → 'L'   (ingen fysisk container — by cache_type)
+      Lab Cache     → 'V'   (ingen fysisk container — vises som Virtual)
     Not chosen og tom → 5 tomme segmenter, intet bogstav
     """
 
@@ -293,7 +293,7 @@ class SizeBarDelegate(QStyledItemDelegate):
     _LABEL_TYPES = {
         "virtual cache": "V",
         "earthcache":    "E",
-        "lab cache":     "L",
+        "lab cache":     "V",
     }
 
     _SEG_COUNT   = 5

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -1175,6 +1175,11 @@ class MainWindow(QMainWindow):
 
     def _refresh_after_import(self) -> None:
         """Reload both cache table and map after a successful import."""
+        from opensak.gui.settings import get_settings
+        s = get_settings()
+        if s.home_lat and s.home_lon:
+            from opensak.db.database import recalculate_distances
+            recalculate_distances(s.home_lat, s.home_lon)
         self._refresh_cache_list()
         count = self._cache_table.row_count()
         self._statusbar.showMessage(

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -165,13 +165,19 @@ def _parse_wpt(wpt_el) -> Optional[dict]:
         _text(wpt_el, "gpx:name", gpx_ns) or
         _text(wpt_el, "gpx:n", gpx_ns)
     )
-    # Accept GC codes (standard caches) and LC codes (Adventure Lab / lab2gpx)
-    if not gc_code or not (gc_code.startswith("GC") or gc_code.startswith("LC")):
+    if not gc_code:
         return None
 
     # Cache type from <type>Geocache|Traditional Cache</type>
     type_raw = _text(wpt_el, "gpx:type", gpx_ns) or ""
     cache_type_full = type_raw.split("|")[-1].strip() if "|" in type_raw else type_raw
+
+    # Accept GC codes (standard caches), LC codes (Adventure Lab / lab2gpx),
+    # and any other code the type field identifies as a Geocache — covers other
+    # lab2gpx-encoded Adventure Lab prefixes such as LB, LA, etc.
+    if not gc_code.startswith("GC") and not gc_code.startswith("LC"):
+        if not type_raw.startswith("Geocache"):
+            return None
 
     hidden_raw = _text(wpt_el, "gpx:time", gpx_ns)
 

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -113,7 +113,7 @@ class TestHelpers:
         from opensak.gui.cache_table import _container_text
         assert _container_text("other", "Virtual Cache") == "Virtual"
         assert _container_text("other", "EarthCache")    == "Earth"
-        assert _container_text("other", "Lab Cache")     == "Lab"
+        assert _container_text("other", "Lab Cache")     == "Virtual"
 
 
 # ── model basics ────────────────────────────────────────────────────────────────

--- a/tests/unit-tests/test_container_sort.py
+++ b/tests/unit-tests/test_container_sort.py
@@ -41,7 +41,7 @@ def test_physical_containers_sorted_smallest_to_largest_in_group_1():
 def test_non_physical_types_use_group_2_letter_alphabetically():
     # cache_type wins over container value: a Virtual with container 'Other' sorts as 'V'.
     assert _container_sort_key("Other", "EarthCache") == (2, "E")
-    assert _container_sort_key("Other", "Lab Cache") == (2, "L")
+    assert _container_sort_key("Other", "Lab Cache") == (2, "V")
     assert _container_sort_key("Other") == (2, "O")
     assert _container_sort_key("Other", "Virtual Cache") == (2, "V")
 
@@ -68,9 +68,9 @@ def test_full_ascending_order_physical_then_letters_then_empty():
         FakeCache("SMALL", "Small"),
     ]
     assert _sort(caches) == [
-        "MICRO", "SMALL", "REGULAR", "LARGE",   # group 1, smallest first
-        "EARTH", "LAB", "OTHER", "VIRT",        # group 2, E < L < O < V
-        "NOTCHOSEN",                            # group 3
+        "MICRO", "SMALL", "REGULAR", "LARGE",       # group 1, smallest first
+        "EARTH", "OTHER", "VIRT", "LAB",            # group 2, E < O < V (Lab sorts as V with Virtual)
+        "NOTCHOSEN",                                # group 3
     ]
 
 

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -285,6 +285,24 @@ def test_import_zip_multiple_with_companion_wpts(tmp_db, tmp_path):
         assert any(wp.prefix == "PK" for wp in cache.waypoints)
 
 
+def test_import_lb_lab_cache_codes(tmp_db, tmp_path):
+    # lab2gpx exports Adventure Lab stages with LB* codes (Geocache|Lab Cache).
+    # These were silently dropped because only GC and LC prefixes were accepted.
+    gpx = write_gpx(tmp_path, "labs.gpx", build_gpx(
+        cache_wpt("LB1AQD01", name="Lab Stage 1", cache_type="Lab Cache"),
+        cache_wpt("LB1AQD02", name="Lab Stage 2", cache_type="Lab Cache"),
+        cache_wpt("LC9XYZ01", name="Lab Stage LC", cache_type="Lab Cache"),
+    ))
+    with get_session() as s:
+        result = import_gpx(gpx, s)
+    assert result.total == 3, f"Expected 3 imported, got {result.total}"
+    assert result.errors == []
+    with get_session() as s:
+        assert s.query(Cache).filter_by(gc_code="LB1AQD01").count() == 1
+        assert s.query(Cache).filter_by(gc_code="LB1AQD02").count() == 1
+        assert s.query(Cache).filter_by(gc_code="LC9XYZ01").count() == 1
+
+
 def test_import_gpx_inline_extra_waypoints(tmp_db, tmp_path):
     # Verify extra waypoints embedded in the main GPX are linked to their cache.
     with get_session() as s:


### PR DESCRIPTION
Three bugs in the same flow — all visible when importing a lab2gpx GPX file that mixes LC and LB Adventure Lab codes.

**Silent import loss — LB\* prefix codes dropped.** `_parse_wpt` only accepted `GC` and `LC` prefixes. `LB*` codes (and any future `L*` variant lab2gpx generates) were rejected as main caches, fell through to `_parse_extra_wpt` as "Listed By" waypoints, then silently discarded when no parent cache matched. Fix: move the `type_raw` read before the prefix guard and accept any code whose `<type>` starts with `"Geocache"` — covers all lab2gpx prefix encodings without hardcoding each letter.

**Container column shows "Lab" instead of "Virtual".** `_NON_PHYSICAL_TEXT_LABELS` and `SizeBarDelegate._LABEL_TYPES` overrode the stored container value with `"Lab"`/`"L"` for Lab Cache type, while the detail panel shows the actual stored value (`"Virtual"`). Fix: map Lab Cache to `"V"`/`"Virtual"` throughout so both views match.

**No distance/bearing after import.** `recalculate_distances` was only called at startup and on home-point change, never after an import. Newly imported caches always started with `NULL` distance and bearing. Fix: call it in `_refresh_after_import` when a home point is configured.

Closes #359