### PR TITLE
Enhancement: Option to display geocache type as text in the Type column

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -265,6 +265,41 @@ from PySide6.QtGui import QPainter, QColor
 from PySide6.QtCore import QRect
 
 
+class CacheTypeDelegate(QStyledItemDelegate):
+    """Centers the cache-type icon in the column (icon-only mode).
+
+    In 'text' and 'both' modes the default delegate handles rendering;
+    this delegate only kicks in for 'icon' mode where Qt's default would
+    left-align the decoration inside the content rect.
+    """
+
+    def paint(self, painter: QPainter, option, index) -> None:
+        if get_type_display() != "icon":
+            super().paint(painter, option, index)
+            return
+
+        raw = index.data(Qt.ItemDataRole.DecorationRole)
+        if not raw:
+            super().paint(painter, option, index)
+            return
+
+        from PySide6.QtWidgets import QStyle
+        from PySide6.QtGui import QIcon, QPixmap
+        if isinstance(raw, QPixmap):
+            icon = QIcon(raw)
+        elif isinstance(raw, QIcon):
+            icon = raw
+        else:
+            super().paint(painter, option, index)
+            return
+
+        painter.save()
+        style = option.widget.style() if option.widget else QApplication.style()
+        style.drawPrimitive(QStyle.PrimitiveElement.PE_PanelItemViewItem, option, painter, option.widget)
+        icon.paint(painter, option.rect, Qt.AlignmentFlag.AlignCenter)
+        painter.restore()
+
+
 class SizeBarDelegate(QStyledItemDelegate):
     """Tegner GSAK-stil segmenteret størrelsesindikator for container-kolonnen.
 
@@ -974,6 +1009,9 @@ class CacheTableView(QTableView):
                         sizes = TEXT_SIZE_MAP[text_size]
                         self._size_bar_delegate.set_icon_size(sizes["icon"])
                         self.setItemDelegateForColumn(i, self._size_bar_delegate)
+                elif col_id == "cache_type":
+                    self._cache_type_delegate = CacheTypeDelegate(self)
+                    self.setItemDelegateForColumn(i, self._cache_type_delegate)
                 elif col_id == "gc_code":
                     self._gc_code_delegate = GcCodeDelegate(self)
                     self.setItemDelegateForColumn(i, self._gc_code_delegate)

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -22,7 +22,7 @@ from opensak.lang import tr
 from opensak.utils.types import DateFormat, GcCode, TEXT_SIZE_MAP, TextSize, norm_locale_date_fmt
 from opensak.utils.utils import normalize_geocacher_name
 from opensak.gui.icon_provider import get_cache_type_icon, get_flag_placeholder_icon
-from opensak.gui.dialogs.column_dialog import get_column_widths, set_column_widths, get_container_display
+from opensak.gui.dialogs.column_dialog import get_column_widths, set_column_widths, get_container_display, get_type_display
 import math
 
 
@@ -215,6 +215,10 @@ def _container_text(container: str | None, cache_type: str | None) -> str:
         return _NON_PHYSICAL_TEXT_LABELS[type_key]
     size_key = (container or "").lower()
     return _CONTAINER_TEXT_LABELS.get(size_key, (container or "").title())
+
+
+def _type_text(cache_type: str | None) -> str:
+    return (cache_type or "").replace("Unknown", "Mystery")
 
 
 def _container_sort_key(container: str | None, cache_type: str | None = None) -> tuple:
@@ -658,6 +662,8 @@ class CacheTableModel(QAbstractTableModel):
     def _decoration_value(self, cache: Cache, col: str):
         """Return QIcon for columns that show icons."""
         if col == "cache_type":
+            if get_type_display() == "text":
+                return None
             icon_size = TEXT_SIZE_MAP[get_settings().text_size]["grid_icon"]
             return get_cache_type_icon(self._type_icon_key(cache), size=icon_size)
         if col == "container":
@@ -690,7 +696,9 @@ class CacheTableModel(QAbstractTableModel):
         if col == "name":
             return cache.name or ""
         if col == "cache_type":
-            return ""   # ikon vises via DecorationRole — fuldt navn i tooltip
+            if get_type_display() in ("text", "both"):
+                return _type_text(cache.cache_type)
+            return ""  # icon-only: DecorationRole, full name in tooltip
         if col == "difficulty":
             return f"{cache.difficulty:.1f}" if cache.difficulty else "?"
         if col == "terrain":

--- a/src/opensak/gui/dialogs/column_dialog.py
+++ b/src/opensak/gui/dialogs/column_dialog.py
@@ -210,7 +210,7 @@ class ColumnChooserDialog(QDialog):
         self._type_display_combo = QComboBox()
         for label, value in (
             (tr("type_display_icon"), "icon"),
-            (tr("type_display_text"), "text"),
+            (tr("container_display_text"), "text"),
             (tr("type_display_both"), "both"),
         ):
             self._type_display_combo.addItem(label, value)

--- a/src/opensak/gui/dialogs/column_dialog.py
+++ b/src/opensak/gui/dialogs/column_dialog.py
@@ -137,6 +137,20 @@ def set_container_display(mode: str) -> None:
     get_store().set(_CONTAINER_DISPLAY_KEY, mode)
 
 
+_TYPE_DISPLAY_KEY = "columns.type_display"
+
+
+def get_type_display() -> str:
+    """Return the cache_type column display mode: 'icon', 'text', or 'both'."""
+    val = get_store().get(_TYPE_DISPLAY_KEY, "icon")
+    return val if val in ("icon", "text", "both") else "icon"
+
+
+def set_type_display(mode: str) -> None:
+    """Persist the cache_type column display mode."""
+    get_store().set(_TYPE_DISPLAY_KEY, mode)
+
+
 class ColumnChooserDialog(QDialog):
     """Dialog til at vælge hvilke kolonner der vises i cachelisten."""
 
@@ -191,6 +205,20 @@ class ColumnChooserDialog(QDialog):
         display_row.addWidget(self._container_display_combo)
         layout.addLayout(display_row)
 
+        type_row = QHBoxLayout()
+        type_row.addWidget(QLabel(tr("type_display_label")))
+        self._type_display_combo = QComboBox()
+        for label, value in (
+            (tr("type_display_icon"), "icon"),
+            (tr("type_display_text"), "text"),
+            (tr("type_display_both"), "both"),
+        ):
+            self._type_display_combo.addItem(label, value)
+        _type_idx = {"icon": 0, "text": 1, "both": 2}.get(get_type_display(), 0)
+        self._type_display_combo.setCurrentIndex(_type_idx)
+        type_row.addWidget(self._type_display_combo)
+        layout.addLayout(type_row)
+
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok |
             QDialogButtonBox.StandardButton.Cancel
@@ -233,4 +261,5 @@ class ColumnChooserDialog(QDialog):
 
         set_visible_columns(visible)
         set_container_display(self._container_display_combo.currentData())
+        set_type_display(self._type_display_combo.currentData())
         self.accept()

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -509,7 +509,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Text",
     "type_display_label":           "Zobrazení typu:",
     "type_display_icon":            "Ikona",
-    "type_display_text":            "Text",
     "type_display_both":            "Ikona + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -507,6 +507,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Zobrazení velikosti:",
     "container_display_bar":        "Pruh",
     "container_display_text":       "Text",
+    "type_display_label":           "Zobrazení typu:",
+    "type_display_icon":            "Ikona",
+    "type_display_text":            "Text",
+    "type_display_both":            "Ikona + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Uložený filtr:",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -509,7 +509,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Tekst",
     "type_display_label":           "Cache-type visning:",
     "type_display_icon":            "Ikon",
-    "type_display_text":            "Tekst",
     "type_display_both":            "Ikon + Tekst",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -507,6 +507,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Størrelses-visning:",
     "container_display_bar":        "Bjælke",
     "container_display_text":       "Tekst",
+    "type_display_label":           "Cache-type visning:",
+    "type_display_icon":            "Ikon",
+    "type_display_text":            "Tekst",
+    "type_display_both":            "Ikon + Tekst",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Gemt filter:",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -509,7 +509,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Text",
     "type_display_label":           "Cache-Typ-Anzeige:",
     "type_display_icon":            "Symbol",
-    "type_display_text":            "Text",
     "type_display_both":            "Symbol + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -507,6 +507,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Größenanzeige:",
     "container_display_bar":        "Balken",
     "container_display_text":       "Text",
+    "type_display_label":           "Cache-Typ-Anzeige:",
+    "type_display_icon":            "Symbol",
+    "type_display_text":            "Text",
+    "type_display_both":            "Symbol + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Gespeicherte Filter:",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -508,7 +508,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Text",
     "type_display_label":           "Cache type display:",
     "type_display_icon":            "Icon",
-    "type_display_text":            "Text",
     "type_display_both":            "Icon + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -506,6 +506,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Container size display:",
     "container_display_bar":        "Bar",
     "container_display_text":       "Text",
+    "type_display_label":           "Cache type display:",
+    "type_display_icon":            "Icon",
+    "type_display_text":            "Text",
+    "type_display_both":            "Icon + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Saved filter:",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -509,7 +509,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Texte",
     "type_display_label":           "Affichage type:",
     "type_display_icon":            "Icône",
-    "type_display_text":            "Texte",
     "type_display_both":            "Icône + Texte",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -507,6 +507,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Affichage taille:",
     "container_display_bar":        "Barre",
     "container_display_text":       "Texte",
+    "type_display_label":           "Affichage type:",
+    "type_display_icon":            "Icône",
+    "type_display_text":            "Texte",
+    "type_display_both":            "Icône + Texte",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Filtre enregistré:",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -512,7 +512,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Tekst",
     "type_display_label":           "Type weergave:",
     "type_display_icon":            "Pictogram",
-    "type_display_text":            "Tekst",
     "type_display_both":            "Pictogram + Tekst",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -510,6 +510,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Grootte weergave:",
     "container_display_bar":        "Balk",
     "container_display_text":       "Tekst",
+    "type_display_label":           "Type weergave:",
+    "type_display_icon":            "Pictogram",
+    "type_display_text":            "Tekst",
+    "type_display_both":            "Pictogram + Tekst",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Opgeslagen filter:",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -509,7 +509,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Texto",
     "type_display_label":           "Visualização de tipo:",
     "type_display_icon":            "Ícone",
-    "type_display_text":            "Texto",
     "type_display_both":            "Ícone + Texto",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -507,6 +507,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Visualização de tamanho:",
     "container_display_bar":        "Barra",
     "container_display_text":       "Texto",
+    "type_display_label":           "Visualização de tipo:",
+    "type_display_icon":            "Ícone",
+    "type_display_text":            "Texto",
+    "type_display_both":            "Ícone + Texto",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Filtro guardado:",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -509,7 +509,6 @@ STRINGS: dict[str, str] = {
     "container_display_text":       "Text",
     "type_display_label":           "Cache-typ visning:",
     "type_display_icon":            "Ikon",
-    "type_display_text":            "Text",
     "type_display_both":            "Ikon + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -507,6 +507,10 @@ STRINGS: dict[str, str] = {
     "container_display_label":      "Storleksvisning:",
     "container_display_bar":        "Stapel",
     "container_display_text":       "Text",
+    "type_display_label":           "Cache-typ visning:",
+    "type_display_icon":            "Ikon",
+    "type_display_text":            "Text",
+    "type_display_both":            "Ikon + Text",
 
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_saved_label":           "Sparat filter:",

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -114,6 +114,16 @@ class TestHelpers:
         assert _container_text("other", "EarthCache")    == "Earth"
         assert _container_text("other", "Lab Cache")     == "Virtual"
 
+    def test_type_text_passthrough(self):
+        from opensak.gui.cache_table import _type_text
+        assert _type_text("Traditional Cache") == "Traditional Cache"
+        assert _type_text("Multi-cache")       == "Multi-cache"
+        assert _type_text(None)                == ""
+
+    def test_type_text_normalises_unknown(self):
+        from opensak.gui.cache_table import _type_text
+        assert _type_text("Unknown Cache") == "Mystery Cache"
+
 
 # ── model basics ────────────────────────────────────────────────────────────────
 
@@ -182,6 +192,22 @@ class TestDisplayValues:
         # behind the first bar segment via super().paint().
         monkeypatch.setattr(ct, "get_container_display", lambda: "bar")
         assert model._decoration_value(_cache(container="micro"), "container") is None
+
+    def test_type_icon_mode_no_text(self, model, monkeypatch):
+        monkeypatch.setattr(ct, "get_type_display", lambda: "icon")
+        assert model._display_value(_cache(cache_type="Traditional Cache"), "cache_type") == ""
+
+    def test_type_text_mode_shows_text_no_icon(self, model, monkeypatch):
+        monkeypatch.setattr(ct, "get_type_display", lambda: "text")
+        assert model._display_value(_cache(cache_type="Traditional Cache"), "cache_type") == "Traditional Cache"
+        assert model._display_value(_cache(cache_type="Unknown Cache"),     "cache_type") == "Mystery Cache"
+        assert model._display_value(_cache(cache_type=None),                "cache_type") == ""
+        assert model._decoration_value(_cache(cache_type="Traditional Cache"), "cache_type") is None
+
+    def test_type_both_mode_shows_text_and_icon(self, model, monkeypatch):
+        monkeypatch.setattr(ct, "get_type_display", lambda: "both")
+        assert model._display_value(_cache(cache_type="Multi-cache"), "cache_type") == "Multi-cache"
+        assert model._decoration_value(_cache(cache_type="Multi-cache"), "cache_type") is not None
 
     def test_difficulty_terrain(self, model):
         assert model._display_value(_cache(difficulty=2.5), "difficulty") == "2.5"

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -15,6 +15,7 @@ from opensak.gui import cache_table as ct
 from opensak.gui.cache_table import (
     CacheTableModel,
     CacheTableView,
+    CacheTypeDelegate,
     SizeBarDelegate,
     GcCodeDelegate,
     _bearing_deg,
@@ -570,6 +571,22 @@ class TestDelegates:
         delegate.paint(painter, opt, idx)
         painter.end()
 
+    def test_cache_type_delegate_paints_icon_mode(self, model, monkeypatch):
+        monkeypatch.setattr(ct, "get_type_display", lambda: "icon")
+        model.load([_cache(cache_type="Traditional Cache")])
+        self._paint(CacheTypeDelegate(), model, "cache_type")
+        self._paint(CacheTypeDelegate(), model, "cache_type", selected=True)
+
+    def test_cache_type_delegate_falls_back_in_text_mode(self, model, monkeypatch):
+        monkeypatch.setattr(ct, "get_type_display", lambda: "text")
+        model.load([_cache(cache_type="Traditional Cache")])
+        self._paint(CacheTypeDelegate(), model, "cache_type")
+
+    def test_cache_type_delegate_falls_back_in_both_mode(self, model, monkeypatch):
+        monkeypatch.setattr(ct, "get_type_display", lambda: "both")
+        model.load([_cache(cache_type="Traditional Cache")])
+        self._paint(CacheTypeDelegate(), model, "cache_type")
+
     def test_size_bar_delegate_paints_physical(self, model):
         model.load([_cache(container="small", cache_type="traditional cache")])
         d = SizeBarDelegate()
@@ -713,11 +730,13 @@ def view(monkeypatch, qtbot):
 
 class TestView:
     def test_construction_sets_delegates(self, view):
-        # container + gc_code columns get custom delegates
+        # container + gc_code + cache_type columns get custom delegates
         assert isinstance(view.itemDelegateForColumn(ALL_COLUMNS.index("container")),
                           SizeBarDelegate)
         assert isinstance(view.itemDelegateForColumn(ALL_COLUMNS.index("gc_code")),
                           GcCodeDelegate)
+        assert isinstance(view.itemDelegateForColumn(ALL_COLUMNS.index("cache_type")),
+                          CacheTypeDelegate)
 
     def test_load_and_counts(self, view):
         view.load_caches([_cache(gc_code="A"), _cache(gc_code="B", user_flag=True)])

--- a/tests/unit-tests/test_column_dialog.py
+++ b/tests/unit-tests/test_column_dialog.py
@@ -13,9 +13,11 @@ from opensak.gui.dialogs.column_dialog import (
     get_all_columns,
     get_column_widths,
     get_container_display,
+    get_type_display,
     get_visible_columns,
     set_column_widths,
     set_container_display,
+    set_type_display,
     set_visible_columns,
 )
 
@@ -77,6 +79,18 @@ class TestColumnHelpers:
         store.set("columns.container_display", "invalid")
         assert get_container_display() == "bar"
 
+    def test_type_display_defaults_to_icon(self, store):
+        assert get_type_display() == "icon"
+
+    def test_type_display_roundtrip(self, store):
+        for mode in ("icon", "text", "both"):
+            set_type_display(mode)
+            assert get_type_display() == mode
+
+    def test_type_display_invalid_falls_back_to_icon(self, store):
+        store.set("columns.type_display", "invalid")
+        assert get_type_display() == "icon"
+
 
 # ── ColumnChooserDialog ───────────────────────────────────────────────────────
 
@@ -137,6 +151,18 @@ class TestColumnChooserDialog:
         dlg._container_display_combo.setCurrentIndex(1)  # "text"
         dlg._save_and_accept()
         assert get_container_display() == "text"
+
+    def test_type_display_combo_saves_on_accept(self, qtbot, store):
+        dlg = ColumnChooserDialog()
+        qtbot.addWidget(dlg)
+        dlg._type_display_combo.setCurrentIndex(1)  # "text"
+        dlg._save_and_accept()
+        assert get_type_display() == "text"
+        dlg2 = ColumnChooserDialog()
+        qtbot.addWidget(dlg2)
+        dlg2._type_display_combo.setCurrentIndex(2)  # "both"
+        dlg2._save_and_accept()
+        assert get_type_display() == "both"
 
     def test_remove_col_preserves_order_of_remainder(self, qtbot, store):
         set_visible_columns(["name", "gc_code", "found", "difficulty", "terrain"])


### PR DESCRIPTION
## Summary

- Adds a **Cache type display** combo in the Column Chooser dialog with three modes: **Icon** (default, unchanged behaviour), **Text** (type name only, no icon), and **Icon + Text** (icon and name side by side).
- `get_type_display` / `set_type_display` helpers in `column_dialog.py` persist the setting to `opensak.json`.
- `_type_text()` in `cache_table.py` maps the raw `cache_type` value to a display string, normalising "Unknown" → "Mystery" for consistency with the existing tooltip.
- Lang keys added to all 8 language files; the redundant "Text" option reuses `container_display_text` to satisfy the global-key-uniqueness test.

Closes #413