### PR TITLE
bump __version__ to 1.14.0-beta.15

### DIFF
--- a/src/opensak/__init__.py
+++ b/src/opensak/__init__.py
@@ -1,5 +1,5 @@
 """OpenSAK — cross-platform geocache management tool."""
 
-__version__ = "1.14.0-beta.14"
+__version__ = "1.14.0-beta.15"
 __author__ = "OpenSAK Contributors"
 __license__ = "MIT"


### PR DESCRIPTION
## Summary

- `site/user-guide.html` was updated to `beta.15` in commit `50ec2af` but `src/opensak/__init__.py` was never incremented
- `test_user_guide_changelog_link_pins_to_release_tag` checks that the changelog link matches `__version__`, so the mismatch broke CI
- This PR bumps `__version__` to `1.14.0-beta.15` to align with the site