### PR TITLE
Improvement: Do not enable the Favorites column by default for new databases

### DIFF
--- a/src/opensak/gui/dialogs/column_dialog.py
+++ b/src/opensak/gui/dialogs/column_dialog.py
@@ -30,7 +30,7 @@ _ALL_COLUMNS_DEF = [
     ("distance",     "col_distance",     75,  True),
     ("bearing",      "col_bearing",      70,  True),
     ("found",        "col_found",        36,  True),
-    ("favorite",     "col_favorite",     36,  True),
+    ("favorite",     "col_favorite",     36, False),
     ("corrected",    "col_corrected_label",    36,  True),
     # Ekstra kolonner (fra)
     ("country",      "col_country",      80, False),

--- a/tests/unit-tests/test_column_dialog.py
+++ b/tests/unit-tests/test_column_dialog.py
@@ -44,6 +44,10 @@ class TestColumnHelpers:
         assert "gc_code" in vis
         assert "country" not in vis  # not a default-visible column
 
+    def test_favorite_not_in_defaults(self, store):
+        # favorite requires the Geocaching API and will always be empty without it
+        assert "favorite" not in get_visible_columns()
+
     def test_visible_roundtrip(self, store):
         set_visible_columns(["gc_code", "name", "country"])
         assert get_visible_columns() == ["gc_code", "name", "country"]


### PR DESCRIPTION
Closes #418

Mark the `favorite` column as non-default (`False`) in `_ALL_COLUMNS_DEF`. The column shows whether the logged-in user has favorited a cache, which requires a live Geocaching API connection. Until that integration is in place the column will always be empty for every database, so there is no value in showing it by default.

Users who want it can enable it at any time via the column chooser.