### PR TITLE
Keyboard shortcuts

### DIFF
--- a/src/opensak/gui/dialogs/shortcuts_dialog.py
+++ b/src/opensak/gui/dialogs/shortcuts_dialog.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QTableWidget,
+    QTableWidgetItem, QHeaderView, QDialogButtonBox, QPushButton,
+    QAbstractItemView, QKeySequenceEdit,
+)
+from PySide6.QtGui import QKeySequence
+from PySide6.QtCore import Qt
+from opensak.lang import tr
+
+if TYPE_CHECKING:
+    from PySide6.QtWidgets import QWidget
+    from PySide6.QtGui import QAction
+
+# Default shortcut strings, keyed by settings_key.
+_DEFAULTS: dict[str, str] = {
+    "manage_databases":  "Ctrl+D",
+    "import":            "Ctrl+I",
+    "quit":              "Ctrl+Q",
+    "add_cache":         "Ctrl+N",
+    "edit_cache":        "Ctrl+E",
+    "delete_cache":      "Delete",
+    "refresh":           "F5",
+    "filter":            "Ctrl+F",
+    "settings":          "Ctrl+,",
+    "gps_export":        "Ctrl+G",
+    "trip_planner":      "Ctrl+T",
+    "coord_converter":   "Ctrl+K",
+    "projection":        "Ctrl+P",
+}
+
+
+class ShortcutsDialog(QDialog):
+    def __init__(
+        self,
+        registry: list[tuple[str, str, list[QAction]]],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(tr("shortcuts_dialog_title"))
+        self.setMinimumWidth(400)
+        self._registry = registry
+        self._editors: list[QKeySequenceEdit] = []
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
+
+        self._table = QTableWidget(len(self._registry), 2)
+        self._table.setHorizontalHeaderLabels([
+            tr("shortcuts_col_action"),
+            tr("shortcuts_col_shortcut"),
+        ])
+        self._table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
+        self._table.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self._table.verticalHeader().setVisible(False)
+        self._table.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        self._table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+
+        for row, (key, label_key, actions) in enumerate(self._registry):
+            name_item = QTableWidgetItem(tr(label_key))
+            name_item.setFlags(Qt.ItemFlag.ItemIsEnabled)
+            self._table.setItem(row, 0, name_item)
+
+            current = actions[0].shortcut().toString(
+                QKeySequence.SequenceFormat.NativeText
+            )
+            editor = QKeySequenceEdit(QKeySequence(current))
+            self._editors.append(editor)
+            self._table.setCellWidget(row, 1, editor)
+
+        layout.addWidget(self._table)
+
+        btn_row = QHBoxLayout()
+        reset_btn = QPushButton(tr("shortcuts_reset_all"))
+        reset_btn.clicked.connect(self._reset_all)
+        btn_row.addWidget(reset_btn)
+        btn_row.addStretch()
+        layout.addLayout(btn_row)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok |
+            QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _reset_all(self) -> None:
+        for row, (key, _label, _actions) in enumerate(self._registry):
+            default = _DEFAULTS.get(key, "")
+            editor = self._editors[row]
+            editor.setKeySequence(QKeySequence(default))
+
+    def get_shortcuts(self) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for row, (key, _label, _actions) in enumerate(self._registry):
+            seq = self._editors[row].keySequence()
+            result[key] = seq.toString(QKeySequence.SequenceFormat.PortableText)
+        return result

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -204,6 +204,8 @@ class MainWindow(QMainWindow):
         self._setup_ui()
         self._setup_menu()
         self._setup_toolbar()
+        self._setup_shortcut_registry()
+        self._apply_saved_shortcuts()
         self._setup_search_bar()
         self._setup_statusbar()
         self._restore_state()
@@ -310,18 +312,18 @@ class MainWindow(QMainWindow):
 
         file_menu.addSeparator()
 
-        act_quit = QAction(tr("action_quit"), self)
-        act_quit.setShortcut(QKeySequence("Ctrl+Q"))
-        act_quit.triggered.connect(self.close)
-        file_menu.addAction(act_quit)
+        self._act_quit = QAction(tr("action_quit"), self)
+        self._act_quit.setShortcut(QKeySequence("Ctrl+Q"))
+        self._act_quit.triggered.connect(self.close)
+        file_menu.addAction(self._act_quit)
 
         # ── Waypoint ──────────────────────────────────────────────────────────
         wp_menu = menubar.addMenu(tr("menu_waypoint"))
 
-        act_wp_add = QAction(tr("action_wp_add"), self)
-        act_wp_add.setShortcut(QKeySequence("Ctrl+N"))
-        act_wp_add.triggered.connect(self._add_waypoint)
-        wp_menu.addAction(act_wp_add)
+        self._act_wp_add = QAction(tr("action_wp_add"), self)
+        self._act_wp_add.setShortcut(QKeySequence("Ctrl+N"))
+        self._act_wp_add.triggered.connect(self._add_waypoint)
+        wp_menu.addAction(self._act_wp_add)
 
         self._act_wp_edit = QAction(tr("action_wp_edit"), self)
         self._act_wp_edit.setShortcut(QKeySequence("Ctrl+E"))
@@ -372,17 +374,17 @@ class MainWindow(QMainWindow):
         # ── Vis ───────────────────────────────────────────────────────────────
         view_menu = menubar.addMenu(tr("menu_view"))
 
-        act_refresh = QAction(tr("action_refresh"), self)
-        act_refresh.setShortcut(QKeySequence("F5"))
-        act_refresh.triggered.connect(self._refresh_cache_list)
-        view_menu.addAction(act_refresh)
+        self._act_refresh = QAction(tr("action_refresh"), self)
+        self._act_refresh.setShortcut(QKeySequence("F5"))
+        self._act_refresh.triggered.connect(self._refresh_cache_list)
+        view_menu.addAction(self._act_refresh)
 
         view_menu.addSeparator()
 
-        act_filter = QAction(tr("action_filter"), self)
-        act_filter.setShortcut("Ctrl+F")
-        act_filter.triggered.connect(self._open_filter_dialog)
-        view_menu.addAction(act_filter)
+        self._act_filter_menu = QAction(tr("action_filter"), self)
+        self._act_filter_menu.setShortcut("Ctrl+F")
+        self._act_filter_menu.triggered.connect(self._open_filter_dialog)
+        view_menu.addAction(self._act_filter_menu)
 
         act_clear = QAction(tr("action_clear_filter"), self)
         act_clear.triggered.connect(self._clear_filter)
@@ -397,12 +399,12 @@ class MainWindow(QMainWindow):
         # ── Funktioner ────────────────────────────────────────────────────────
         tools_menu = menubar.addMenu(tr("menu_tools"))
 
-        act_settings = QAction(tr("action_settings"), self)
-        act_settings.setShortcut(QKeySequence("Ctrl+,"))
+        self._act_settings = QAction(tr("action_settings"), self)
+        self._act_settings.setShortcut(QKeySequence("Ctrl+,"))
         # Ctrl+, triggers macOS PreferencesRole auto-assignment, relabeling the action "Preferences".
-        act_settings.setMenuRole(QAction.MenuRole.NoRole)
-        act_settings.triggered.connect(self._open_settings)
-        tools_menu.addAction(act_settings)
+        self._act_settings.setMenuRole(QAction.MenuRole.NoRole)
+        self._act_settings.triggered.connect(self._open_settings)
+        tools_menu.addAction(self._act_settings)
 
         tools_menu.addSeparator()
 
@@ -426,15 +428,15 @@ class MainWindow(QMainWindow):
         # ── Geocaching Værktøjer ──────────────────────────────────────────────
         gc_tools_menu = menubar.addMenu(tr("menu_gc_tools"))
 
-        act_coord_converter = QAction(tr("action_coord_converter"), self)
-        act_coord_converter.setShortcut(QKeySequence("Ctrl+K"))
-        act_coord_converter.triggered.connect(self._open_coord_converter)
-        gc_tools_menu.addAction(act_coord_converter)
+        self._act_coord_converter = QAction(tr("action_coord_converter"), self)
+        self._act_coord_converter.setShortcut(QKeySequence("Ctrl+K"))
+        self._act_coord_converter.triggered.connect(self._open_coord_converter)
+        gc_tools_menu.addAction(self._act_coord_converter)
 
-        act_projection = QAction(tr("action_projection"), self)
-        act_projection.setShortcut(QKeySequence("Ctrl+P"))
-        act_projection.triggered.connect(self._open_projection)
-        gc_tools_menu.addAction(act_projection)
+        self._act_projection = QAction(tr("action_projection"), self)
+        self._act_projection.setShortcut(QKeySequence("Ctrl+P"))
+        self._act_projection.triggered.connect(self._open_projection)
+        gc_tools_menu.addAction(self._act_projection)
 
         gc_tools_menu.addSeparator()
 
@@ -464,6 +466,12 @@ class MainWindow(QMainWindow):
         act_check_update = QAction(tr("action_check_update"), self)
         act_check_update.triggered.connect(self._check_update_manual)
         help_menu.addAction(act_check_update)
+
+        help_menu.addSeparator()
+
+        act_shortcuts = QAction(tr("action_shortcuts"), self)
+        act_shortcuts.triggered.connect(self._open_shortcuts)
+        help_menu.addAction(act_shortcuts)
 
         help_menu.addSeparator()
 
@@ -1218,6 +1226,53 @@ class MainWindow(QMainWindow):
                 self._detail_panel.show_cache(full)
             else:
                 self._detail_panel.refresh_sizes()
+
+    # ── Tastaturgenveje ────────────────────────────────────────────────────────
+
+    def _setup_shortcut_registry(self) -> None:
+        # Each entry: (settings_key, label_lang_key, [actions sharing this shortcut])
+        self._shortcut_registry: list[tuple[str, str, list[QAction]]] = [
+            ("manage_databases",  "shortcut_manage_databases",  [self._act_db_manager]),
+            ("import",            "shortcut_import",            [self._act_import]),
+            ("quit",              "shortcut_quit",              [self._act_quit]),
+            ("add_cache",         "shortcut_add_cache",         [self._act_wp_add]),
+            ("edit_cache",        "shortcut_edit_cache",        [self._act_wp_edit]),
+            ("delete_cache",      "shortcut_delete_cache",      [self._act_wp_delete]),
+            ("refresh",           "shortcut_refresh",           [self._act_refresh]),
+            ("filter",            "shortcut_filter",            [self._act_filter_menu, self._act_filter]),
+            ("settings",          "shortcut_settings",          [self._act_settings]),
+            ("gps_export",        "shortcut_gps_export",        [self._act_gps_export]),
+            ("trip_planner",      "shortcut_trip_planner",      [self._act_trip_planner]),
+            ("coord_converter",   "shortcut_coord_converter",   [self._act_coord_converter]),
+            ("projection",        "shortcut_projection",        [self._act_projection]),
+        ]
+
+    def _apply_saved_shortcuts(self) -> None:
+        from PySide6.QtCore import QSettings
+        s = QSettings("OpenSAK Project", "OpenSAK")
+        for key, _label, actions in self._shortcut_registry:
+            saved = s.value(f"shortcuts/{key}", "")
+            if saved:
+                seq = QKeySequence(str(saved))
+                for act in actions:
+                    act.setShortcut(seq)
+
+    def _open_shortcuts(self) -> None:
+        from opensak.gui.dialogs.shortcuts_dialog import ShortcutsDialog
+        from PySide6.QtCore import QSettings
+        dlg = ShortcutsDialog(self._shortcut_registry, self)
+        if dlg.exec():
+            new_shortcuts = dlg.get_shortcuts()
+            s = QSettings("OpenSAK Project", "OpenSAK")
+            for key, _label, actions in self._shortcut_registry:
+                seq_str = new_shortcuts.get(key, "")
+                if seq_str:
+                    s.setValue(f"shortcuts/{key}", seq_str)
+                else:
+                    s.remove(f"shortcuts/{key}")
+                seq = QKeySequence(seq_str) if seq_str else QKeySequence()
+                for act in actions:
+                    act.setShortcut(seq)
 
     def _reload_home_combo(self) -> None:
         """Genindlæs hjemmepunkts-dropdown fra settings."""

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -80,9 +80,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "O &OpenSAK…",
     "action_check_update":          "Zkontrolovat aktualizace…",
     "action_user_guide":            "Uživatelská příručka",
+    "action_shortcuts":             "⌨️  &Klávesové zkratky…",
 
     "action_open_log_file": "Otevřít soubor protokolu",
     "log_file_not_found": "Soubor protokolu ještě nebyl nalezen: {path}",
+
+    # ── Klávesové zkratky dialog ──────────────────────────────────────────────
+    "shortcuts_dialog_title":       "Klávesové zkratky",
+    "shortcuts_col_action":         "Akce",
+    "shortcuts_col_shortcut":       "Zkratka",
+    "shortcuts_reset_all":          "Obnovit výchozí hodnoty",
+    "shortcut_manage_databases":    "Spravovat databáze",
+    "shortcut_import":              "Importovat GPX / PQ zip",
+    "shortcut_quit":                "Ukončit",
+    "shortcut_add_cache":           "Přidat kešku",
+    "shortcut_edit_cache":          "Upravit kešku",
+    "shortcut_delete_cache":        "Smazat kešku",
+    "shortcut_refresh":             "Obnovit seznam",
+    "shortcut_filter":              "Nastavit filtr",
+    "shortcut_settings":            "Nastavení",
+    "shortcut_gps_export":          "Odeslat do GPS",
+    "shortcut_trip_planner":        "Plánování trasy",
+    "shortcut_coord_converter":     "Převodník souřadnic",
+    "shortcut_projection":          "Projekce souřadnic",
 
     # ── Geocaching Tools menu ─────────────────────────────────────────────────
     "menu_gc_tools":                "&Nástroje",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -80,9 +80,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "Om &OpenSAK…",
     "action_check_update":          "Tjek for opdateringer…",
     "action_user_guide":            "Brugervejledning",
+    "action_shortcuts":             "⌨️  &Tastaturgenveje…",
 
     "action_open_log_file": "Åbn logfil",
     "log_file_not_found": "Logfil ikke fundet endnu: {path}",
+
+    # ── Tastaturgenveje-dialog ────────────────────────────────────────────────
+    "shortcuts_dialog_title":       "Tastaturgenveje",
+    "shortcuts_col_action":         "Handling",
+    "shortcuts_col_shortcut":       "Genvej",
+    "shortcuts_reset_all":          "Nulstil alle til standard",
+    "shortcut_manage_databases":    "Administrer databaser",
+    "shortcut_import":              "Importer GPX / PQ zip",
+    "shortcut_quit":                "Afslut",
+    "shortcut_add_cache":           "Tilføj cache",
+    "shortcut_edit_cache":          "Rediger cache",
+    "shortcut_delete_cache":        "Slet cache",
+    "shortcut_refresh":             "Opdater liste",
+    "shortcut_filter":              "Indstil filter",
+    "shortcut_settings":            "Indstillinger",
+    "shortcut_gps_export":          "Send til GPS",
+    "shortcut_trip_planner":        "Turplanlægger",
+    "shortcut_coord_converter":     "Koordinatkonverter",
+    "shortcut_projection":          "Koordinatprojektion",
 
     # ── Geocaching Værktøjer-menu ─────────────────────────────────────────────
     "menu_gc_tools":                "&Værktøjer",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -80,9 +80,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "Über &OpenSAK…",
     "action_check_update":          "Nach Updates suchen…",
     "action_user_guide":            "Benutzerhandbuch",
+    "action_shortcuts":             "⌨️  &Tastaturkürzel…",
 
     "action_open_log_file": "Protokolldatei öffnen",
     "log_file_not_found": "Protokolldatei noch nicht gefunden: {path}",
+
+    # ── Tastaturkürzel-Dialog ─────────────────────────────────────────────────
+    "shortcuts_dialog_title":       "Tastaturkürzel",
+    "shortcuts_col_action":         "Aktion",
+    "shortcuts_col_shortcut":       "Kürzel",
+    "shortcuts_reset_all":          "Alle zurücksetzen",
+    "shortcut_manage_databases":    "Datenbanken verwalten",
+    "shortcut_import":              "GPX / PQ-ZIP importieren",
+    "shortcut_quit":                "Beenden",
+    "shortcut_add_cache":           "Cache hinzufügen",
+    "shortcut_edit_cache":          "Cache bearbeiten",
+    "shortcut_delete_cache":        "Cache löschen",
+    "shortcut_refresh":             "Liste aktualisieren",
+    "shortcut_filter":              "Filter setzen",
+    "shortcut_settings":            "Einstellungen",
+    "shortcut_gps_export":          "An GPS senden",
+    "shortcut_trip_planner":        "Tourenplaner",
+    "shortcut_coord_converter":     "Koordinatenkonverter",
+    "shortcut_projection":          "Koordinatenprojektion",
 
     # ── Geocaching Tools menu ─────────────────────────────────────────────────
     "menu_gc_tools":                "&Tools",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -80,9 +80,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "About &OpenSAK…",
     "action_check_update":          "Check for updates…",
     "action_user_guide":            "User Guide",
+    "action_shortcuts":             "⌨️  &Keyboard Shortcuts…",
 
     "action_open_log_file": "Open log file",
     "log_file_not_found": "Log file not found yet: {path}",
+
+    # ── Keyboard Shortcuts dialog ─────────────────────────────────────────────
+    "shortcuts_dialog_title":       "Keyboard Shortcuts",
+    "shortcuts_col_action":         "Action",
+    "shortcuts_col_shortcut":       "Shortcut",
+    "shortcuts_reset_all":          "Reset All to Defaults",
+    "shortcut_manage_databases":    "Manage Databases",
+    "shortcut_import":              "Import GPX / PQ Zip",
+    "shortcut_quit":                "Quit",
+    "shortcut_add_cache":           "Add Cache",
+    "shortcut_edit_cache":          "Edit Cache",
+    "shortcut_delete_cache":        "Delete Cache",
+    "shortcut_refresh":             "Refresh List",
+    "shortcut_filter":              "Set Filter",
+    "shortcut_settings":            "Settings",
+    "shortcut_gps_export":          "Send to GPS",
+    "shortcut_trip_planner":        "Trip Planner",
+    "shortcut_coord_converter":     "Coordinate Converter",
+    "shortcut_projection":          "Coordinate Projection",
 
     # ── Geocaching Tools menu ─────────────────────────────────────────────────
     "menu_gc_tools":                "&Tools",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -80,9 +80,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "A propos d'&OpenSAK…",
     "action_check_update":          "Vérifier les mises à jour…",
     "action_user_guide":            "Guide utilisateur",
+    "action_shortcuts":             "⌨️  &Raccourcis clavier…",
 
     "action_open_log_file": "Ouvrir le fichier journal",
     "log_file_not_found": "Fichier journal introuvable : {path}",
+
+    # ── Raccourcis clavier dialog ─────────────────────────────────────────────
+    "shortcuts_dialog_title":       "Raccourcis clavier",
+    "shortcuts_col_action":         "Action",
+    "shortcuts_col_shortcut":       "Raccourci",
+    "shortcuts_reset_all":          "Rétablir les valeurs par défaut",
+    "shortcut_manage_databases":    "Gérer les bases de données",
+    "shortcut_import":              "Importer GPX / PQ zip",
+    "shortcut_quit":                "Quitter",
+    "shortcut_add_cache":           "Ajouter une cache",
+    "shortcut_edit_cache":          "Modifier la cache",
+    "shortcut_delete_cache":        "Supprimer la cache",
+    "shortcut_refresh":             "Actualiser la liste",
+    "shortcut_filter":              "Définir le filtre",
+    "shortcut_settings":            "Paramètres",
+    "shortcut_gps_export":          "Envoyer vers GPS",
+    "shortcut_trip_planner":        "Planificateur de voyage",
+    "shortcut_coord_converter":     "Convertisseur de coordonnées",
+    "shortcut_projection":          "Projection de coordonnées",
 
     # ── Menu Outils de géocaching ─────────────────────────────────────────────
     "menu_gc_tools":                "&Outils géo",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -83,9 +83,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "Over &OpenSAK…",
     "action_check_update":          "Controleren op updates…",
     "action_user_guide":            "Gebruikershandleiding",
+    "action_shortcuts":             "⌨️  &Sneltoetsen…",
 
     "action_open_log_file": "Logbestand openen",
     "log_file_not_found": "Logbestand nog niet gevonden: {path}",
+
+    # ── Sneltoetsen-dialog ────────────────────────────────────────────────────
+    "shortcuts_dialog_title":       "Sneltoetsen",
+    "shortcuts_col_action":         "Actie",
+    "shortcuts_col_shortcut":       "Sneltoets",
+    "shortcuts_reset_all":          "Alles resetten",
+    "shortcut_manage_databases":    "Databases beheren",
+    "shortcut_import":              "GPX / PQ zip importeren",
+    "shortcut_quit":                "Afsluiten",
+    "shortcut_add_cache":           "Cache toevoegen",
+    "shortcut_edit_cache":          "Cache bewerken",
+    "shortcut_delete_cache":        "Cache verwijderen",
+    "shortcut_refresh":             "Lijst vernieuwen",
+    "shortcut_filter":              "Filter instellen",
+    "shortcut_settings":            "Instellingen",
+    "shortcut_gps_export":          "Naar GPS sturen",
+    "shortcut_trip_planner":        "Routeplanner",
+    "shortcut_coord_converter":     "Coördinatenomzetter",
+    "shortcut_projection":          "Coördinatenprojectie",
 
     # ── Geocaching Tools menu ─────────────────────────────────────────────────
     "menu_gc_tools":                "&Extra's",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -80,9 +80,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "Sobre o &OpenSAK…",
     "action_check_update":          "Verificar atualizações…",
     "action_user_guide":            "Guia do utilizador",
+    "action_shortcuts":             "⌨️  &Atalhos de teclado…",
 
     "action_open_log_file": "Abrir ficheiro de registo",
     "log_file_not_found": "Ficheiro de registo ainda não encontrado: {path}",
+
+    # ── Atalhos de teclado dialog ─────────────────────────────────────────────
+    "shortcuts_dialog_title":       "Atalhos de teclado",
+    "shortcuts_col_action":         "Ação",
+    "shortcuts_col_shortcut":       "Atalho",
+    "shortcuts_reset_all":          "Repor todos os padrões",
+    "shortcut_manage_databases":    "Gerir bases de dados",
+    "shortcut_import":              "Importar GPX / PQ zip",
+    "shortcut_quit":                "Sair",
+    "shortcut_add_cache":           "Adicionar cache",
+    "shortcut_edit_cache":          "Editar cache",
+    "shortcut_delete_cache":        "Eliminar cache",
+    "shortcut_refresh":             "Atualizar lista",
+    "shortcut_filter":              "Definir filtro",
+    "shortcut_settings":            "Definições",
+    "shortcut_gps_export":          "Enviar para GPS",
+    "shortcut_trip_planner":        "Planeador de percurso",
+    "shortcut_coord_converter":     "Conversor de coordenadas",
+    "shortcut_projection":          "Projeção de coordenadas",
 
     # ── Geocaching Tools menu ─────────────────────────────────────────────────
     "menu_gc_tools":                "&Ferramentas de geocaching",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -80,9 +80,29 @@ STRINGS: dict[str, str] = {
     "action_about":                 "Om &OpenSAK…",
     "action_check_update":          "Sök efter uppdateringar…",
     "action_user_guide":            "Användarguide",
+    "action_shortcuts":             "⌨️  &Tangentbordsgenvägar…",
 
     "action_open_log_file": "Öppna loggfil",
     "log_file_not_found": "Loggfilen hittades inte än: {path}",
+
+    # ── Tangentbordsgenvägar-dialog ───────────────────────────────────────────
+    "shortcuts_dialog_title":       "Tangentbordsgenvägar",
+    "shortcuts_col_action":         "Åtgärd",
+    "shortcuts_col_shortcut":       "Genväg",
+    "shortcuts_reset_all":          "Återställ alla till standard",
+    "shortcut_manage_databases":    "Hantera databaser",
+    "shortcut_import":              "Importera GPX / PQ zip",
+    "shortcut_quit":                "Avsluta",
+    "shortcut_add_cache":           "Lägg till cache",
+    "shortcut_edit_cache":          "Redigera cache",
+    "shortcut_delete_cache":        "Ta bort cache",
+    "shortcut_refresh":             "Uppdatera lista",
+    "shortcut_filter":              "Ange filter",
+    "shortcut_settings":            "Inställningar",
+    "shortcut_gps_export":          "Skicka till GPS",
+    "shortcut_trip_planner":        "Reseplanerare",
+    "shortcut_coord_converter":     "Koordinatomvandlare",
+    "shortcut_projection":          "Koordinatprojektion",
 
     # ── Geocaching Tools menu ─────────────────────────────────────────────────
     "menu_gc_tools":                "&Verktyg",

--- a/tests/unit-tests/test_shortcuts_dialog.py
+++ b/tests/unit-tests/test_shortcuts_dialog.py
@@ -1,0 +1,124 @@
+# tests/unit-tests/test_shortcuts_dialog.py — keyboard shortcuts dialog.
+
+import pytest
+from unittest.mock import MagicMock
+from PySide6.QtGui import QKeySequence
+
+pytest.importorskip("pytestqt")
+
+from opensak.gui.dialogs.shortcuts_dialog import ShortcutsDialog, _DEFAULTS
+from opensak.lang import load_language
+
+load_language("en")
+
+
+def _make_action(shortcut: str):
+    act = MagicMock()
+    act.shortcut.return_value = QKeySequence(shortcut)
+    return act
+
+
+def _make_registry(keys: list[str] | None = None):
+    keys = keys or list(_DEFAULTS.keys())
+    return [
+        (k, f"shortcut_{k.replace('-', '_')}", [_make_action(_DEFAULTS[k])])
+        for k in keys
+    ]
+
+
+class TestShortcutsDialogLayout:
+    def test_row_count_matches_registry(self, qtbot):
+        reg = _make_registry()
+        dlg = ShortcutsDialog(reg)
+        qtbot.addWidget(dlg)
+        assert dlg._table.rowCount() == len(reg)
+
+    def test_column_count_is_two(self, qtbot):
+        dlg = ShortcutsDialog(_make_registry())
+        qtbot.addWidget(dlg)
+        assert dlg._table.columnCount() == 2
+
+    def test_editors_match_registry_length(self, qtbot):
+        reg = _make_registry()
+        dlg = ShortcutsDialog(reg)
+        qtbot.addWidget(dlg)
+        assert len(dlg._editors) == len(reg)
+
+    def test_action_names_shown_in_first_column(self, qtbot):
+        reg = [("quit", "shortcut_quit", [_make_action("Ctrl+Q")])]
+        dlg = ShortcutsDialog(reg)
+        qtbot.addWidget(dlg)
+        item = dlg._table.item(0, 0)
+        assert item is not None
+        assert item.text() == "Quit"
+
+    def test_window_title_is_translated(self, qtbot):
+        dlg = ShortcutsDialog(_make_registry())
+        qtbot.addWidget(dlg)
+        assert dlg.windowTitle() == "Keyboard Shortcuts"
+
+
+class TestGetShortcuts:
+    def test_returns_dict_with_all_keys(self, qtbot):
+        reg = _make_registry()
+        dlg = ShortcutsDialog(reg)
+        qtbot.addWidget(dlg)
+        result = dlg.get_shortcuts()
+        assert set(result.keys()) == {k for k, _, _ in reg}
+
+    def test_initial_values_match_actions(self, qtbot):
+        reg = [("quit", "shortcut_quit", [_make_action("Ctrl+Q")])]
+        dlg = ShortcutsDialog(reg)
+        qtbot.addWidget(dlg)
+        result = dlg.get_shortcuts()
+        seq = QKeySequence(result["quit"])
+        assert not seq.isEmpty()
+
+    def test_empty_shortcut_returns_empty_string(self, qtbot):
+        reg = [("delete_cache", "shortcut_delete_cache", [_make_action("")])]
+        dlg = ShortcutsDialog(reg)
+        qtbot.addWidget(dlg)
+        result = dlg.get_shortcuts()
+        assert result["delete_cache"] == ""
+
+
+class TestResetAll:
+    def test_reset_restores_defaults(self, qtbot):
+        reg = [
+            ("quit", "shortcut_quit", [_make_action("Ctrl+Q")]),
+            ("import", "shortcut_import", [_make_action("Ctrl+I")]),
+        ]
+        dlg = ShortcutsDialog(reg)
+        qtbot.addWidget(dlg)
+        # Change the first editor
+        dlg._editors[0].setKeySequence(QKeySequence("Ctrl+Z"))
+        dlg._reset_all()
+        result = dlg.get_shortcuts()
+        assert QKeySequence(result["quit"]) == QKeySequence(_DEFAULTS["quit"])
+        assert QKeySequence(result["import"]) == QKeySequence(_DEFAULTS["import"])
+
+    def test_reset_uses_defaults_dict(self, qtbot):
+        for key, default in _DEFAULTS.items():
+            reg = [(key, f"shortcut_{key}", [_make_action("")])]
+            dlg = ShortcutsDialog(reg)
+            qtbot.addWidget(dlg)
+            dlg._reset_all()
+            result = dlg.get_shortcuts()
+            assert QKeySequence(result[key]) == QKeySequence(default), (
+                f"reset for '{key}' should produce '{default}'"
+            )
+
+
+class TestDefaultsDict:
+    def test_all_defaults_are_valid_key_sequences(self):
+        for key, val in _DEFAULTS.items():
+            seq = QKeySequence(val)
+            assert not seq.isEmpty(), f"_DEFAULTS['{key}'] = '{val}' is not a valid sequence"
+
+    def test_defaults_cover_all_expected_actions(self):
+        expected = {
+            "manage_databases", "import", "quit", "add_cache", "edit_cache",
+            "delete_cache", "refresh", "filter", "settings", "gps_export",
+            "trip_planner", "coord_converter", "projection",
+        }
+        assert set(_DEFAULTS.keys()) == expected


### PR DESCRIPTION
Users had no way to discover the keyboard shortcuts available in OpenSAK, and no way to customise them.

A new **Keyboard Shortcuts** dialog (Help → Keyboard Shortcuts…) lists all shortcut-carrying actions in a table. Each row has a `QKeySequenceEdit` so the user can click and type a new binding. A **Reset All to Defaults** button restores the original keys. Custom bindings are saved to `QSettings` under `shortcuts/<key>` and re-applied every time the window opens.

Closes #205