### PR TITLE
Bug: Container size icon column shows visual artifact behind the first icon

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -21,7 +21,7 @@ from opensak.coords import format_coords, format_lat, format_lon, format_lat, fo
 from opensak.lang import tr
 from opensak.utils.types import DateFormat, GcCode, TEXT_SIZE_MAP, TextSize, norm_locale_date_fmt
 from opensak.utils.utils import normalize_geocacher_name
-from opensak.gui.icon_provider import get_cache_type_icon, get_cache_size_icon, get_flag_placeholder_icon
+from opensak.gui.icon_provider import get_cache_type_icon, get_flag_placeholder_icon
 from opensak.gui.dialogs.column_dialog import get_column_widths, set_column_widths, get_container_display
 import math
 
@@ -655,30 +655,17 @@ class CacheTableModel(QAbstractTableModel):
         }
         return mapping.get(t, "unknown")
 
-    @staticmethod
-    def _size_icon_key(cache: Cache) -> str:
-        """Map container string to icon_provider size key."""
-        mapping = {
-            "micro":      "micro",
-            "small":      "small",
-            "regular":    "regular",
-            "large":      "large",
-            "other":      "other",
-            "not chosen": "not_chosen",
-            "virtual":    "not_chosen",
-        }
-        return mapping.get((cache.container or "").lower(), "other")
-
     def _decoration_value(self, cache: Cache, col: str):
         """Return QIcon for columns that show icons."""
         if col == "cache_type":
             icon_size = TEXT_SIZE_MAP[get_settings().text_size]["grid_icon"]
             return get_cache_type_icon(self._type_icon_key(cache), size=icon_size)
         if col == "container":
-            if get_container_display() == "text":
-                return None
-            icon_size = TEXT_SIZE_MAP[get_settings().text_size]["grid_icon"]
-            return get_cache_size_icon(self._size_icon_key(cache), size=icon_size)
+            # "bar" mode: SizeBarDelegate paints the segments; returning an icon
+            # here would cause super().paint() to draw it behind the first bar
+            # segment, producing a visual artifact (issue #416).
+            # "text" mode: display value is plain text, no decoration needed.
+            return None
         if col == "user_flag" and not cache.user_flag:
             return get_flag_placeholder_icon(16)
         return None

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -61,7 +61,6 @@ def fake_settings(monkeypatch, qapp):
     monkeypatch.setattr(ct, "get_settings", lambda: s)
     monkeypatch.setattr("opensak.gui.settings.get_settings", lambda: s)
     monkeypatch.setattr(ct, "get_cache_type_icon", lambda *a, **k: QPixmap(4, 4))
-    monkeypatch.setattr(ct, "get_cache_size_icon", lambda *a, **k: QPixmap(4, 4))
     return s
 
 
@@ -172,9 +171,12 @@ class TestDisplayValues:
         monkeypatch.setattr(ct, "get_container_display", lambda: "text")
         assert model._decoration_value(_cache(container="micro"), "container") is None
 
-    def test_container_bar_mode_returns_icon(self, model, monkeypatch):
+    def test_container_bar_mode_no_decoration_icon(self, model, monkeypatch):
+        # Issue #416: in "bar" mode SizeBarDelegate paints the cell entirely;
+        # returning a DecorationRole icon here caused it to show as an artifact
+        # behind the first bar segment via super().paint().
         monkeypatch.setattr(ct, "get_container_display", lambda: "bar")
-        assert model._decoration_value(_cache(container="micro"), "container") is not None
+        assert model._decoration_value(_cache(container="micro"), "container") is None
 
     def test_difficulty_terrain(self, model):
         assert model._display_value(_cache(difficulty=2.5), "difficulty") == "2.5"
@@ -340,7 +342,9 @@ class TestDataRoles:
         type_idx = model.index(0, ALL_COLUMNS.index("cache_type"))
         cont_idx = model.index(0, ALL_COLUMNS.index("container"))
         assert model.data(type_idx, Qt.ItemDataRole.DecorationRole) is not None
-        assert model.data(cont_idx, Qt.ItemDataRole.DecorationRole) is not None
+        # Issue #416: container column has no DecorationRole icon; SizeBarDelegate
+        # paints the cell entirely, so no icon should be returned here.
+        assert model.data(cont_idx, Qt.ItemDataRole.DecorationRole) is None
 
     def test_flag_placeholder_icon_when_unset(self, model):
         model.load([_cache(user_flag=False), _cache(gc_code="GCB", user_flag=True)])
@@ -371,10 +375,6 @@ class TestIconKeys:
     def test_type_icon_mapping(self):
         assert CacheTableModel._type_icon_key(_cache(cache_type="Multi-cache")) == "multi"
         assert CacheTableModel._type_icon_key(_cache(cache_type="Weird Type")) == "unknown"
-
-    def test_size_icon_mapping(self):
-        assert CacheTableModel._size_icon_key(_cache(container="large")) == "large"
-        assert CacheTableModel._size_icon_key(_cache(container="whatever")) == "other"
 
 
 # ── effective coords ────────────────────────────────────────────────────────────


### PR DESCRIPTION
`SizeBarDelegate.paint()` calls `super().paint()` for non-selected rows to draw the standard background. The `_decoration_value()` method was returning a `QIcon` (circular badge from `get_cache_size_icon`) for the container column in "bar" mode. `super().paint()` rendered that icon at the left edge of the cell; then `SizeBarDelegate` painted the five bar segments on top. The icon wasn't fully covered by the first segment, leaving a visual glitch behind it.

The fix: `_decoration_value()` now returns `None` for the container column in all modes — `SizeBarDelegate` owns the full cell rendering in "bar" mode, and "text" mode needs no icon either. The now-unused `_size_icon_key()` method and `get_cache_size_icon` import are removed as cleanup.

Test changes:
- `test_decoration_role_icons`: flipped the container assertion to `is None`
- `test_container_bar_mode_no_decoration_icon`: renamed from `…returns_icon` and flipped to assert `None`
- Removed `test_size_icon_mapping` and the stale `get_cache_size_icon` monkeypatch

Closes #416