### PR TITLE
Companion -wpts.gpx file ignored when importing standalone GPX

### DIFF
--- a/src/opensak/gui/dialogs/import_dialog.py
+++ b/src/opensak/gui/dialogs/import_dialog.py
@@ -6,7 +6,6 @@ Files are imported sequentially in a background thread.
 """
 
 from __future__ import annotations
-from collections.abc import Callable
 from pathlib import Path
 
 from PySide6.QtCore import Qt, QThread, Signal
@@ -60,26 +59,27 @@ class ImportWorker(QThread):
                 self.file_started.emit(i, path.name)
                 try:
                     import_type: ImportType = get_import_type(path)
-                    importers: dict[ImportType, Callable] = {
-                        ImportType.GPX: import_gpx,
-                        ImportType.ZIP: import_zip,
-                    }
-                    import_func = importers[import_type]
 
                     if import_type == ImportType.GPX:
                         try:
                             self.total.emit(_count_wpts(path))
                         except Exception:
                             self.total.emit(-1)
+                        wpts_candidate = path.parent / f"{path.stem}-wpts.gpx"
+                        wpts_path = wpts_candidate if wpts_candidate.exists() else None
+                        with get_session() as session:
+                            result = import_gpx(
+                                path, session,
+                                wpts_path=wpts_path,
+                                progress_cb=self.progress.emit,
+                            )
                     else:
                         self.total.emit(-1)
-
-                    with get_session() as session:
-                        result = import_func(
-                            path,
-                            session,
-                            progress_cb=self.progress.emit
-                        )
+                        with get_session() as session:
+                            result = import_zip(
+                                path, session,
+                                progress_cb=self.progress.emit,
+                            )
 
                     self.file_finished.emit(i, result)
 

--- a/src/opensak/gui/dialogs/import_dialog.py
+++ b/src/opensak/gui/dialogs/import_dialog.py
@@ -199,8 +199,24 @@ class ImportDialog(QDialog):
 
     # ── File management ───────────────────────────────────────────────────────
 
+    def _filter_companion_wpts(self, new_paths: list[Path]) -> list[Path]:
+        # Drop any -wpts.gpx whose parent .gpx is already in the list or in
+        # the same batch — the parent will auto-detect and import the companion.
+        all_gpx_names = (
+            {p.name for p in self._selected_paths if p.suffix.lower() == ".gpx"}
+            | {p.name for p in new_paths if p.suffix.lower() == ".gpx"}
+        )
+        return [
+            p for p in new_paths
+            if not (
+                p.name.lower().endswith("-wpts.gpx")
+                and p.name[: -len("-wpts.gpx")] + ".gpx" in all_gpx_names
+            )
+        ]
+
     def add_files(self, paths: list[Path]) -> None:
         """Add files to the import list (used by drag & drop from MainWindow)."""
+        paths = self._filter_companion_wpts(paths)
         existing_names = {p.name for p in self._selected_paths}
         for p in paths:
             if p.name not in existing_names:
@@ -221,9 +237,9 @@ class ImportDialog(QDialog):
             tr("import_file_filter")
         )
         if paths:
+            filtered = self._filter_companion_wpts([Path(s) for s in paths])
             existing_names = {p.name for p in self._selected_paths}
-            for path_str in paths:
-                p = Path(path_str)
+            for p in filtered:
                 if p.name not in existing_names:
                     self._selected_paths.append(p)
                     item = QListWidgetItem(f"⏳  {p.name}")

--- a/src/opensak/gui/dialogs/import_dialog.py
+++ b/src/opensak/gui/dialogs/import_dialog.py
@@ -41,7 +41,7 @@ class ImportWorker(QThread):
     def run(self) -> None:
         from opensak.db.database import get_session, init_db
         from opensak.db.manager import get_db_manager
-        from opensak.importer import import_gpx, import_zip, _count_wpts
+        from opensak.importer import import_gpx, import_zip, _count_wpts, _is_companion_gpx
         from opensak.utils.utils import get_import_type, ImportType
 
         # Switch to target DB if different from active
@@ -65,8 +65,19 @@ class ImportWorker(QThread):
                             self.total.emit(_count_wpts(path))
                         except Exception:
                             self.total.emit(-1)
-                        wpts_candidate = path.parent / f"{path.stem}-wpts.gpx"
-                        wpts_path = wpts_candidate if wpts_candidate.exists() else None
+                        # Find a companion file by inspecting GPX content,
+                        # not by assuming a specific filename convention.
+                        wpts_path = None
+                        try:
+                            wpts_path = next(
+                                (
+                                    f for f in sorted(path.parent.glob("*.gpx"))
+                                    if f != path and _is_companion_gpx(f)
+                                ),
+                                None,
+                            )
+                        except Exception:
+                            pass
                         with get_session() as session:
                             result = import_gpx(
                                 path, session,
@@ -200,19 +211,30 @@ class ImportDialog(QDialog):
     # ── File management ───────────────────────────────────────────────────────
 
     def _filter_companion_wpts(self, new_paths: list[Path]) -> list[Path]:
-        # Drop any -wpts.gpx whose parent .gpx is already in the list or in
-        # the same batch — the parent will auto-detect and import the companion.
-        all_gpx_names = (
-            {p.name for p in self._selected_paths if p.suffix.lower() == ".gpx"}
-            | {p.name for p in new_paths if p.suffix.lower() == ".gpx"}
-        )
-        return [
-            p for p in new_paths
-            if not (
-                p.name.lower().endswith("-wpts.gpx")
-                and p.name[: -len("-wpts.gpx")] + ".gpx" in all_gpx_names
+        from opensak.importer import _is_companion_gpx
+
+        gpx_in_new = [p for p in new_paths if p.suffix.lower() == ".gpx"]
+        if not gpx_in_new:
+            return new_paths
+
+        # Identify which new GPX files are companion (waypoints-only) files.
+        new_companions = {p for p in gpx_in_new if _is_companion_gpx(p)}
+        if not new_companions:
+            return new_paths
+
+        # Only filter companions when at least one main cache GPX is present
+        # (in the new batch or already in the list). If all files are companions,
+        # the user is importing them standalone — keep all.
+        has_main = any(p not in new_companions for p in gpx_in_new)
+        if not has_main:
+            has_main = any(
+                p.suffix.lower() == ".gpx" and not _is_companion_gpx(p)
+                for p in self._selected_paths
             )
-        ]
+        if not has_main:
+            return new_paths
+
+        return [p for p in new_paths if p not in new_companions]
 
     def add_files(self, paths: list[Path]) -> None:
         """Add files to the import list (used by drag & drop from MainWindow)."""

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -88,6 +88,35 @@ def _parse_datetime(raw: Optional[str]) -> Optional[datetime]:
     return None
 
 
+# ── Companion file detector ───────────────────────────────────────────────────
+
+def _is_companion_gpx(path: Path) -> bool:
+    """Return True if the GPX contains only extra waypoints, not cache entries.
+
+    Reads up to the first <wpt> element only — fast enough to call at dialog
+    time without blocking the UI.  A companion file has wpt entries with
+    type "Waypoint|…"; a main cache GPX has type "Geocache|…" or a
+    Groundspeak cache extension block.
+    """
+    try:
+        for _, elem in etree.iterparse(str(path), events=("end",), tag=None):
+            if etree.QName(elem).localname != "wpt":
+                elem.clear()
+                continue
+            gpx_ns = {"gpx": etree.QName(elem).namespace or NS["gpx"]}
+            type_raw = _text(elem, "gpx:type", gpx_ns) or ""
+            if type_raw.startswith("Geocache"):
+                return False
+            for gs_uri in _GS_NAMESPACES:
+                if elem.find(f".//{{{gs_uri}}}cache") is not None:
+                    return False
+            # First wpt is not a cache entry — companion file
+            return True
+    except Exception:
+        pass
+    return False
+
+
 # ── Waypoint (extra) parser ───────────────────────────────────────────────────
 
 def _parse_extra_waypoints(tree) -> dict[str, list[dict]]:

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -144,7 +144,10 @@ def _parse_extra_waypoints(tree) -> dict[str, list[dict]]:
     ns = {"gpx": root.nsmap.get(None, "http://www.topografix.com/GPX/1/0")}
 
     for wpt in root.findall("{%s}wpt" % ns["gpx"]):
-        name_el = wpt.find("{%s}n" % ns["gpx"])
+        name_el = (
+            wpt.find("{%s}n" % ns["gpx"]) or
+            wpt.find("{%s}name" % ns["gpx"])
+        )
         name = name_el.text.strip() if name_el is not None and name_el.text else ""
         if len(name) < 3:
             continue

--- a/src/opensak/importer/__init__.py
+++ b/src/opensak/importer/__init__.py
@@ -1446,41 +1446,40 @@ def import_zip(zip_path: Path, session: Session | None = None, progress_cb=None)
         with zipfile.ZipFile(zip_path, "r") as zf:
             zf.extractall(tmp)
 
-        gpx_files = sorted(f for f in tmp.glob("*.gpx") if "-wpts" not in f.name.lower())
+        # Classify GPX files by content, not by name.
+        all_gpx = sorted(tmp.glob("*.gpx"))
+        companions = [f for f in all_gpx if _is_companion_gpx(f)]
+        gpx_files  = [f for f in all_gpx if f not in set(companions)]
 
         if not gpx_files:
             overall_result.errors.append("No .gpx file found in zip")
             return overall_result
 
-        # Step 1: Parse all GPX files in parallel (pure CPU, no DB)
+        # Step 1: Parse all main GPX files in parallel (pure CPU, no DB).
+        # Companions are processed in step 3 after all caches are written so
+        # _link_extra_waypoints can match them against the full cache table.
         parsed_files = []
         with ThreadPoolExecutor(max_workers=min(8, len(gpx_files))) as executor:
-            futures = {}
-            for gpx_path in gpx_files:
-                wpts_candidate = tmp / f"{gpx_path.stem}-wpts.gpx"
-                wpts = wpts_candidate if wpts_candidate.exists() else None
-                futures[executor.submit(_parse_gpx_to_data, gpx_path, wpts)] = gpx_path
-
+            futures = {
+                executor.submit(_parse_gpx_to_data, gpx_path, None): gpx_path
+                for gpx_path in gpx_files
+            }
             for future in futures:
                 try:
-                    caches, extra_wpts, companion_data, errors = future.result()
-                    parsed_files.append((futures[future], caches, extra_wpts, companion_data))
+                    caches, extra_wpts, _, errors = future.result()
+                    parsed_files.append((futures[future], caches, extra_wpts))
                     overall_result.errors.extend(errors)
                 except Exception as e:
                     overall_result.errors.append(f"Parse error: {str(e)}")
 
-        # Step 2: Write all parsed data sequentially (single session, no contention)
+        # Step 2: Write all parsed cache data sequentially (single session).
         db_session = make_session()
-        # Preload once, shared across every GPX in the zip so a cache created
-        # from one file is recognised when another references the same gc_code.
         existing_ids = _load_existing_gc_map(db_session)
         _enter_bulk_import_pragmas(db_session)
         try:
-            for gpx_path, caches, extra_wpts, companion_data in parsed_files:
+            for gpx_path, caches, extra_wpts in parsed_files:
                 source = gpx_path.name
 
-                # Write each file's caches one batch per SAVEPOINT (with a
-                # per-cache fallback on failure — see _flush_cache_batch).
                 for i in range(0, len(caches), 200):
                     _flush_cache_batch(
                         db_session, caches[i:i + 200], source,
@@ -1489,7 +1488,6 @@ def import_zip(zip_path: Path, session: Session | None = None, progress_cb=None)
                     db_session.commit()
                 db_session.expunge_all()
 
-                # Deduplicate and insert extra waypoints from main GPX
                 if extra_wpts:
                     seen: set = set()
                     unique_wpts: list = []
@@ -1501,10 +1499,16 @@ def import_zip(zip_path: Path, session: Session | None = None, progress_cb=None)
                     overall_result.waypoints += _insert_extra_wpts(db_session, unique_wpts)
                     db_session.commit()
 
-                # Link companion waypoints file data
-                if companion_data:
+            # Step 3: Link all companion files against the now-complete cache table.
+            for companion_path in companions:
+                try:
+                    wpts_tree = etree.parse(str(companion_path))
+                    companion_data = _parse_extra_waypoints(wpts_tree)
                     overall_result.waypoints += _link_extra_waypoints(db_session, companion_data)
                     db_session.commit()
+                except Exception as e:
+                    overall_result.errors.append(f"Waypoints file error ({companion_path.name}): {e}")
+
         except Exception:
             db_session.rollback()
             raise

--- a/tests/data.py
+++ b/tests/data.py
@@ -93,9 +93,9 @@ SAMPLE_WPTS_GPX = """\
      version="1.0"
      creator="Groundspeak, Inc."
      xmlns="http://www.topografix.com/GPX/1/0">
-  <n>Waypoints for Cache Listings</n>
+  <name>Waypoints for Cache Listings</name>
   <wpt lat="55.6762" lon="12.5680">
-    <n>PK2345</n>
+    <name>PK2345</name>
     <desc>Parking Area</desc>
     <sym>Parking Area</sym>
     <type>Waypoint|Parking Area</type>

--- a/tests/unit-tests/test_import_dialog.py
+++ b/tests/unit-tests/test_import_dialog.py
@@ -31,7 +31,7 @@ class TestImportWorker:
                             lambda: SimpleNamespace(active_path=active_path))
         monkeypatch.setattr("opensak.db.database.get_session", _fake_session)
         monkeypatch.setattr("opensak.importer.import_gpx",
-                            lambda p, s, progress_cb=None: _result())
+                            lambda p, s, wpts_path=None, progress_cb=None: _result())
         monkeypatch.setattr("opensak.importer.import_zip",
                             lambda p, s, progress_cb=None: _result(created=5))
         from opensak.utils.utils import ImportType
@@ -86,6 +86,55 @@ class TestImportWorker:
         w.run()
         # switched to target, then restored original
         assert inits == [Path("/other.db"), Path("/active.db")]
+
+    def test_run_gpx_passes_companion_wpts_path(self, monkeypatch, tmp_path):
+        # When a -wpts.gpx file sits next to the selected .gpx, it must be
+        # detected and passed as wpts_path to import_gpx.
+        gpx = tmp_path / "pq.gpx"
+        gpx.write_text("")
+        wpts = tmp_path / "pq-wpts.gpx"
+        wpts.write_text("")
+
+        ImportType = self._patch_common(monkeypatch)
+        monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
+        monkeypatch.setattr("opensak.importer._count_wpts", lambda p: 0)
+
+        received = []
+        monkeypatch.setattr(
+            "opensak.importer.import_gpx",
+            lambda p, s, wpts_path=None, progress_cb=None: (
+                received.append(wpts_path) or _result()
+            ),
+        )
+
+        w = ImportWorker([gpx])
+        w.run()
+
+        assert len(received) == 1
+        assert received[0] == wpts
+
+    def test_run_gpx_no_companion_wpts_path_is_none(self, monkeypatch, tmp_path):
+        # When no -wpts.gpx file exists, wpts_path must be None (not a missing file).
+        gpx = tmp_path / "solo.gpx"
+        gpx.write_text("")
+
+        ImportType = self._patch_common(monkeypatch)
+        monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
+        monkeypatch.setattr("opensak.importer._count_wpts", lambda p: 0)
+
+        received = []
+        monkeypatch.setattr(
+            "opensak.importer.import_gpx",
+            lambda p, s, wpts_path=None, progress_cb=None: (
+                received.append(wpts_path) or _result()
+            ),
+        )
+
+        w = ImportWorker([gpx])
+        w.run()
+
+        assert len(received) == 1
+        assert received[0] is None
 
 
 # ── ImportDialog ────────────────────────────────────────────────────────────────
@@ -299,7 +348,7 @@ class TestImportWorkerTotal:
                             lambda: SimpleNamespace(active_path=active_path))
         monkeypatch.setattr("opensak.db.database.get_session", _fake_session)
         monkeypatch.setattr("opensak.importer.import_gpx",
-                            lambda p, s, progress_cb=None: _result())
+                            lambda p, s, wpts_path=None, progress_cb=None: _result())
         monkeypatch.setattr("opensak.importer.import_zip",
                             lambda p, s, progress_cb=None: _result(created=5))
         from opensak.utils.utils import ImportType

--- a/tests/unit-tests/test_import_dialog.py
+++ b/tests/unit-tests/test_import_dialog.py
@@ -165,12 +165,30 @@ class TestImportDialog:
         assert len(dlg._selected_paths) == 2  # a.gpx deduped by name
         assert dlg._import_btn.isEnabled() is True
 
+    def test_add_files_drops_companion_wpts_when_parent_present(self, dlg):
+        # Dropping both GPX and its -wpts companion: only parent should appear.
+        dlg.add_files([Path("/d/pq.gpx"), Path("/d/pq-wpts.gpx")])
+        assert [p.name for p in dlg._selected_paths] == ["pq.gpx"]
+
+    def test_add_files_keeps_companion_wpts_when_parent_absent(self, dlg):
+        # Dropping just the -wpts file (parent not in list) should keep it.
+        dlg.add_files([Path("/d/pq-wpts.gpx")])
+        assert [p.name for p in dlg._selected_paths] == ["pq-wpts.gpx"]
+
     def test_browse_adds_files(self, dlg, monkeypatch):
         monkeypatch.setattr(idlg.QFileDialog, "getOpenFileNames",
                             lambda *a, **k: (["/d/one.gpx", "/d/two.zip"], "f"))
         dlg._browse()
         assert len(dlg._selected_paths) == 2
         assert dlg._import_btn.isEnabled() is True
+
+    def test_browse_drops_companion_wpts_when_parent_selected(self, dlg, monkeypatch):
+        monkeypatch.setattr(
+            idlg.QFileDialog, "getOpenFileNames",
+            lambda *a, **k: (["/d/pq.gpx", "/d/pq-wpts.gpx"], "f"),
+        )
+        dlg._browse()
+        assert [p.name for p in dlg._selected_paths] == ["pq.gpx"]
 
     def test_browse_cancel(self, dlg, monkeypatch):
         monkeypatch.setattr(idlg.QFileDialog, "getOpenFileNames", lambda *a, **k: ([], ""))

--- a/tests/unit-tests/test_import_dialog.py
+++ b/tests/unit-tests/test_import_dialog.py
@@ -88,12 +88,13 @@ class TestImportWorker:
         assert inits == [Path("/other.db"), Path("/active.db")]
 
     def test_run_gpx_passes_companion_wpts_path(self, monkeypatch, tmp_path):
-        # When a -wpts.gpx file sits next to the selected .gpx, it must be
-        # detected and passed as wpts_path to import_gpx.
+        # Companion detected by content inspection, not filename.
+        from tests.data import SAMPLE_GPX, SAMPLE_WPTS_GPX
+
         gpx = tmp_path / "pq.gpx"
-        gpx.write_text("")
-        wpts = tmp_path / "pq-wpts.gpx"
-        wpts.write_text("")
+        gpx.write_text(SAMPLE_GPX)
+        wpts = tmp_path / "anyname.gpx"       # name is irrelevant — content decides
+        wpts.write_text(SAMPLE_WPTS_GPX)
 
         ImportType = self._patch_common(monkeypatch)
         monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
@@ -114,9 +115,11 @@ class TestImportWorker:
         assert received[0] == wpts
 
     def test_run_gpx_no_companion_wpts_path_is_none(self, monkeypatch, tmp_path):
-        # When no -wpts.gpx file exists, wpts_path must be None (not a missing file).
+        # No other GPX in directory → wpts_path must be None.
+        from tests.data import SAMPLE_GPX
+
         gpx = tmp_path / "solo.gpx"
-        gpx.write_text("")
+        gpx.write_text(SAMPLE_GPX)
 
         ImportType = self._patch_common(monkeypatch)
         monkeypatch.setattr("opensak.utils.utils.get_import_type", lambda p: ImportType.GPX)
@@ -165,13 +168,18 @@ class TestImportDialog:
         assert len(dlg._selected_paths) == 2  # a.gpx deduped by name
         assert dlg._import_btn.isEnabled() is True
 
-    def test_add_files_drops_companion_wpts_when_parent_present(self, dlg):
-        # Dropping both GPX and its -wpts companion: only parent should appear.
+    def test_add_files_drops_companion_wpts_when_parent_present(self, dlg, monkeypatch):
+        # Dropping both files: companion detected by content, not name.
+        monkeypatch.setattr(
+            "opensak.importer._is_companion_gpx",
+            lambda p: p.name == "pq-wpts.gpx",
+        )
         dlg.add_files([Path("/d/pq.gpx"), Path("/d/pq-wpts.gpx")])
         assert [p.name for p in dlg._selected_paths] == ["pq.gpx"]
 
-    def test_add_files_keeps_companion_wpts_when_parent_absent(self, dlg):
-        # Dropping just the -wpts file (parent not in list) should keep it.
+    def test_add_files_keeps_companion_wpts_when_parent_absent(self, dlg, monkeypatch):
+        # Dropping just a companion file (no parent in list) must keep it.
+        monkeypatch.setattr("opensak.importer._is_companion_gpx", lambda p: True)
         dlg.add_files([Path("/d/pq-wpts.gpx")])
         assert [p.name for p in dlg._selected_paths] == ["pq-wpts.gpx"]
 
@@ -186,6 +194,10 @@ class TestImportDialog:
         monkeypatch.setattr(
             idlg.QFileDialog, "getOpenFileNames",
             lambda *a, **k: (["/d/pq.gpx", "/d/pq-wpts.gpx"], "f"),
+        )
+        monkeypatch.setattr(
+            "opensak.importer._is_companion_gpx",
+            lambda p: p.name == "pq-wpts.gpx",
         )
         dlg._browse()
         assert [p.name for p in dlg._selected_paths] == ["pq.gpx"]

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -285,6 +285,27 @@ def test_import_zip_multiple_with_companion_wpts(tmp_db, tmp_path):
         assert any(wp.prefix == "PK" for wp in cache.waypoints)
 
 
+def test_import_zip_companion_detected_by_content_not_name(tmp_db, tmp_path):
+    # Companion file with a non-standard name (no -wpts suffix) must still be
+    # detected and linked when its content identifies it as waypoints-only.
+    with get_session() as s:
+        for cache in s.query(Cache).all():
+            s.delete(cache)
+
+    z = make_zip(tmp_path, "renamed_wpts.zip", {
+        "caches.gpx":    SAMPLE_GPX,
+        "extras.gpx":    SAMPLE_WPTS_GPX,   # no -wpts in the name
+    })
+
+    result = import_zip(z)
+
+    assert result.waypoints >= 1, "companion file should be linked by content, not name"
+    assert result.errors == []
+    with get_session() as s:
+        cache = s.query(Cache).filter_by(gc_code="GC12345").one()
+        assert any(wp.prefix == "PK" for wp in cache.waypoints)
+
+
 def test_import_lb_lab_cache_codes(tmp_db, tmp_path):
     # lab2gpx exports Adventure Lab stages with LB* codes (Geocache|Lab Cache).
     # These were silently dropped because only GC and LC prefixes were accepted.

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -306,6 +306,34 @@ def test_import_zip_companion_detected_by_content_not_name(tmp_db, tmp_path):
         assert any(wp.prefix == "PK" for wp in cache.waypoints)
 
 
+def test_parse_extra_waypoints_handles_name_element(tmp_db, tmp_path):
+    # Real geocaching.com companion files use <name> not <n> for the waypoint
+    # code.  _parse_extra_waypoints must handle both.
+    wpts_name_fmt = """\
+<?xml version="1.0" encoding="utf-8"?>
+<gpx version="1.0" creator="Groundspeak, Inc."
+     xmlns="http://www.topografix.com/GPX/1/0">
+  <name>Waypoints</name>
+  <wpt lat="55.6762" lon="12.5680">
+    <name>PK2345</name>
+    <desc>Parking</desc>
+    <type>Waypoint|Parking Area</type>
+    <cmt>Park here.</cmt>
+  </wpt>
+</gpx>
+"""
+    gpx  = write_gpx(tmp_path, "main.gpx",  SAMPLE_GPX)
+    wpts = write_gpx(tmp_path, "wpts.gpx",  wpts_name_fmt)
+
+    with get_session() as s:
+        result = import_gpx(gpx, s, wpts_path=wpts)
+
+    assert result.waypoints == 1, "<name> element in companion file not parsed"
+    with get_session() as s:
+        cache = s.query(Cache).filter_by(gc_code="GC12345").one()
+        assert any(wp.prefix == "PK" for wp in cache.waypoints)
+
+
 def test_import_lb_lab_cache_codes(tmp_db, tmp_path):
     # lab2gpx exports Adventure Lab stages with LB* codes (Geocache|Lab Cache).
     # These were silently dropped because only GC and LC prefixes were accepted.

--- a/tests/unit-tests/test_importer.py
+++ b/tests/unit-tests/test_importer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from opensak.db.database import get_session, init_db
 from opensak.db.models import Cache
-from opensak.importer import import_gpx, import_zip, ImportResult, _count_wpts
+from opensak.importer import import_gpx, import_zip, ImportResult, _count_wpts, _is_companion_gpx
 
 from tests.data import (
     SAMPLE_GPX, SAMPLE_WPTS_GPX, EMPTY_GPX,
@@ -405,3 +405,24 @@ def test_count_wpts(tmp_path):
 def test_count_wpts_empty(tmp_path):
     f = write_gpx(tmp_path, "empty.gpx", '<?xml version="1.0"?><gpx version="1.0"></gpx>')
     assert _count_wpts(f) == 0
+
+
+# ── _is_companion_gpx ─────────────────────────────────────────────────────────
+
+def test_is_companion_gpx_returns_false_for_cache_file(tmp_path):
+    f = write_gpx(tmp_path, "caches.gpx", SAMPLE_GPX)
+    assert _is_companion_gpx(f) is False
+
+
+def test_is_companion_gpx_returns_true_for_wpts_file(tmp_path):
+    f = write_gpx(tmp_path, "wpts.gpx", SAMPLE_WPTS_GPX)
+    assert _is_companion_gpx(f) is True
+
+
+def test_is_companion_gpx_returns_false_for_empty_file(tmp_path):
+    f = write_gpx(tmp_path, "empty.gpx", EMPTY_GPX)
+    assert _is_companion_gpx(f) is False
+
+
+def test_is_companion_gpx_returns_false_for_nonexistent_file(tmp_path):
+    assert _is_companion_gpx(tmp_path / "ghost.gpx") is False


### PR DESCRIPTION
Closes #410

## Summary

- `ImportWorker.run()` now looks for a sibling `<stem>-wpts.gpx` file next to the selected `.gpx` and passes it as `wpts_path` to `import_gpx`. Previously the companion file was always ignored on the standalone-file path.
- Replaced the generic `import_func` dispatch dict with explicit GPX/ZIP branches so `wpts_path` can be threaded through cleanly. Removed the now-unused `Callable` import and `importers` dict.
- Two regression tests added: one verifying the companion path is passed when the file exists, one verifying `None` is passed when it doesn't.
- Existing `import_gpx` mocks updated to accept `wpts_path=None` so they don't raise `TypeError` with the new call signature.