### PR TITLE
Bug: Container column sort order is incorrect

### DIFF
--- a/src/opensak/filters/engine.py
+++ b/src/opensak/filters/engine.py
@@ -1199,6 +1199,30 @@ class FilterSet:
 
 # ── Sort spec ─────────────────────────────────────────────────────────────────
 
+# Logical container sort: physical sizes first (micro→large), then non-physical
+# types (earthcache/lab/virtual), then empty/not-chosen. Mirrors _container_sort_key
+# in gui/cache_table.py — both must be kept in sync.
+_CONTAINER_PHYSICAL_ORDER = {"micro": 1, "small": 2, "regular": 3, "large": 4}
+_NON_PHYSICAL_TYPES = {
+    "earthcache": "E", "lab cache": "V",
+    "virtual cache": "V", "locationless (reverse) cache": "R",
+}
+_EMPTY_CONTAINERS = {"", "not chosen"}
+
+
+def _container_sort_key(c) -> tuple:
+    ct = (c.cache_type or "").strip().lower()
+    letter = _NON_PHYSICAL_TYPES.get(ct)
+    if letter is not None:
+        return (2, letter)
+    key = (c.container or "").strip().lower()
+    if key in _CONTAINER_PHYSICAL_ORDER:
+        return (1, _CONTAINER_PHYSICAL_ORDER[key])
+    if key in _EMPTY_CONTAINERS:
+        return (3, "")
+    return (2, "O")
+
+
 # Valid sort fields and how to extract the sort key from a Cache object
 SORT_FIELDS: dict[str, Any] = {
     "name":            lambda c: (c.name or "").lower(),
@@ -1211,7 +1235,7 @@ SORT_FIELDS: dict[str, Any] = {
     "state":           lambda c: (c.state or "").lower(),
     "county":          lambda c: (c.county or "").lower(),
     "placed_by":       lambda c: (c.placed_by or "").lower(),
-    "container":       lambda c: (c.container or "").lower(),
+    "container":       _container_sort_key,
     "found":           lambda c: int(c.found),
     "archived":        lambda c: int(c.archived),
     # Kolonner sorteret i CacheTableModel — accepteres af SortSpec men bruges

--- a/tests/unit-tests/test_container_sort.py
+++ b/tests/unit-tests/test_container_sort.py
@@ -1,4 +1,4 @@
-# tests/unit-tests/test_container_sort.py — Container column sort key (issue #90).
+# tests/unit-tests/test_container_sort.py — Container column sort key (#90, #412).
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from typing import Optional
 import pytest
 
 from opensak.gui.cache_table import _container_sort_key
+from opensak.filters.engine import SORT_FIELDS
 
 
 @dataclass
@@ -87,3 +88,37 @@ def test_stable_sort_preserves_secondary_order_within_a_group():
         FakeCache("FAR_LARGE", "Large"),
     ]
     assert _sort(caches) == ["CLOSE_SMALL", "MID_SMALL", "CLOSE_LARGE", "MID_LARGE", "FAR_LARGE"]
+
+
+# Issue #412: SORT_FIELDS["container"] must use the same logical order as
+# _container_sort_key, not alphabetical string comparison.
+def test_sort_fields_container_uses_logical_order_not_alphabetical():
+    # Alphabetical order of container values: "" < "Large" < "Micro" < "Not chosen"
+    # < "Other" < "Regular" < "Small". Logical order: micro, small, regular, large,
+    # then non-physical (by letter), then empty/not-chosen.
+    sort_fn = SORT_FIELDS["container"]
+    caches = [
+        FakeCache("LARGE",     "Large",      "Traditional Cache"),
+        FakeCache("MICRO",     "Micro",      "Traditional Cache"),
+        FakeCache("NC",        "Not chosen", "Traditional Cache"),
+        FakeCache("VIRT",      "Other",      "Virtual Cache"),
+        FakeCache("REGULAR",   "Regular",    "Traditional Cache"),
+        FakeCache("OTHER",     "Other",      "Traditional Cache"),
+        FakeCache("EARTH",     "",           "EarthCache"),
+        FakeCache("SMALL",     "Small",      "Traditional Cache"),
+    ]
+    caches.sort(key=sort_fn)
+    gc_codes = [c.gc_code for c in caches]
+    assert gc_codes == ["MICRO", "SMALL", "REGULAR", "LARGE", "EARTH", "OTHER", "VIRT", "NC"]
+
+
+def test_sort_fields_container_non_physical_type_overrides_other_container():
+    # A Virtual Cache with container="Other" must sort as non-physical (2,"V"),
+    # NOT as "other" container (2,"O"). This requires checking cache_type.
+    sort_fn = SORT_FIELDS["container"]
+    virtual = FakeCache("VIRT", "Other", "Virtual Cache")
+    other_trad = FakeCache("OTHR", "Other", "Traditional Cache")
+    earth = FakeCache("EART", "Other", "EarthCache")
+    caches = [virtual, other_trad, earth]
+    caches.sort(key=sort_fn)
+    assert [c.gc_code for c in caches] == ["EART", "OTHR", "VIRT"]


### PR DESCRIPTION
`SORT_FIELDS["container"]` in `filters/engine.py` sorted container sizes alphabetically by the raw `container` string, ignoring `cache_type` entirely. This meant a Virtual Cache with `container="Other"` sorted as 'O' instead of 'V', and physical sizes produced the wrong order ("" < "Large" < "Micro" rather than micro → small → regular → large).

Replace the alphabetical lambda with `_container_sort_key()`, a helper that mirrors the sort already used by `CacheTableModel.sort()` in `cache_table.py`:

- Group 1: physical sizes, smallest → largest (micro, small, regular, large)
- Group 2: non-physical cache types, by letter (E, O, R, V) — cache_type takes precedence over container value
- Group 3: empty / not chosen — always last

Two regression tests added to `test_container_sort.py`: one covering the full ascending order via `SORT_FIELDS`, and one verifying that `cache_type` overrides `container` for virtual/earth caches.

Closes #412