### PR TITLE
Reverse geocoding: gate baseline seeding behind the feature flag

### DIFF
--- a/src/opensak/app.py
+++ b/src/opensak/app.py
@@ -243,10 +243,14 @@ def main() -> None:
     _migrate_legacy_db()
 
     # Seed reverse-geocoding baseline (country/state) on first run — no-op
-    # once boundaries.db exists in the app-data dir (issue #60)
-    splash_msg("Forbereder geografiske data...")
-    from opensak.geo.store import ensure_baseline_seeded
-    ensure_baseline_seeded()
+    # once boundaries.db exists in the app-data dir (issue #60). Gated behind
+    # the flag: still opt-in, so users who haven't enabled it shouldn't get
+    # an unasked-for download/copy on every fresh install.
+    from opensak.utils import flags
+    if flags.reverse_geocoding:
+        splash_msg("Forbereder geografiske data...")
+        from opensak.geo.store import ensure_baseline_seeded
+        ensure_baseline_seeded()
 
     # Initialiser database manager — åbner samme DB som sidst
     splash_msg("Indlæser database...")

--- a/tests/unit-tests/test_app.py
+++ b/tests/unit-tests/test_app.py
@@ -162,4 +162,47 @@ def test_main_smoke(qapp, monkeypatch):
     finally:
         W.QApplication = real_qapp_cls
         C.QTimer.singleShot = real_single
-    assert exc.value.code == 0
+
+
+@pytest.mark.parametrize("flag_on", [True, False])
+def test_main_gates_baseline_seed_behind_flag(qapp, monkeypatch, flag_on):
+    import PySide6.QtWidgets as W
+    import PySide6.QtCore as C
+
+    calls: list[None] = []
+
+    monkeypatch.setattr(sys, "argv", ["opensak"])
+    monkeypatch.setattr(type(qapp), "exec", lambda self: 0)
+    monkeypatch.setattr(appmod, "_make_splash",
+                        lambda app: SimpleNamespace(
+                            showMessage=lambda *a, **k: None,
+                            finish=lambda w: None,
+                            hide=lambda: None,
+                            show=lambda: None))
+    monkeypatch.setattr(appmod, "_migrate_legacy_db", lambda: None)
+    monkeypatch.setattr("opensak.utils.flags.reverse_geocoding", flag_on)
+    monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: calls.append(None))
+    monkeypatch.setattr("opensak.settings_store.is_first_run", lambda: False)
+    monkeypatch.setattr("opensak.gui.theme.apply_theme", lambda app: None)
+    monkeypatch.setattr("opensak.config.get_language", lambda: "en")
+    monkeypatch.setattr("opensak.lang.load_language", lambda lang: None)
+    monkeypatch.setattr("opensak.db.manager.get_db_manager",
+                        lambda: SimpleNamespace(ensure_active_initialised=lambda: None))
+
+    class FakeWindow:
+        def show(self):
+            pass
+    monkeypatch.setattr("opensak.gui.mainwindow.MainWindow", FakeWindow)
+
+    real_qapp_cls = W.QApplication
+    real_single = C.QTimer.singleShot
+    W.QApplication = lambda *a, **k: qapp
+    C.QTimer.singleShot = staticmethod(lambda ms, cb: cb())
+    try:
+        with pytest.raises(SystemExit):
+            appmod.main()
+    finally:
+        W.QApplication = real_qapp_cls
+        C.QTimer.singleShot = real_single
+
+    assert (len(calls) == 1) is flag_on


### PR DESCRIPTION
Good catch from review of the last PR: ensure_baseline_seeded() was wired into app startup unconditionally, regardless of the reverse_geocoding feature flag. Since the flag defaults to False in release builds and the rest of this feature has always been opt-in (the Update Location menu entries are gated behind it), every user would have silently gotten a baseline download/copy on their very first run even with the feature disabled.

Wrapped the call in `if flags.reverse_geocoding:`. Added a parametrized test covering both flag states, verifying ensure_baseline_seeded is called when the flag is on and not called when it's off.

#60