### PR TITLE
Reverse geocoding: update plan docs to reflect real status

### DIFF
--- a/docs/reverse-geocoding-data.md
+++ b/docs/reverse-geocoding-data.md
@@ -1,40 +1,48 @@
 # Reverse-geocoding boundary data (`data/`)
 
-The offline boundary engine (`src/opensak/geo/`, issue #60) reads its dataset
-from a **local `data/` folder at the repo root**. That folder is a *dev-only
-stand-in*: it is **git-ignored** (see `.gitignore`) and exists only until the
-real dataset is published to the **`OpenSAK-Org/OpenSAK-Data`** repository and
-seeded into the per-user app-data directory. The switch-over is described in
-[`plans/reverse-geocoding-data-migration.md`](../plans/reverse-geocoding-data-migration.md).
+The offline boundary engine (`src/opensak/geo/`, issue #60) reads its real
+dataset from **`config.get_app_data_dir()/boundaries`** — seeded on first run
+from either the PyInstaller-bundled baseline or a download from the published
+**`OpenSAK-Org/OpenSAK-Data`** repository (`reverse-geocoding-v1` release), see
+`geo/store.ensure_baseline_seeded()`.
 
-Until then, drop the files below into `data/` by hand to exercise the engine.
+A **local `data/` folder at the repo root** is still used as a dev/regeneration
+workspace: it's where `tools/boundaries/gsak_to_opensak.py` reads its GSAK
+source files (`bb.db3` + zips, gitignored) and writes its output, and it's
+handy for hand-testing the engine against a throwaway dataset. It is **not**
+an implicit runtime fallback any more — the app only reads it when
+`OPENSAK_BOUNDARIES_DIR` explicitly points at it.
 
 ## Where the engine looks
 
 `geo.store.default_data_dir()` resolves, in order:
 
-1. `$OPENSAK_BOUNDARIES_DIR` if set (used by the tests and handy for pointing at
-   a throwaway dataset);
-2. otherwise `<repo-root>/data`.
+1. `$OPENSAK_BOUNDARIES_DIR` if set (used by the tests, and by pointing it at
+   the repo-root `data/` folder for local dev/hand-testing);
+2. otherwise `config.get_app_data_dir() / "boundaries"` — the real per-user
+   app-data directory.
 
 So `OPENSAK_BOUNDARIES_DIR=/some/path python …` overrides it without touching
 the tree.
 
 ## Expected layout
 
-`data/` mirrors the future `<app-data>/opensak/boundaries/` layout from the
+`data/` mirrors the real `<app-data>/boundaries/` layout from the
 [architecture doc](../architecture/reverse-geocoding.md#53-on-disk-layout-and-caching):
 
 ```
 data/
 ├── boundaries.db        # SQLite: per-layer R-Trees + region metadata
-├── manifest.json        # dataset + per-pack versions (used from Phase 2 on)
+├── manifest.json        # dataset version; "baseline" (world.geojson + state packs)
+│                         # and "packs" (county, on-demand) sections
 ├── countries/
 │   └── world.geojson    # baseline — one country FeatureCollection
 ├── states/
-│   └── *.geojson        # baseline
+│   └── *.geojson        # baseline, one per country code (e.g. prt.geojson)
 └── counties/
-    └── <cc>.geojson     # one FeatureCollection per country (e.g. prt.geojson)
+    └── <cc>_<pack>.geojson   # flat — one or more per country (e.g. prt_all_prt.geojson,
+                                # usa_california.geojson); flat because GitHub Release
+                                # assets can't hold subdirectories
 ```
 
 ## `boundaries.db` schema

--- a/plans/reverse-geocoding-data-migration.md
+++ b/plans/reverse-geocoding-data-migration.md
@@ -1,6 +1,6 @@
 # Plan — migrate boundary data from local `data/` to `OpenSAK-Data`
 
-Status: Proposed (future work)
+Status: DONE. `OpenSAK-Data` hosts a real published release (`reverse-geocoding-v1`); `default_data_dir()` no longer falls back to the repo automatically; shipped builds bundle the baseline and seed it into the real app-data dir on first run, with a network-fetch fallback when nothing's bundled. Gated behind `flags.reverse_geocoding`.
 Relates to: GitHub issue #60 · [`architecture/reverse-geocoding.md`](../architecture/reverse-geocoding.md) · [`plans/reverse-geocoding.md`](./reverse-geocoding.md)
 
 The engine currently reads from a dev-only, git-ignored `data/` folder at the
@@ -22,50 +22,50 @@ here as one migration story so the cut-over from `data/` is explicit.
 
 ## Steps
 
-1. **Produce the real dataset (main-plan Phase 0).** Once Mike's polygon files
-   arrive, run the `tools/boundaries/` pipeline to emit `boundaries.db`, the
-   baseline GeoJSON (`countries/`, `states/`), the per-country county packs and
-   `manifest.json`. Publish them as **GitHub Release assets** on
-   `OpenSAK-Org/OpenSAK-Data` (public, ODbL `LICENSE` + attribution). The artefacts
-   must match the contract in [`docs/reverse-geocoding-data.md`](../docs/reverse-geocoding-data.md)
-   so the engine reads them unchanged.
+1. **Produce the real dataset (main-plan Phase 0). ✓ DONE.** `tools/boundaries/gsak_to_opensak.py`
+   emits `boundaries.db`, the baseline GeoJSON (`countries/`, `states/`), the
+   per-country county packs and `manifest.json`. Published as **GitHub Release
+   assets** on `OpenSAK-Org/OpenSAK-Data`, tag `reverse-geocoding-v1` (242
+   assets, public, ODbL `LICENSE` + attribution under `reverse-geocoding/`).
 
-2. **Bundle the baseline in the install (main-plan Phase 5).** Ship
-   `boundaries.db` + `countries/` + `states/` as package data via `opensak.spec`
-   (`datas` / `collect_data_files`). On first run, seed them into
-   `get_app_data_dir()/boundaries/` if absent — so country/state resolution works
-   offline from first launch, with no network.
+2. **Bundle the baseline in the install (main-plan Phase 5). ✓ DONE.** `opensak.spec`
+   ships `boundaries.db` + `countries/` + `states/` as package data — **not**
+   `counties/`, which was being bundled unconditionally before this fix (a few
+   hundred MB, the opposite of the on-demand design). `ensure_baseline_seeded()`
+   seeds `get_app_data_dir()/boundaries/` on first run from the bundle if
+   present, else downloads via `fetch_baseline()`.
 
-3. **Flip `default_data_dir()`.** Change its fallback from `<repo-root>/data` to
-   `config.get_app_data_dir() / "boundaries"`. Keep the `OPENSAK_BOUNDARIES_DIR`
-   override (tests and local datasets rely on it), so `test_geo.py` keeps working
-   untouched.
+3. **Flip `default_data_dir()`. ✓ DONE.** Fallback is now
+   `config.get_app_data_dir() / "boundaries"`. `OPENSAK_BOUNDARIES_DIR` override
+   kept, `test_geo.py` untouched.
 
-4. **Add on-demand county packs (main-plan Phase 2): `geo/packs.py`.** On a
-   county cache miss, download that country's pack from its `OpenSAK-Data`
-   Release URL, write it under `counties/` with an **atomic** temp-then-swap, and
-   serve locally thereafter. Add a "download all" pre-fetch and a throttled
-   `manifest.json` update check (re-download only changed files; flag affected
-   caches' `location_dataset` as stale rather than rewriting values). `BoundaryStore`
-   gains a "pack missing" path that calls into `packs.py`; the resolver still just
-   asks the store for geometry.
+4. **Add on-demand county packs (main-plan Phase 2): `geo/packs.py`. ✓ DONE.**
+   County cache miss → `fetch_pack` downloads that pack, atomic temp+rename,
+   served locally thereafter. `fetch_all` ("download all"), `check_update`/
+   `apply_update` (throttled manifest check), and now `fetch_baseline` (the
+   country/state wholesale download for step 2) all verified live against the
+   real release, not just mocked.
 
-5. **Retire the stand-in.** Remove the `/data/` entry from `.gitignore` and the
-   note from [`docs/reverse-geocoding-data.md`](../docs/reverse-geocoding-data.md)
-   (or keep `OPENSAK_BOUNDARIES_DIR` documented purely as a dev override). The
-   repo-root `data/` folder is no longer special.
+5. **Retire the stand-in. ✓ DONE, in spirit.** `default_data_dir()` no longer
+   implicitly falls back to repo-root `data/` — it now only appears via the
+   explicit `OPENSAK_BOUNDARIES_DIR` override. `/data/` stays in `.gitignore`
+   deliberately: it's still the working directory for regenerating and
+   hand-testing the dataset locally (see `docs/reverse-geocoding-data.md`), just
+   no longer an implicit runtime fallback.
 
-6. **Tests stay offline.** Mock the network for `packs.py` (mirror `conftest.py`'s
-   offline pattern): cache-miss → fetch → local second lookup; version compare;
-   atomic swap; offline fallback returns the coarser cached layer, never a wrong
-   guess. The existing synthetic-dataset tests in `test_geo.py` continue to cover
-   the resolver via `OPENSAK_BOUNDARIES_DIR`.
+6. **Tests stay offline. ✓ DONE.** `packs.py`/`fetch_baseline` fully covered
+   with mocked network (`test_packs.py`); `test_geo.py` continues to cover the
+   resolver via `OPENSAK_BOUNDARIES_DIR`. A real, unmocked end-to-end run was
+   also done once, against the live release, to prove the mocks weren't lying.
 
 ## Acceptance
 
-- A fresh install resolves country/state offline from the bundled baseline.
-- A lookup for an uncached country fetches its pack once (mocked in tests) from
-  `OpenSAK-Data`, then resolves locally.
-- `default_data_dir()` no longer points at the repo; `data/` can be deleted with
-  no effect on a normal run.
-- `TerritoryResolver` and the two-stage lookup are unchanged from Phase 1.
+- ✓ A fresh install resolves country/state offline from the bundled (or
+  first-run-seeded) baseline — verified live, not just mocked.
+- ✓ A lookup for an uncached country fetches its pack once from `OpenSAK-Data`,
+  then resolves locally — verified live.
+- ✓ `default_data_dir()` no longer points at the repo by default.
+- ✓ `TerritoryResolver` and the two-stage lookup are unchanged from Phase 1.
+- Whole feature gated behind `flags.reverse_geocoding` (default off in release
+  builds) — including the first-run seed call itself, not just the GUI menu
+  entries.

--- a/plans/reverse-geocoding.md
+++ b/plans/reverse-geocoding.md
@@ -1,6 +1,6 @@
 # Development Plan — Offline Reverse Geocoding (County / State / Country)
 
-Status: Phase 0 + Phase 1 DONE (merged into beta). Phase 3 DONE (merged into beta). Phase 4 DONE (merged into beta). Phase 5 DONE (merged into beta). Phase 2 DONE (branch `60-phase-2-packs`, unpushed — awaiting OK). Phase Extra in progress (branch `60-phase-extra-speed`).
+Status: all phases DONE and merged into beta, including every item this doc previously listed as blocked on the `OpenSAK-Data` repo. The repo exists, hosts a real published release (`reverse-geocoding-v1`), and shipped builds now actually seed from it. Gated behind the `reverse-geocoding` feature flag (off by default in release builds) — see "Feature flag" below.
 Relates to: GitHub issue #60 · design in [`architecture/reverse-geocoding.md`](../architecture/reverse-geocoding.md)
 Scope: full implementation of the offline boundary engine — data pipeline, runtime engine, on-demand packs, schema, GUI, packaging/CI.
 
@@ -17,7 +17,11 @@ This plan turns the architecture document into shippable work. It is ordered **b
 ## Prerequisites
 
 - [x] Receive the full polygon-file set from Mike (*Lignumaqua*) — full `bb.db3` + all country/state/county zips are now in the worktree (gitignored). Phase 0 is unblocked and done.
-- [ ] Create the data repository **`OpenSAK-Org/OpenSAK-Data`** (public) with its own `LICENSE` + attribution file (the polygons are ODbL, not public domain).
+- [x] Create the data repository **`OpenSAK-Org/OpenSAK-Data`** (public) with its own `LICENSE` + attribution file (the polygons are ODbL, not public domain). Docs live under `reverse-geocoding/` since the repo will host more datasets later (maps, altimetry).
+
+## Feature flag
+
+The whole feature stays behind `flags.reverse_geocoding` (`utils/flags.py`, default `False` in release builds — see `features.json` / `--feature reverse-geocoding=true` to enable locally). This gates more than the GUI: `geo.store.ensure_baseline_seeded()`, called from `app.py` startup, only runs when the flag is on — without this a disabled feature would still silently download/copy boundary data on every user's first run. Any new runtime side effect added to this feature (network calls, file writes, background work) needs the same explicit check; being reachable only through an already-flag-gated menu entry is not sufficient; startup-level code runs regardless of what menu items exist.
 
 ## Out of scope (follow-ups)
 
@@ -31,7 +35,7 @@ This plan turns the architecture document into shippable work. It is ordered **b
 
 **Goal:** a reproducible pipeline that turns raw polygon files into the artefacts the app consumes.
 
-**What was built:** a single converter `tools/boundaries/gsak_to_opensak.py` (combines normalise + geojson + bbdb steps). Run: `python3 tools/boundaries/gsak_to_opensak.py --bb-path bb.db3`. `bb.db3` lives at **repo root**, not inside `data/`. Writes `data/boundaries.db` + `data/countries/world.geojson` + `data/states/<cc>.geojson` + `data/counties/<cc>/<pack>.geojson`. Output: 383 countries, 1931 states, 20026 counties.
+**What was built:** a single converter `tools/boundaries/gsak_to_opensak.py` (combines normalise + geojson + bbdb steps). Run: `.venv/bin/python3 tools/boundaries/gsak_to_opensak.py --bb-path bb.db3` (must be the project's own venv, see below). `bb.db3` lives at **repo root**, not inside `data/`. Writes `data/boundaries.db` + `data/manifest.json` + `data/countries/world.geojson` + `data/states/<cc>.geojson` + `data/counties/<cc>_<pack>.geojson` (flat). Output: 383 countries, 1931 states, 20026 counties.
 
 **Key fixes inside the converter:**
 - `_split_antimeridian()`: rings with |Δlon|>180° teleportation edges (Russia, Alaska, Fiji…) are split into independently-closed sub-rings → MultiPolygon. Also detects the synthetic implicit-closing-edge when ring[0] recurs mid-ring.
@@ -39,12 +43,16 @@ This plan turns the architecture document into shippable work. It is ordered **b
 
 **Known data gaps (not bugs):** Portugal 0 states, Russia 0 counties — correct per GSAK's source data. 18 state zips + 8 county zips missing from dataset.
 
-**Remaining tasks (deferred to when `OpenSAK-Data` repo exists):**
-- [ ] Geometry simplification (Douglas–Peucker) for the baseline layer.
-- [ ] `manifest.json` generation and publishing as Release assets to `OpenSAK-Org/OpenSAK-Data`.
-- [ ] Keep `tools/` out of the PyInstaller bundle.
+**Real bugs found running the full pipeline end to end (not caught until the actual publish attempt):**
+- County pack output was nested (`counties/<cc>/<pack>.geojson`, with `/` baked into the DB `pack` column) — incompatible with flat GitHub Release assets and `packs.py`'s fetch contract. Flattened to `counties/<cc>_<pack>.geojson` everywhere.
+- `manifest.json` was never generated at all; each feature's `version` property was hardcoded to `1` instead of the real per-pack GSAK version. Both fixed — `_write_manifest()` now writes real dataset + per-pack versions, split into `"baseline"` (world.geojson + state packs) and `"packs"` (county, on-demand).
+- Real GSAK county rings are self-intersecting for ~6% of counties (1168/20026) straight out of the raw parse — nothing to do with simplification. `shapely.contains()` doesn't raise on invalid geometry, it silently returns wrong answers, so this was a live resolver correctness bug. Fixed with a `buffer(0)` repair, applied unconditionally regardless of simplification tolerance.
+- Running the converter with system `python3` (3.8 here) instead of the project's own `.venv` (3.11+) silently undercounts counties — legacy `zipfile` CP437 filename decoding mangles non-ASCII names in zips that don't set the UTF-8 flag bit, with zero error output. **Always use `.venv/bin/python3`.**
+- 685MB dataset was far above the ~70MB estimate; the 227MB country+state baseline (bundled in every install) needed Douglas-Peucker simplification (tolerance 0.0005°≈55m via shapely) — cut to 57MB. Counties stay full-resolution, fetched on demand.
 
-**Acceptance:** ✓ pipeline runs reproducibly; `BoundaryStore` + `TerritoryResolver` resolve correctly against real data. `OpenSAK-Data` Release not yet created (blocked on repo creation).
+**Remaining tasks:** none — all done.
+
+**Acceptance:** ✓ pipeline runs reproducibly; `BoundaryStore` + `TerritoryResolver` resolve correctly against real data; 0/22340 invalid geometries across all layers. `OpenSAK-Data` release `reverse-geocoding-v1` is live with 242 assets.
 
 ---
 
@@ -52,10 +60,9 @@ This plan turns the architecture document into shippable work. It is ordered **b
 
 **Goal:** an offline `TerritoryResolver` that returns `GeoLocation(country, state, county)`.
 
-**What was built:** `src/opensak/geo/store.py` (`BoundaryStore`) + `src/opensak/geo/boundaries.py` (`TerritoryResolver`). Pure-Python ray-cast PIP (shapely deferred). 14 unit tests in `test_geo.py`. mypy-clean. Nothing imports `geo` in production yet — that's Phase 4. `default_data_dir()` = `$OPENSAK_BOUNDARIES_DIR` or `<repo-root>/data` (parents[3]).
+**What was built:** `src/opensak/geo/store.py` (`BoundaryStore`) + `src/opensak/geo/boundaries.py` (`TerritoryResolver`). Pure-Python ray-cast PIP (shapely deferred). 14 unit tests in `test_geo.py`. mypy-clean. Nothing imports `geo` in production yet — that's Phase 4. `default_data_dir()` = `$OPENSAK_BOUNDARIES_DIR`, else `config.get_app_data_dir()/boundaries` — the real persistent per-user app-data dir (flipped from an earlier repo-root/ephemeral-frozen-path fallback, see Phase 5).
 
-**Remaining tasks:**
-- [ ] Seed `boundaries.db` + baseline GeoJSON into `<app-data>/opensak/boundaries/` on first run (Phase 5 packaging concern).
+**Remaining tasks:** none — first-run seeding landed as `ensure_baseline_seeded()`, see Phase 5.
 
 **Acceptance:** ✓ resolves correctly offline; 14 tests pass; mypy green.
 
@@ -67,11 +74,11 @@ This plan turns the architecture document into shippable work. It is ordered **b
 
 **What was built:** `geo/packs.py` — `fetch_manifest`, `fetch_pack` (atomic temp+rename), `fetch_all` (downloads all missing packs with progress callback), `check_update` (throttled weekly by manifest.json mtime, bypass with `force=True`), `apply_update` (only re-downloads locally-cached packs that changed; skips uncached packs; saves manifest). `BoundaryStore._load_pack` now triggers `fetch_pack` on a county pack miss; `TerritoryResolver` skips a candidate gracefully when its pack cannot be fetched (returns `None` for county rather than crashing). Two new Waypoint menu actions under the `update_location` flag guard: "Download boundary packs…" and "Check for boundary data updates…", backed by `BoundaryDownloadDialog` and `BoundaryCheckDialog` workers. 19 i18n keys added to all 8 lang files. 23 unit tests with mocked network covering all code paths.
 
-**Remaining (blocked on OpenSAK-Org/OpenSAK-Data repo):**
-- [ ] Verify release asset URL pattern once the repo and its first release exist.
-- [ ] Build pipeline step to publish `data/` as GitHub Release assets.
+**Also added:** `fetch_baseline()` — downloads `boundaries.db` + the country/state baseline (manifest's `"baseline"` list) for first-run seeding when nothing is bundled (see Phase 5). Real bug found+fixed here: `_fetch_file_atomic` assumed its destination directory already existed (true for its only prior caller, `apply_update`, always invoked on an already-initialized dir) — `fetch_baseline` is the first caller that can hit a genuinely nonexistent directory, the real first-run case, and crashed with `FileNotFoundError`.
 
-**Acceptance:** ✓ 23 tests pass; throttle, force, atomic write, selective re-download, graceful degradation all covered; 1385 unit tests pass.
+**Remaining tasks:** none — verified live against the real `reverse-geocoding-v1` release, not just mocked: `fetch_manifest`/`fetch_pack`/`fetch_baseline` all confirmed working end to end, including a full first-run simulation (empty local dir → on-demand county fetch → correct resolution).
+
+**Acceptance:** ✓ 23+ tests pass; throttle, force, atomic write, selective re-download, graceful degradation all covered.
 
 ---
 
@@ -91,9 +98,9 @@ This plan turns the architecture document into shippable work. It is ordered **b
 
 **What was built:** `ReverseGeocodeWorker` now uses `TerritoryResolver` instead of the GeoNames KD-tree; writes all four provenance columns (`location_source="boundary"`, `location_basis`, `location_updated`, `location_dataset`) per cache. `_CacheRow` gained a `basis` field (default `"posted"`) so the import dialog and the manual dialog both record which coordinate type was used. `OnlineLookupWorker` and the Nominatim path removed entirely. "Use corrected coordinates" now defaults **off** (posted coordinates are the default). `geocoder.py` deleted; `reverse_geocoder` and `pycountry` removed from runtime deps and the PyInstaller spec. Lang files updated: GeoNames references replaced, online/ETA keys removed, `update_loc_no_boundaries` added. `BoundaryStore.dataset_version()` reads the version from `file_version` in `boundaries.db`.
 
-**Deferred to Phase 2 (blocked on `OpenSAK-Data` repo):**
-- Menu actions: **Download all boundary packs** and **Check for boundary updates**
-- Stale indicator when `location_dataset` trails the current dataset
+**Deferred:**
+- ~~Menu actions: **Download all boundary packs** and **Check for boundary updates**~~ — done, see Phase 2.
+- Stale indicator when `location_dataset` trails the current dataset — still genuinely open, not part of this round of work.
 
 **Acceptance:** ✓ dialog resolves via boundary engine; provenance columns written; import auto-fills with basis; `reverse_geocoder`/`pycountry` gone; all 1355 unit tests pass; all language key tests pass.
 **Risk:** medium (UI wiring + dep removal). Size: L.
@@ -106,16 +113,15 @@ This plan turns the architecture document into shippable work. It is ordered **b
 
 **What was built:**
 - `shapely>=2.0` added to runtime deps in `pyproject.toml`; `boundaries.py` uses `shapely.geometry.shape().contains(Point)` for the stage-2 PIP when shapely is present, pure-Python ray-cast as fallback.
-- `default_data_dir()` in `store.py` now checks `sys.frozen` first — frozen bundles resolve to `sys._MEIPASS/data/`.
-- `opensak.spec` bundles `data/boundaries.db` + `data/countries/` + `data/states/` + `data/counties/` conditionally (skipped if `data/boundaries.db` is absent at build time); shapely added to `hiddenimports`.
 - `tests/unit-tests/test_geo_deps.py` — 5 smoke tests: shapely importable, `_HAS_SHAPELY` is True, point-in-polygon (Polygon + MultiPolygon) via shapely path.
 - ODbL attribution added to `about_text` in all 8 lang files.
+- `default_data_dir()` in `store.py` flipped from a `sys.frozen`-then-`sys._MEIPASS/data` / repo-root fallback to the real persistent `config.get_app_data_dir()/boundaries` — neither prior fallback was a writable, persistent location a real install could use. New `ensure_baseline_seeded()`: copies `boundaries.db` + `countries/` + `states/` from the frozen PyInstaller bundle if present, else downloads them via `geo/packs.fetch_baseline()` (e.g. a pip install with nothing bundled). Counties are never seeded — always fetched on demand, per country. Wired into `app.py` startup, gated behind `flags.reverse_geocoding` (see "Feature flag" above — a review catch: this was initially wired unconditionally).
+- `opensak.spec` bundles `data/boundaries.db` + `data/countries/` + `data/states/` only — **not** `counties/`, which was being bundled unconditionally whenever present at build time (a few hundred MB, the opposite of the on-demand design). Fixed.
+- All 4 `build.yml` jobs run `scripts/fetch_boundary_baseline.py` (fetches the real published baseline via `fetch_baseline`) before invoking `pyinstaller` — best-effort, a failure just warns and lets the build continue since the app can self-seed at first run regardless.
 
-**Remaining (blocked on OpenSAK-Org/OpenSAK-Data repo):**
-- [ ] Build pipeline step to fetch/generate `data/` before `pyinstaller opensak.spec` runs (currently converter must be run manually with the GSAK source files).
-- [ ] Verify install/footprint delta stays within Phase 0 budget.
+**Remaining tasks:** none.
 
-**Acceptance:** ✓ shapely integrated; frozen path correct; smoke tests pass; ODbL in About.
+**Acceptance:** ✓ shapely integrated; frozen-bundle-then-app-data-dir seeding verified for real (not just mocked) against the live release; smoke tests pass; ODbL in About; CI fetches real data before every build.
 **Risk:** medium (native wheels are the usual culprit). Size: M.
 
 ---


### PR DESCRIPTION
Docs-only. plans/reverse-geocoding.md, plans/reverse-geocoding-data-migration.md, and docs/reverse-geocoding-data.md all still described phases as blocked on the OpenSAK-Data repo existing, or listed "remaining" tasks that were actually resolved (or found to need more work than expected) once the data was really generated and published end to end this round. Updated every phase section, the migration plan's steps/acceptance, and the data-dir docs to match what's actually shipped and merged (flat county pack naming, manifest.json's baseline section, county validity repair, baseline simplification, the feature-flag gate on ensure_baseline_seeded, and the venv-vs-system-python zipfile gotcha).

#60