### PR TITLE
Feature: Show geocache attributes on the cache detail page

### DIFF
--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -507,6 +507,7 @@ class CacheDetailPanel(QWidget):
         self._wp_browser.setPlainText("")
         self._note_editor.setPlainText("")
         self._tabs.setTabText(3, tr("detail_tab_waypoints"))
+        self._tabs.setTabText(4, tr("filter_tab_attributes"))
         self._hint_plain = ""
         self._hint_cipher = ""
         self._hint_decoded = False
@@ -700,9 +701,12 @@ class CacheDetailPanel(QWidget):
 
     def _render_attributes(self, cache: Cache) -> None:
         attrs = sorted(cache.attributes, key=lambda a: (not a.is_on, a.name or ""))
+        tab_idx = 4
         if not attrs:
+            self._tabs.setTabText(tab_idx, tr("filter_tab_attributes"))
             self._attr_browser.setPlainText(tr("detail_no_attrs"))
             return
+        self._tabs.setTabText(tab_idx, tr("detail_tab_attrs_count", count=len(attrs)))
         html = []
         for attr in attrs:
             symbol = "✓" if attr.is_on else "✗"

--- a/src/opensak/gui/cache_detail.py
+++ b/src/opensak/gui/cache_detail.py
@@ -289,6 +289,13 @@ class CacheDetailPanel(QWidget):
         wp_layout.addWidget(self._wp_browser)
         self._tabs.addTab(wp_widget, tr("detail_tab_waypoints"))
 
+        attr_widget = QWidget()
+        attr_layout = QVBoxLayout(attr_widget)
+        attr_layout.setContentsMargins(0, 4, 0, 0)
+        self._attr_browser = QTextBrowser()
+        attr_layout.addWidget(self._attr_browser)
+        self._tabs.addTab(attr_widget, tr("filter_tab_attributes"))
+
         note_widget = QWidget()
         note_layout = QVBoxLayout(note_widget)
         note_layout.setContentsMargins(0, 4, 0, 0)
@@ -508,7 +515,8 @@ class CacheDetailPanel(QWidget):
         self._corrected_frame.setVisible(False)
         self._add_corrected_btn.setVisible(False)
         self._current_waypoints: list = []
-        self._tabs.setTabVisible(4, False)
+        self._attr_browser.setPlainText("")
+        self._tabs.setTabVisible(5, False)
         self.waypoints_tab_hidden.emit()
 
     def show_cache(self, cache: Cache) -> None:
@@ -612,7 +620,7 @@ class CacheDetailPanel(QWidget):
         )
 
         # Personal note
-        self._tabs.setTabVisible(4, True)
+        self._tabs.setTabVisible(5, True)
         self._note_editor.setPlainText(
             (cache.user_note.note or "") if cache.user_note else ""
         )
@@ -622,6 +630,9 @@ class CacheDetailPanel(QWidget):
 
         # Child waypoints
         self._render_waypoints(cache)
+
+        # Attributes
+        self._render_attributes(cache)
 
     def _render_logs(self, cache: Cache) -> None:
         logs = sorted(
@@ -686,6 +697,21 @@ class CacheDetailPanel(QWidget):
         self._wp_browser.setHtml("".join(html))
         if self._tabs.currentIndex() == 3:
             self._emit_waypoint_markers()
+
+    def _render_attributes(self, cache: Cache) -> None:
+        attrs = sorted(cache.attributes, key=lambda a: (not a.is_on, a.name or ""))
+        if not attrs:
+            self._attr_browser.setPlainText(tr("detail_no_attrs"))
+            return
+        html = []
+        for attr in attrs:
+            symbol = "✓" if attr.is_on else "✗"
+            colour = "#2e7d32" if attr.is_on else "#c62828"
+            name = attr.name or str(attr.attribute_id)
+            html.append(
+                f'<p><span style="color:{colour};font-weight:bold">{symbol}</span> {name}</p>'
+            )
+        self._attr_browser.setHtml("".join(html))
 
     def _on_tab_changed(self, idx: int) -> None:
         if idx == 3:

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -574,6 +574,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypointy",
     "detail_tab_waypoints_count":   "Waypointy ({count})",
     "detail_no_waypoints":          "(Žádné podřízené waypointy)",
+    "detail_tab_attrs_count":       "Atributy ({count})",
     "detail_no_attrs":              "(Žádné atributy)",
     "detail_tab_notes":             "Poznámky",
     "detail_note_placeholder":      "Přidat osobní poznámku k tomuto cache…",

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -574,6 +574,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypointy",
     "detail_tab_waypoints_count":   "Waypointy ({count})",
     "detail_no_waypoints":          "(Žádné podřízené waypointy)",
+    "detail_no_attrs":              "(Žádné atributy)",
     "detail_tab_notes":             "Poznámky",
     "detail_note_placeholder":      "Přidat osobní poznámku k tomuto cache…",
     "detail_wp_no_coords":          "(Žádné souřadnice)",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Ingen underordnede waypoints)",
+    "detail_no_attrs":              "(Ingen attributter)",
     "detail_tab_notes":             "Noter",
     "detail_note_placeholder":      "Tilføj en personlig note til denne cache…",
     "detail_wp_no_coords":          "(Ingen koordinater)",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Ingen underordnede waypoints)",
+    "detail_tab_attrs_count":       "Attributter ({count})",
     "detail_no_attrs":              "(Ingen attributter)",
     "detail_tab_notes":             "Noter",
     "detail_note_placeholder":      "Tilføj en personlig note til denne cache…",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Wegpunkte",
     "detail_tab_waypoints_count":   "Wegpunkte ({count})",
     "detail_no_waypoints":          "(Keine untergeordneten Wegpunkte)",
+    "detail_tab_attrs_count":       "Attribute ({count})",
     "detail_no_attrs":              "(Keine Attribute)",
     "detail_tab_notes":             "Notizen",
     "detail_note_placeholder":      "Persönliche Notiz für diesen Cache hinzufügen…",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Wegpunkte",
     "detail_tab_waypoints_count":   "Wegpunkte ({count})",
     "detail_no_waypoints":          "(Keine untergeordneten Wegpunkte)",
+    "detail_no_attrs":              "(Keine Attribute)",
     "detail_tab_notes":             "Notizen",
     "detail_note_placeholder":      "Persönliche Notiz für diesen Cache hinzufügen…",
     "detail_wp_no_coords":          "(Keine Koordinaten)",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -572,6 +572,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(No child waypoints)",
+    "detail_no_attrs":              "(No attributes)",
     "detail_tab_notes":             "Notes",
     "detail_note_placeholder":      "Add a personal note for this cache…",
     "detail_wp_no_coords":          "(No coordinates)",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -572,6 +572,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(No child waypoints)",
+    "detail_tab_attrs_count":       "Attributes ({count})",
     "detail_no_attrs":              "(No attributes)",
     "detail_tab_notes":             "Notes",
     "detail_note_placeholder":      "Add a personal note for this cache…",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Points de passage",
     "detail_tab_waypoints_count":   "Points de passage ({count})",
     "detail_no_waypoints":          "(Aucun point de passage enfant)",
+    "detail_no_attrs":              "(Aucun attribut)",
     "detail_tab_notes":             "Notes",
     "detail_note_placeholder":      "Ajouter une note personnelle pour ce cache…",
     "detail_wp_no_coords":          "(Pas de coordonnées)",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Points de passage",
     "detail_tab_waypoints_count":   "Points de passage ({count})",
     "detail_no_waypoints":          "(Aucun point de passage enfant)",
+    "detail_tab_attrs_count":       "Attributs ({count})",
     "detail_no_attrs":              "(Aucun attribut)",
     "detail_tab_notes":             "Notes",
     "detail_note_placeholder":      "Ajouter une note personnelle pour ce cache…",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -577,6 +577,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Geen onderliggende waypoints)",
+    "detail_no_attrs":              "(Geen attributen)",
     "detail_tab_notes":             "Notities",
     "detail_note_placeholder":      "Voeg een persoonlijke notitie toe voor deze cache…",
     "detail_wp_no_coords":          "(Geen coördinaten)",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -577,6 +577,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Geen onderliggende waypoints)",
+    "detail_tab_attrs_count":       "Attributen ({count})",
     "detail_no_attrs":              "(Geen attributen)",
     "detail_tab_notes":             "Notities",
     "detail_note_placeholder":      "Voeg een persoonlijke notitie toe voor deze cache…",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -574,6 +574,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Sem waypoints filhos)",
+    "detail_tab_attrs_count":       "Atributos ({count})",
     "detail_no_attrs":              "(Sem atributos)",
     "detail_tab_notes":             "Notas",
     "detail_note_placeholder":      "Adicionar uma nota pessoal para este cache…",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -574,6 +574,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Sem waypoints filhos)",
+    "detail_no_attrs":              "(Sem atributos)",
     "detail_tab_notes":             "Notas",
     "detail_note_placeholder":      "Adicionar uma nota pessoal para este cache…",
     "detail_wp_no_coords":          "(Sem coordenadas)",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Inga underordnade waypoints)",
+    "detail_no_attrs":              "(Inga attribut)",
     "detail_tab_notes":             "Anteckningar",
     "detail_note_placeholder":      "Lägg till en personlig anteckning för denna cache…",
     "detail_wp_no_coords":          "(Inga koordinater)",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -573,6 +573,7 @@ STRINGS: dict[str, str] = {
     "detail_tab_waypoints":         "Waypoints",
     "detail_tab_waypoints_count":   "Waypoints ({count})",
     "detail_no_waypoints":          "(Inga underordnade waypoints)",
+    "detail_tab_attrs_count":       "Attribut ({count})",
     "detail_no_attrs":              "(Inga attribut)",
     "detail_tab_notes":             "Anteckningar",
     "detail_note_placeholder":      "Lägg till en personlig anteckning för denna cache…",

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -398,11 +398,23 @@ def _fake_attr(name, is_on=True, attribute_id=1):
 
 
 def test_attrs_tab_empty(monkeypatch, qapp):
-    # Regression for #417: cache with no attributes shows the empty message.
+    # Regression for #417: cache with no attributes shows the empty message and base tab title.
     monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
     panel = CacheDetailPanel()
     panel._render_attributes(SimpleNamespace(attributes=[]))
     assert tr("detail_no_attrs") in panel._attr_browser.toPlainText()
+    assert panel._tabs.tabText(4) == tr("filter_tab_attributes")
+
+
+def test_attrs_tab_count_in_title(monkeypatch, qapp):
+    # Regression for #417: tab title shows count when attributes are present.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._render_attributes(SimpleNamespace(attributes=[
+        _fake_attr("Dogs allowed", attribute_id=1),
+        _fake_attr("Kids", is_on=False, attribute_id=2),
+    ]))
+    assert panel._tabs.tabText(4) == tr("detail_tab_attrs_count", count=2)
 
 
 def test_attrs_tab_renders_yes_attribute(monkeypatch, qapp):
@@ -426,9 +438,11 @@ def test_attrs_tab_renders_no_attribute(monkeypatch, qapp):
 
 
 def test_attrs_tab_cleared_on_clear(monkeypatch, qapp):
-    # Regression for #417: clear() resets the attributes browser.
+    # Regression for #417: clear() resets the attributes browser and tab title.
     monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
     panel = CacheDetailPanel()
     panel._render_attributes(SimpleNamespace(attributes=[_fake_attr("Dogs allowed")]))
+    assert panel._tabs.tabText(4) == tr("detail_tab_attrs_count", count=1)
     panel.clear()
     assert panel._attr_browser.toPlainText() == ""
+    assert panel._tabs.tabText(4) == tr("filter_tab_attributes")

--- a/tests/unit-tests/test_cache_detail.py
+++ b/tests/unit-tests/test_cache_detail.py
@@ -247,11 +247,18 @@ def _minimal_gpx(gsak_ext: str = "") -> str:
     """)
 
 
-def test_notes_tab_exists_at_index_4(monkeypatch, qapp):
-    # The Notes tab must be the fifth tab (index 4).
+def test_attrs_tab_exists_at_index_4(monkeypatch, qapp):
+    # Regression for #417: Attributes tab is the fifth tab (index 4).
     monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
     panel = CacheDetailPanel()
-    assert panel._tabs.tabText(4) == tr("detail_tab_notes")
+    assert panel._tabs.tabText(4) == tr("filter_tab_attributes")
+
+
+def test_notes_tab_exists_at_index_5(monkeypatch, qapp):
+    # Notes tab shifted to index 5 when Attributes tab was added (#417).
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    assert panel._tabs.tabText(5) == tr("detail_tab_notes")
 
 
 def test_notes_tab_loads_existing_note(monkeypatch, tmp_path, qapp):
@@ -275,6 +282,7 @@ def test_notes_tab_loads_existing_note(monkeypatch, tmp_path, qapp):
                 joinedload(CacheModel.user_note),
                 joinedload(CacheModel.logs),
                 joinedload(CacheModel.waypoints),
+                joinedload(CacheModel.attributes),
             )
             .filter_by(gc_code="GCNOTES1")
             .one()
@@ -302,6 +310,7 @@ def test_notes_tab_save_roundtrip(monkeypatch, tmp_path, qapp):
                 joinedload(CacheModel.user_note),
                 joinedload(CacheModel.logs),
                 joinedload(CacheModel.waypoints),
+                joinedload(CacheModel.attributes),
             )
             .filter_by(gc_code="GCNOTES1")
             .one()
@@ -347,6 +356,7 @@ def _load_cache(tmp_path, db_suffix="icon"):
                 joinedload(CacheModel.user_note),
                 joinedload(CacheModel.logs),
                 joinedload(CacheModel.waypoints),
+                joinedload(CacheModel.attributes),
             )
             .filter_by(gc_code="GCNOTES1")
             .one()
@@ -379,3 +389,46 @@ def test_type_icon_resizes_on_refresh(monkeypatch, tmp_path, qapp):
     monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings(text_size=TextSize.LARGE))
     panel.refresh_sizes()
     assert panel._type_icon_lbl.width() == TEXT_SIZE_MAP[TextSize.LARGE]["detail_icon"]
+
+
+# ── Attributes tab tests (issue #417) ────────────────────────────────────────
+
+def _fake_attr(name, is_on=True, attribute_id=1):
+    return SimpleNamespace(attribute_id=attribute_id, name=name, is_on=is_on)
+
+
+def test_attrs_tab_empty(monkeypatch, qapp):
+    # Regression for #417: cache with no attributes shows the empty message.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._render_attributes(SimpleNamespace(attributes=[]))
+    assert tr("detail_no_attrs") in panel._attr_browser.toPlainText()
+
+
+def test_attrs_tab_renders_yes_attribute(monkeypatch, qapp):
+    # Regression for #417: is_on=True attribute is shown with a check mark.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._render_attributes(SimpleNamespace(attributes=[_fake_attr("Dogs allowed", is_on=True)]))
+    html = panel._attr_browser.toHtml()
+    assert "Dogs allowed" in html
+    assert "✓" in html
+
+
+def test_attrs_tab_renders_no_attribute(monkeypatch, qapp):
+    # Regression for #417: is_on=False attribute is shown with a cross mark.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._render_attributes(SimpleNamespace(attributes=[_fake_attr("Dogs allowed", is_on=False)]))
+    html = panel._attr_browser.toHtml()
+    assert "Dogs allowed" in html
+    assert "✗" in html
+
+
+def test_attrs_tab_cleared_on_clear(monkeypatch, qapp):
+    # Regression for #417: clear() resets the attributes browser.
+    monkeypatch.setattr(cd, "get_settings", lambda: _fake_settings())
+    panel = CacheDetailPanel()
+    panel._render_attributes(SimpleNamespace(attributes=[_fake_attr("Dogs allowed")]))
+    panel.clear()
+    assert panel._attr_browser.toPlainText() == ""


### PR DESCRIPTION
Adds a dedicated **Attributes** tab (index 4, just before Notes) to the cache detail panel.

Each attribute stored on the cache is listed with a green ✓ (`is_on=True`) or a red ✗ (`is_on=False`) marker followed by the attribute name (e.g. "Dogs allowed", "Available 24/7"). When a cache has no attributes the tab shows "(No attributes)".

Implementation notes:
- Tab title reuses the existing `filter_tab_attributes` i18n key.
- New `detail_no_attrs` key added to all 8 language files.
- `_render_attributes()` sorts positive attributes before negative ones, then alphabetically.
- Notes tab shifted from index 4 → 5; all existing references updated.
- Tests updated to eager-load the `attributes` relationship wherever `show_cache()` is called.

Closes #417