### PR TITLE
Automatically notify linked issues when a PR merges to beta

### DIFF
--- a/.github/workflows/notify-linked-issues.yml
+++ b/.github/workflows/notify-linked-issues.yml
@@ -1,0 +1,39 @@
+name: Notify linked issues on beta merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - beta
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment on linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issues = [...new Set([...body.matchAll(pattern)].map(m => parseInt(m[1])))];
+
+            if (issues.length === 0) {
+              console.log('No linked issues found in PR body.');
+              return;
+            }
+
+            for (const issueNumber of issues) {
+              console.log(`Commenting on issue #${issueNumber}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `This has been merged in PR #${prNumber} and will be included in the **next beta release**. 🎉`
+              });
+            }

--- a/.github/workflows/notify-linked-issues.yml
+++ b/.github/workflows/notify-linked-issues.yml
@@ -1,7 +1,7 @@
 name: Notify linked issues on beta merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - beta


### PR DESCRIPTION
Closes #433

## What

Adds `.github/workflows/notify-linked-issues.yml` — a GitHub Actions workflow that fires whenever a PR is merged into `beta`, parses the PR body for issue references (`closes #X`, `fixes #X`, `resolves #X`, etc.), and posts a comment on each linked issue:

> This has been merged in PR #X and will be included in the **next beta release**. 🎉

## Why

Raised in [discussion #428](https://github.com/AgreeDK/OpenSAK/discussions/428). Because PRs target `beta` (not the default branch), GitHub's native auto-close never fires and users following issues have no signal that a fix has landed.

## How it works

- Triggers only on actual merges (`merged == true`), not on closed-without-merge
- Regex covers all standard GitHub closing keywords, case-insensitive
- Deduplicates issue numbers in case the same issue appears twice in the PR body
- Requires only `issues: write` permission — no other access needed
- Zero overhead for maintainers: no milestones, no manual steps