### PR TITLE
Reverse geocoding: validity-repair county geometry

### DIFF
--- a/tests/unit-tests/test_gsak_to_opensak.py
+++ b/tests/unit-tests/test_gsak_to_opensak.py
@@ -74,9 +74,15 @@ def test_county_packs_are_flat_and_manifest_matches_real_versions(tmp_path: Path
     assert manifest["packs"]["usa_texas.geojson"]["version"] == "5"
 
 
-def test_simplify_noop_when_tolerance_is_zero() -> None:
+def test_simplify_preserves_shape_when_tolerance_is_zero() -> None:
+    # tolerance=0 skips Douglas-Peucker, but the result still round-trips through
+    # shapely for the validity check (counties rely on this — see the comment
+    # on _simplify), so compare geometrically rather than by raw dict equality.
+    from shapely.geometry import shape
+
     geom: dict[str, object] = {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}
-    assert conv._simplify(geom, 0.0) == geom
+    result = conv._simplify(geom, 0.0)
+    assert shape(result).equals(shape(geom))
 
 
 def test_simplify_repairs_self_intersection_from_preserve_topology(monkeypatch) -> None:
@@ -100,6 +106,31 @@ def test_simplify_repairs_self_intersection_from_preserve_topology(monkeypatch) 
     from shapely.geometry import shape
 
     assert shape(result).is_valid
+
+
+def test_county_output_is_validity_repaired(tmp_path: Path) -> None:
+    # Real GSAK county rings are self-intersecting for ~6% of real counties —
+    # not something simplification introduces, present in the raw parsed data
+    # itself. Counties are never Douglas-Peucker simplified, but must still go
+    # through the same validity repair as the baseline layers (see _simplify).
+    from shapely.geometry import shape
+
+    bb_path = tmp_path / "bb.db3"
+    _write_bb_db3(bb_path)
+    _write_country_zip(tmp_path / "country_v1.zip", "1", "United States")
+    # Bowtie ring (lat,lon lines): (0,0),(10,10),(10,0),(0,10),(0,0) in [lon,lat].
+    bowtie_txt = "0,0\n10,10\n0,10\n10,0\n0,0\n"
+    zip_path = tmp_path / "counties" / "usa" / "california_v3.zip"
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("1.txt", f"# GsakName=Bowtie County\n{bowtie_txt}")
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    _run(bb_path, tmp_path, out_dir)
+
+    fc = json.loads((out_dir / "counties" / "usa_california.geojson").read_text())
+    assert shape(fc["features"][0]["geometry"]).is_valid
 
 
 def _run(bb_path: Path, gsak_dir: Path, out_dir: Path) -> None:

--- a/tools/boundaries/gsak_to_opensak.py
+++ b/tools/boundaries/gsak_to_opensak.py
@@ -181,19 +181,26 @@ def _geometry(polygons: list[list[list[list[float]]]]) -> dict[str, object]:
 
 
 def _simplify(geom: dict[str, object], tolerance: float) -> dict[str, object]:
-    # Douglas-Peucker, degrees-based tolerance. Baseline layers only (country/state) —
-    # counties stay full-resolution since they're fetched on demand, not bundled.
-    if tolerance <= 0 or not geom.get("coordinates"):
+    # Douglas-Peucker (degrees-based tolerance) for the baseline layers
+    # (country/state) only — counties stay full-resolution since they're
+    # fetched on demand, not bundled. Called with tolerance=0 for counties to
+    # skip simplification but still get the validity repair below: the raw
+    # GSAK-derived rings are self-intersecting for ~6% of real counties (not
+    # something simplification introduces), and shapely's .contains() doesn't
+    # raise on an invalid geometry — it silently returns wrong answers.
+    if not geom.get("coordinates"):
         return geom
-    simplified = _shp_shape(geom).simplify(tolerance, preserve_topology=True)
-    if not simplified.is_valid:
+    shp = _shp_shape(geom)
+    if tolerance > 0:
+        shp = shp.simplify(tolerance, preserve_topology=True)
+    if not shp.is_valid:
         # preserve_topology doesn't fully guarantee validity on complex multi-ring
         # geometries (nearby-but-separate rings can end up crossing) — buffer(0)
-        # is the standard GEOS trick to repair minor self-intersections.
-        simplified = simplified.buffer(0)
-    if simplified.is_empty:
+        # is the standard GEOS trick to repair self-intersections.
+        shp = shp.buffer(0)
+    if shp.is_empty:
         return geom
-    return _shp_mapping(simplified)
+    return _shp_mapping(shp)
 
 
 def _feature(name: str, parent: str | None, geom: dict[str, object], version: int) -> dict[str, object]:
@@ -411,7 +418,8 @@ def _convert_counties(
                 if content is None:
                     continue
 
-                geom = _geometry(_parse_gsak_txt(content))
+                # tolerance=0: no simplification, but still validity-checked/repaired.
+                geom = _simplify(_geometry(_parse_gsak_txt(content)), 0.0)
                 feature_index = len(pack_features)
                 pack_features.append(_feature(cname, cc, geom, version))
 


### PR DESCRIPTION
Generating the real dataset end to end and validating every feature's geometry (not just the simplified baseline from the last PR) surfaced a pre-existing bug: 1168 of 20026 real counties (~6%) have self-intersecting rings straight out of the raw GSAK parse. This has nothing to do with simplification -- counties never go through Douglas-Peucker, so this bug predates that work and has been there since Phase 0.

shapely's Polygon.contains() does not raise on an invalid geometry -- it silently returns wrong answers. That means this was a live correctness bug in the resolver for any coordinate near one of those ~6% of counties (confirmed Liberia's "Greater Monrovia" was one of them, and it resolves correctly now).

_simplify() now always validity-checks and buffer(0)-repairs its result regardless of tolerance; Douglas-Peucker itself still only runs when tolerance>0. Counties call it with tolerance=0 to get the repair without any geometric simplification.

Verified against the real dataset: 0/22340 invalid features across all three layers (was 1168 invalid counties before this fix).

#60