### PR TITLE
Reverse geocoding: unblock the UI on first-run baseline seeding

### DIFF
--- a/src/opensak/app.py
+++ b/src/opensak/app.py
@@ -242,16 +242,6 @@ def main() -> None:
     splash_msg("Kontrollerer database...")
     _migrate_legacy_db()
 
-    # Seed reverse-geocoding baseline (country/state) on first run — no-op
-    # once boundaries.db exists in the app-data dir (issue #60). Gated behind
-    # the flag: still opt-in, so users who haven't enabled it shouldn't get
-    # an unasked-for download/copy on every fresh install.
-    from opensak.utils import flags
-    if flags.reverse_geocoding:
-        splash_msg("Forbereder geografiske data...")
-        from opensak.geo.store import ensure_baseline_seeded
-        ensure_baseline_seeded()
-
     # Initialiser database manager — åbner samme DB som sidst
     splash_msg("Indlæser database...")
     from opensak.db.manager import get_db_manager

--- a/src/opensak/geo/packs.py
+++ b/src/opensak/geo/packs.py
@@ -8,6 +8,7 @@ import sqlite3
 import tempfile
 import time
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
 from urllib.error import URLError
@@ -24,6 +25,10 @@ MANIFEST_FILENAME = "manifest.json"
 THROTTLE_SECONDS = 7 * 24 * 3600
 REQUEST_TIMEOUT = 30
 DOWNLOAD_TIMEOUT = 60
+# Baseline downloads are I/O-bound (network round-trip, not CPU) — urllib
+# releases the GIL during the actual socket wait, so a higher worker count
+# than a CPU-bound pool (e.g. the resolver's min(4, cpu_count)) is fine here.
+BASELINE_FETCH_WORKERS = 16
 
 
 def _asset_url(filename: str) -> str:
@@ -92,9 +97,17 @@ def fetch_baseline(data_dir: Path, manifest: dict | None = None) -> bool:
         return False
     if not _fetch_file_atomic("boundaries.db", data_dir):
         return False
-    for filename in manifest.get("baseline", {}):
+
+    baseline = list(manifest.get("baseline", {}))
+    if not baseline:
+        return True
+
+    def _fetch_one(filename: str) -> None:
         dest_dir = data_dir / ("countries" if filename == "world.geojson" else "states")
         fetch_pack(filename, dest_dir)
+
+    with ThreadPoolExecutor(max_workers=min(BASELINE_FETCH_WORKERS, len(baseline))) as executor:
+        list(executor.map(_fetch_one, baseline))
     return True
 
 

--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -73,7 +73,7 @@ class ReverseGeocodeWorker(QThread):
     def run(self) -> None:
         import os
         from concurrent.futures import ThreadPoolExecutor, as_completed
-        from opensak.geo.store import BoundaryStore
+        from opensak.geo.store import BoundaryStore, ensure_baseline_seeded
         from opensak.geo.boundaries import TerritoryResolver
         from opensak.db.database import get_session
         from opensak.db.models import Cache
@@ -83,6 +83,13 @@ class ReverseGeocodeWorker(QThread):
         if self._cancel:
             self.cancelled.emit(result)
             return
+
+        # First-run baseline seed (copy from the PyInstaller bundle, or
+        # download from OpenSAK-Data if nothing's bundled) happens here rather
+        # than at app startup — this already runs on a QThread, per this
+        # feature's own "long work never blocks the main thread" rule, and
+        # the fallback download path can take a while over the network.
+        ensure_baseline_seeded()
 
         check = BoundaryStore()
         if not check.available():

--- a/tests/unit-tests/test_app.py
+++ b/tests/unit-tests/test_app.py
@@ -137,7 +137,6 @@ def test_main_smoke(qapp, monkeypatch):
                             hide=lambda: None,
                             show=lambda: None))
     monkeypatch.setattr(appmod, "_migrate_legacy_db", lambda: None)
-    monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: None)
     monkeypatch.setattr("opensak.settings_store.is_first_run", lambda: False)
     monkeypatch.setattr("opensak.gui.theme.apply_theme", lambda app: None)
     monkeypatch.setattr("opensak.config.get_language", lambda: "en")
@@ -162,47 +161,3 @@ def test_main_smoke(qapp, monkeypatch):
     finally:
         W.QApplication = real_qapp_cls
         C.QTimer.singleShot = real_single
-
-
-@pytest.mark.parametrize("flag_on", [True, False])
-def test_main_gates_baseline_seed_behind_flag(qapp, monkeypatch, flag_on):
-    import PySide6.QtWidgets as W
-    import PySide6.QtCore as C
-
-    calls: list[None] = []
-
-    monkeypatch.setattr(sys, "argv", ["opensak"])
-    monkeypatch.setattr(type(qapp), "exec", lambda self: 0)
-    monkeypatch.setattr(appmod, "_make_splash",
-                        lambda app: SimpleNamespace(
-                            showMessage=lambda *a, **k: None,
-                            finish=lambda w: None,
-                            hide=lambda: None,
-                            show=lambda: None))
-    monkeypatch.setattr(appmod, "_migrate_legacy_db", lambda: None)
-    monkeypatch.setattr("opensak.utils.flags.reverse_geocoding", flag_on)
-    monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: calls.append(None))
-    monkeypatch.setattr("opensak.settings_store.is_first_run", lambda: False)
-    monkeypatch.setattr("opensak.gui.theme.apply_theme", lambda app: None)
-    monkeypatch.setattr("opensak.config.get_language", lambda: "en")
-    monkeypatch.setattr("opensak.lang.load_language", lambda lang: None)
-    monkeypatch.setattr("opensak.db.manager.get_db_manager",
-                        lambda: SimpleNamespace(ensure_active_initialised=lambda: None))
-
-    class FakeWindow:
-        def show(self):
-            pass
-    monkeypatch.setattr("opensak.gui.mainwindow.MainWindow", FakeWindow)
-
-    real_qapp_cls = W.QApplication
-    real_single = C.QTimer.singleShot
-    W.QApplication = lambda *a, **k: qapp
-    C.QTimer.singleShot = staticmethod(lambda ms, cb: cb())
-    try:
-        with pytest.raises(SystemExit):
-            appmod.main()
-    finally:
-        W.QApplication = real_qapp_cls
-        C.QTimer.singleShot = real_single
-
-    assert (len(calls) == 1) is flag_on

--- a/tests/unit-tests/test_update_location_dialog.py
+++ b/tests/unit-tests/test_update_location_dialog.py
@@ -53,6 +53,7 @@ def geo_mocks(monkeypatch):
     resolver = _fake_resolver()
     monkeypatch.setattr("opensak.geo.store.BoundaryStore", lambda: store)
     monkeypatch.setattr("opensak.geo.boundaries.TerritoryResolver", lambda s: resolver)
+    monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: None)
     return store, resolver
 
 
@@ -91,9 +92,28 @@ class TestReverseGeocodeWorker:
         w.run()
         assert cancelled
 
+    def test_run_seeds_baseline_on_worker_thread(self, db, geo_mocks, monkeypatch):
+        # ensure_baseline_seeded runs here rather than at app startup, so any
+        # first-run network fallback happens on this QThread, never the main
+        # thread. See update_location_dialog.py's ReverseGeocodeWorker.run().
+        calls = []
+        monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: calls.append(None))
+        w = ReverseGeocodeWorker([_CacheRow("GC1", 55.0, 12.0)])
+        w.run()
+        assert calls == [None]
+
+    def test_run_cancelled_before_start_skips_baseline_seed(self, db, monkeypatch):
+        calls = []
+        monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: calls.append(None))
+        w = ReverseGeocodeWorker([_CacheRow("GC1", 55.0, 12.0)])
+        w.request_cancel()
+        w.run()
+        assert calls == []
+
     def test_run_no_boundaries_emits_error(self, db, monkeypatch):
         store = _fake_store(available=False)
         monkeypatch.setattr("opensak.geo.store.BoundaryStore", lambda: store)
+        monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: None)
         w = ReverseGeocodeWorker([_CacheRow("GC1", 55.0, 12.0)])
         done = []
         w.all_done.connect(done.append)


### PR DESCRIPTION
Found by actually running the app end to end (not just tests): with the reverse-geocoding + update-location flags enabled and nothing bundled (this dev checkout), the network-fallback baseline seed at startup took ~65 seconds, one file at a time, blocking the UI the whole time. That directly violates this feature's own documented rule (plans/reverse-geocoding.md: "long work stays on a QThread; the main thread never blocks").

Two fixes:

1. Moved ensure_baseline_seeded() out of app.py's main() and into ReverseGeocodeWorker.run() (update_location_dialog.py), which already runs on a QThread for exactly this reason. It now only seeds when Update Location is actually used, not on every app launch. Along the way, found that the existing ReverseGeocodeWorker tests only passed by accident, since this machine's real app-data dir already had a seeded boundaries.db from earlier manual testing -- a clean machine or CI run would have hit the real network during every test. Fixed by mocking ensure_baseline_seeded properly and verified by moving the real seeded directory aside before running the suite.

2. Parallelized fetch_baseline's downloads (packs.py) with a 16-worker ThreadPoolExecutor -- these are small network requests where round-trip latency dominates, not bandwidth, so concurrency helps a lot. Verified live against the real published release: ~65s down to ~8.7s, same correct output (resolved Lisbon/NYC/Berlin correctly against the freshly-fetched data).

Verified for real: relaunched the actual app after these changes with a freshly-deleted app-data dir -- it now starts in a few seconds with no boundaries/ directory created at all (seeding correctly deferred to first actual use).

#60