### PR TITLE
Enhancement: Center content in the Type column

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -565,7 +565,7 @@ class CacheTableModel(QAbstractTableModel):
             return self._display_value(cache, col)
 
         if role == Qt.ItemDataRole.TextAlignmentRole:
-            if col in ("difficulty", "terrain", "distance", "found",
+            if col in ("cache_type", "difficulty", "terrain", "distance", "found",
                        "dnf", "premium_only", "archived", "log_count",
                        "corrected", "first_to_find", "user_flag", "bearing",
                        "user_sort", "favorite_points",

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -269,8 +269,9 @@ class TestDataRoles:
 
     def test_alignment_role(self, model):
         model.load([_cache()])
-        center_idx = model.index(0, ALL_COLUMNS.index("difficulty"))
-        assert model.data(center_idx, Qt.ItemDataRole.TextAlignmentRole) == Qt.AlignmentFlag.AlignCenter
+        for col in ("cache_type", "difficulty", "terrain", "distance", "found"):
+            idx = model.index(0, ALL_COLUMNS.index(col))
+            assert model.data(idx, Qt.ItemDataRole.TextAlignmentRole) == Qt.AlignmentFlag.AlignCenter, col
         left_idx = model.index(0, ALL_COLUMNS.index("name"))
         assert model.data(left_idx, Qt.ItemDataRole.TextAlignmentRole) != Qt.AlignmentFlag.AlignCenter
 


### PR DESCRIPTION
Closes #415

Add `cache_type` to the set of columns that return `AlignCenter` for `TextAlignmentRole`, so the type icon (and the future text mode from #413) is horizontally centered like all other non-name columns.

- Updated `test_alignment_role` to explicitly assert centering for `cache_type` alongside other centered columns.