### PR TITLE
Some text columns are not horizontally centered in the cache table

### DIFF
--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -615,11 +615,13 @@ class CacheTableModel(QAbstractTableModel):
             return self._display_value(cache, col)
 
         if role == Qt.ItemDataRole.TextAlignmentRole:
-            if col in ("cache_type", "difficulty", "terrain", "distance", "found",
-                       "dnf", "premium_only", "archived", "log_count",
-                       "corrected", "first_to_find", "user_flag", "locked", "bearing",
-                       "user_sort", "favorite_points",
-                       "latitude", "longitude"):
+            if col in ("cache_type", "difficulty", "terrain", "container",
+                       "distance", "found", "dnf", "premium_only", "archived",
+                       "log_count", "corrected", "first_to_find", "user_flag",
+                       "locked", "bearing", "user_sort", "favorite_points",
+                       "latitude", "longitude", "favorite",
+                       "hidden_date", "last_log", "found_date", "dnf_date",
+                       "placed_by"):
                 return Qt.AlignmentFlag.AlignCenter
             return Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
 

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -304,11 +304,14 @@ class TestDataRoles:
 
     def test_alignment_role(self, model):
         model.load([_cache()])
-        for col in ("cache_type", "difficulty", "terrain", "distance", "found"):
+        for col in ("cache_type", "difficulty", "terrain", "distance", "found",
+                    "container", "favorite", "hidden_date", "last_log",
+                    "found_date", "dnf_date", "placed_by"):
             idx = model.index(0, ALL_COLUMNS.index(col))
             assert model.data(idx, Qt.ItemDataRole.TextAlignmentRole) == Qt.AlignmentFlag.AlignCenter, col
-        left_idx = model.index(0, ALL_COLUMNS.index("name"))
-        assert model.data(left_idx, Qt.ItemDataRole.TextAlignmentRole) != Qt.AlignmentFlag.AlignCenter
+        for col in ("name", "gc_code", "country", "state", "county"):
+            idx = model.index(0, ALL_COLUMNS.index(col))
+            assert model.data(idx, Qt.ItemDataRole.TextAlignmentRole) != Qt.AlignmentFlag.AlignCenter, col
 
     def test_font_role_italic_when_found(self, model):
         model.load([_cache(found=True)])


### PR DESCRIPTION
Closes #431

## What changed

Extended the `TextAlignmentRole` list in `CacheTableModel.data()` to center the columns that were reported as inconsistently left-aligned:

- **Placed By** (`placed_by`)
- **Hidden Date** (`hidden_date`)
- **Container** in text mode (`container`)
- **Favorite** (`favorite`) — renders "★" or empty, same pattern
- **Last Log**, **Found Date**, **DNF Date** — date columns, same type as Hidden Date