### PR TITLE
Bug: Type column spawns with too small initial width, truncating the header

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -70,7 +70,7 @@ def get_column_defs() -> dict:
     return {
         "gc_code":      (tr("col_gc_code"),           80),
         "name":         (tr("col_name"),             260),
-        "cache_type":   (tr("col_type"),              28),
+        "cache_type":   (tr("col_type"),              40),
         "difficulty":   (tr("col_difficulty"),        50),
         "terrain":      (tr("col_terrain"),           50),
         "container":    (tr("col_container"),         80),

--- a/src/opensak/gui/dialogs/column_dialog.py
+++ b/src/opensak/gui/dialogs/column_dialog.py
@@ -23,7 +23,7 @@ _ALL_COLUMNS_DEF = [
     ("user_flag",    "col_user_flag_label",    30,  True),
     ("gc_code",      "col_gc_code",      80,  True),
     ("name",         "col_name",        260,  True),
-    ("cache_type",   "col_type",          28,  True),   # ikon + tooltip, ingen tekst
+    ("cache_type",   "col_type",          40,  True),   # ikon + tooltip, ingen tekst
     ("container",    "col_container",    80,  True),   # størrelses-bar
     ("difficulty",   "col_difficulty",   36,  True),
     ("terrain",      "col_terrain",      36,  True),

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -129,6 +129,11 @@ class TestModelBasics:
         assert model.cache_at(0) is not None
         assert model.cache_at(5) is None
 
+    def test_cache_type_default_width_is_not_too_narrow(self):
+        # Issue #414: 28px truncated the "Type" header; default must be >= 40.
+        from opensak.gui.cache_table import get_column_defs
+        assert get_column_defs()["cache_type"][1] >= 40
+
     def test_header_display_and_alignment(self, model):
         name = model.headerData(1, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
         assert isinstance(name, str) and name

--- a/tests/unit-tests/test_column_dialog.py
+++ b/tests/unit-tests/test_column_dialog.py
@@ -39,6 +39,11 @@ class TestColumnHelpers:
         assert all(len(c) == 4 for c in cols)
         assert {"gc_code", "name"} <= {c[0] for c in cols}
 
+    def test_cache_type_default_width_fits_header(self):
+        # Issue #414: 28px truncated the "Type" header; minimum must be >= 40.
+        col_map = {fid: w for fid, _, w, _ in get_all_columns()}
+        assert col_map["cache_type"] >= 40
+
     def test_visible_defaults_when_unset(self, store):
         vis = get_visible_columns()
         assert "gc_code" in vis


### PR DESCRIPTION
The `cache_type` column defaulted to 28px — too narrow for the "Type" header text, which was visually clipped on every fresh start. The column needed a manual resize before the header became readable.

Increase the default width from 28px to 40px in both `get_column_defs()` (`cache_table.py`) and `_ALL_COLUMNS_DEF` (`column_dialog.py`). The icon in the data cells is unaffected; only the header area needed the extra space.

Two regression tests added to prevent the value from being reduced again.

Closes #414