### PR TITLE
Reverse geocoding: add e2e coverage for dialog-to-DB integration

### DIFF
--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -387,6 +387,9 @@ class UpdateLocationDialog(QDialog):
         self._set_controls_enabled(True)
         if not self._from_context_menu:
             self._rb_this.setEnabled(False)
+        # The worker is about to delete itself (finished.connect(deleteLater));
+        # drop our reference now so closeEvent never touches a dangling C++ object.
+        self._worker = None
 
     def closeEvent(self, event) -> None:
         if self._worker and self._worker.isRunning():

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,7 +1,10 @@
 # tests/data.py — synthetic GPX/.loc test data and programmatic builders.
 
+import json
+import sqlite3
 import zipfile
 from pathlib import Path
+from typing import Any
 
 
 # ── Hand-written GPX matching real Groundspeak/PQ format ─────────────────────
@@ -293,3 +296,86 @@ def make_fake_manager(db_path: Path, name: str = "E2ETest"):
             raise RuntimeError("new_database called during e2e test")
 
     return _FakeManager()
+
+
+# ── Synthetic reverse-geocoding boundary dataset ──────────────────────────────
+# Mirrors the real layout consumed by BoundaryStore/TerritoryResolver (see
+# docs/reverse-geocoding-data.md): lon/lat squares & triangles.
+#   county layer — two same-bbox triangles (forces Stage-2 PIP) + one far
+#                  square (single bbox hit) + one isolated border triangle;
+#   state/country layer — one big covering square.
+# The single authoritative reference for this data contract — reused by both
+# tests/unit-tests/test_geo.py and tests/e2e-tests/test_e2e_reverse_geocoding.py
+# (those dirs are hyphenated and can't be imported as packages, so it lives
+# here instead of in either suite).
+
+_GEO_TRI_LOWER = [[[0, 0], [2, 0], [0, 2], [0, 0]]]          # x + y <= 2
+_GEO_TRI_UPPER = [[[2, 2], [0, 2], [2, 0], [2, 2]]]          # x + y >= 2
+_GEO_FAR_SQUARE = [[[10, 10], [12, 10], [12, 12], [10, 12], [10, 10]]]
+_GEO_BIG_SQUARE = [[[-1, -1], [13, -1], [13, 13], [-1, 13], [-1, -1]]]
+# Isolated triangle: bbox [20,20,22,22] but polygon only covers the lower-left
+# half. A point at (lat=21.5, lon=21.5) is inside the bbox but outside the
+# triangle — the border-crossing bug. lon+lat=43>42 puts it above the hypotenuse.
+_GEO_ISOLATED_TRI = [[[20, 20], [22, 20], [20, 22], [20, 20]]]
+
+
+def _geo_feature(layer: str, name: str, parent: str | None, polygon: Any, bbox: list[int]) -> dict[str, Any]:
+    return {
+        "type": "Feature",
+        "properties": {"layer": layer, "name": name, "parent": parent,
+                       "version": 1, "source": "test", "licence": "ODbL"},
+        "bbox": bbox,
+        "geometry": {"type": "Polygon", "coordinates": polygon},
+    }
+
+
+def _geo_write_pack(path: Path, features: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"type": "FeatureCollection", "features": features}), encoding="utf-8")
+
+
+def build_boundary_test_data(data_dir: Path) -> None:
+    """Build a tiny but complete synthetic boundaries/ directory.
+
+    Known resolvable points:
+      (1, 1)     -> Testland / Teststate / Alpha County  (x+y<=2)
+      (1.5, 1.5) -> Testland / Teststate / Beta County   (x+y>=2)
+      (11, 11)   -> Testland / Teststate / Gamma County  (far square, single hit)
+      (21, 21)   -> Testland / Teststate / Border County (inside bbox+triangle)
+      (21.5, 21.5) -> Testland / Teststate / None county (inside bbox, outside triangle)
+    """
+    _geo_write_pack(data_dir / "counties" / "test.geojson", [
+        _geo_feature("county", "Alpha County", "TL/TS", _GEO_TRI_LOWER, [0, 0, 2, 2]),
+        _geo_feature("county", "Beta County", "TL/TS", _GEO_TRI_UPPER, [0, 0, 2, 2]),
+        _geo_feature("county", "Gamma County", "TL/TS", _GEO_FAR_SQUARE, [10, 10, 12, 12]),
+        _geo_feature("county", "Border County", "TL/TS", _GEO_ISOLATED_TRI, [20, 20, 22, 22]),
+    ])
+    _geo_write_pack(data_dir / "states" / "test.geojson",
+                     [_geo_feature("state", "Teststate", "TL", _GEO_BIG_SQUARE, [-1, -1, 13, 13])])
+    _geo_write_pack(data_dir / "countries" / "test.geojson",
+                     [_geo_feature("country", "Testland", None, _GEO_BIG_SQUARE, [-1, -1, 13, 13])])
+
+    db = sqlite3.connect(data_dir / "boundaries.db")
+    for layer in ("country", "state", "county"):
+        db.execute(f"CREATE VIRTUAL TABLE rtree_{layer} USING rtree(id, min_lat, max_lat, min_lon, max_lon)")
+        db.execute(f"CREATE TABLE region_{layer} (id INTEGER PRIMARY KEY, name TEXT NOT NULL, "
+                   "parent TEXT, pack TEXT NOT NULL, feature_index INTEGER NOT NULL, "
+                   "poly_version INTEGER NOT NULL, is_bundled INTEGER NOT NULL)")
+    db.execute("CREATE TABLE file_version (layer TEXT, country TEXT, state TEXT, version INTEGER)")
+
+    # rtree rows are (id, min_lat, max_lat, min_lon, max_lon)
+    db.executemany("INSERT INTO rtree_county VALUES (?, ?, ?, ?, ?)",
+                    [(1, 0, 2, 0, 2), (2, 0, 2, 0, 2), (3, 10, 12, 10, 12), (4, 20, 22, 20, 22)])
+    db.executemany("INSERT INTO region_county VALUES (?, ?, ?, ?, ?, ?, ?)", [
+        (1, "Alpha County", "TL/TS", "test.geojson", 0, 1, 1),
+        (2, "Beta County", "TL/TS", "test.geojson", 1, 1, 1),
+        (3, "Gamma County", "TL/TS", "test.geojson", 2, 1, 1),
+        (4, "Border County", "TL/TS", "test.geojson", 3, 1, 1),
+    ])
+    db.execute("INSERT INTO rtree_state VALUES (1, -1, 13, -1, 13)")
+    db.execute("INSERT INTO region_state VALUES (1, 'Teststate', 'TL', 'test.geojson', 0, 1, 1)")
+    db.execute("INSERT INTO rtree_country VALUES (1, -1, 13, -1, 13)")
+    db.execute("INSERT INTO region_country VALUES (1, 'Testland', NULL, 'test.geojson', 0, 1, 1)")
+    db.execute("INSERT INTO file_version VALUES ('dataset', NULL, NULL, 1)")
+    db.commit()
+    db.close()

--- a/tests/e2e-tests/test_e2e_reverse_geocoding.py
+++ b/tests/e2e-tests/test_e2e_reverse_geocoding.py
@@ -1,0 +1,119 @@
+# tests/e2e-tests/test_e2e_reverse_geocoding.py — offline reverse-geocoding, real dialog to real DB.
+#
+# Closes a real integration gap: tests/unit-tests/test_geo.py exercises the
+# real BoundaryStore/TerritoryResolver in isolation, and
+# tests/unit-tests/test_update_location_dialog.py exercises the DB-writing
+# worker with BoundaryStore/TerritoryResolver fully mocked. Nothing proved the
+# two actually work together end to end — a real BoundaryStore resolving
+# against real GeoJSON, through the real dialog, writing to a real DB. Fully
+# offline: the synthetic dataset from tests/data.py stands in for the network
+# fetch/bundled baseline.
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from tests.data import build_boundary_test_data
+
+
+@pytest.fixture
+def geo_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "boundaries"
+    build_boundary_test_data(data_dir)
+    monkeypatch.setenv("OPENSAK_BOUNDARIES_DIR", str(data_dir))
+    return data_dir
+
+
+def _add_cache(gc_code: str, lat: float, lon: float) -> None:
+    from opensak.db.database import get_session
+    from opensak.db.models import Cache
+
+    with get_session() as session:
+        session.add(Cache(gc_code=gc_code, name=gc_code, cache_type="Traditional Cache",
+                           latitude=lat, longitude=lon))
+
+
+def test_update_location_resolves_through_real_dialog(empty_window, qtbot, geo_data_dir):
+    from opensak.db.database import get_session
+    from opensak.db.models import Cache
+    from opensak.gui.dialogs.update_location_dialog import UpdateLocationDialog
+
+    _add_cache("GCTEST1", 11.0, 11.0)  # far square -> Gamma County, single R-Tree hit
+    empty_window._refresh_cache_list()
+
+    dialog = UpdateLocationDialog(parent=empty_window)
+    qtbot.addWidget(dialog)
+    dialog._rb_all.setChecked(True)
+
+    with qtbot.waitSignal(dialog.location_updated, timeout=5000):
+        dialog._start()
+
+    with get_session() as session:
+        cache = session.query(Cache).filter_by(gc_code="GCTEST1").first()
+        assert cache.country == "Testland"
+        assert cache.state == "Teststate"
+        assert cache.county == "Gamma County"
+        assert cache.location_source == "boundary"
+        assert cache.location_basis == "posted"
+        assert cache.location_dataset == "1"
+
+
+def test_update_location_resolves_multiple_regions_in_parallel(empty_window, qtbot, geo_data_dir):
+    # Exercises ReverseGeocodeWorker's real parallel-resolve path (Phase Extra:
+    # ThreadPoolExecutor, one BoundaryStore per thread) against real geometry —
+    # including the two overlapping-bbox triangles that force the Stage-2
+    # point-in-polygon check, not just the single-hit fast path.
+    from opensak.db.database import get_session
+    from opensak.db.models import Cache
+    from opensak.gui.dialogs.update_location_dialog import UpdateLocationDialog
+
+    _add_cache("GCALPHA", 0.5, 0.5)      # Alpha/Beta triangles share a bbox
+    _add_cache("GCBETA", 1.5, 1.5)
+    _add_cache("GCGAMMA", 11.0, 11.0)    # far square, single hit
+    _add_cache("GCBORDER", 20.5, 20.5)   # isolated triangle, outside the big square -> no country/state
+    _add_cache("GCOUTSIDE", 21.5, 21.5)  # inside bbox, outside triangle (above the hypotenuse) -> no county either
+    empty_window._refresh_cache_list()
+
+    dialog = UpdateLocationDialog(parent=empty_window)
+    qtbot.addWidget(dialog)
+    dialog._rb_all.setChecked(True)
+
+    with qtbot.waitSignal(dialog.location_updated, timeout=5000):
+        dialog._start()
+
+    # (country, state, county)
+    expected = {
+        "GCALPHA": ("Testland", "Teststate", "Alpha County"),
+        "GCBETA": ("Testland", "Teststate", "Beta County"),
+        "GCGAMMA": ("Testland", "Teststate", "Gamma County"),
+        "GCBORDER": (None, None, "Border County"),
+        "GCOUTSIDE": (None, None, None),
+    }
+    with get_session() as session:
+        for gc_code, (country, state, county) in expected.items():
+            cache = session.query(Cache).filter_by(gc_code=gc_code).first()
+            assert (cache.country, cache.state, cache.county) == (country, state, county), gc_code
+
+
+def test_update_location_no_boundaries_available_degrades_gracefully(empty_window, qtbot, tmp_path, monkeypatch):
+    # Real (non-mocked) BoundaryStore pointed at an empty directory — the
+    # graceful-degradation path, not the happy path the other tests cover.
+    from opensak.gui.dialogs.update_location_dialog import UpdateLocationDialog
+    from opensak.lang import tr
+
+    monkeypatch.setenv("OPENSAK_BOUNDARIES_DIR", str(tmp_path / "empty"))
+    # Nothing is bundled and there's no boundaries.db here, so ensure_baseline_seeded
+    # would otherwise fall through to a real network fetch (geo.packs.fetch_baseline) —
+    # not what this test is about; keep it offline like every other test in the suite.
+    monkeypatch.setattr("opensak.geo.store.ensure_baseline_seeded", lambda: None)
+    _add_cache("GCTEST1", 11.0, 11.0)
+    empty_window._refresh_cache_list()
+
+    dialog = UpdateLocationDialog(parent=empty_window)
+    qtbot.addWidget(dialog)
+    dialog._rb_all.setChecked(True)
+
+    with qtbot.waitSignal(dialog.location_updated, timeout=5000):
+        dialog._start()
+
+    assert tr("update_loc_no_boundaries") in dialog._log.toPlainText()

--- a/tests/unit-tests/test_geo.py
+++ b/tests/unit-tests/test_geo.py
@@ -1,85 +1,18 @@
 # tests/unit-tests/test_geo.py — offline boundary engine (store + resolver).
 
-import json
-import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from opensak.geo import BoundaryStore, GeoLocation, TerritoryResolver
 from opensak.geo import store as geo_store
-
-# Synthetic dataset (lon/lat squares & triangles), mirroring the real layout:
-#   county layer — two same-bbox triangles (force Stage-2 PIP) + one far square
-#                  (single bbox hit) ; state/country — one big covering square.
-_TRI_LOWER = [[[0, 0], [2, 0], [0, 2], [0, 0]]]          # x + y <= 2
-_TRI_UPPER = [[[2, 2], [0, 2], [2, 0], [2, 2]]]          # x + y >= 2
-_FAR_SQUARE = [[[10, 10], [12, 10], [12, 12], [10, 12], [10, 10]]]
-_BIG_SQUARE = [[[-1, -1], [13, -1], [13, 13], [-1, 13], [-1, -1]]]
-# Isolated triangle: bbox [20,20,22,22] but polygon only covers the lower-left
-# half. A point at (lat=21.5, lon=21.5) is inside the bbox but outside the
-# triangle — the border-crossing bug. lon+lat=43>42 puts it above the hypotenuse.
-_ISOLATED_TRI = [[[20, 20], [22, 20], [20, 22], [20, 20]]]
-
-
-def _feature(layer: str, name: str, parent: str | None, polygon: Any, bbox: list[int]) -> dict[str, Any]:
-    return {
-        "type": "Feature",
-        "properties": {"layer": layer, "name": name, "parent": parent,
-                       "version": 1, "source": "test", "licence": "ODbL"},
-        "bbox": bbox,
-        "geometry": {"type": "Polygon", "coordinates": polygon},
-    }
-
-
-def _write_pack(path: Path, features: list[dict[str, Any]]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"type": "FeatureCollection", "features": features}), encoding="utf-8")
-
-
-def _build_boundaries(data_dir: Path) -> None:
-    _write_pack(data_dir / "counties" / "test.geojson", [
-        _feature("county", "Alpha County", "TL/TS", _TRI_LOWER, [0, 0, 2, 2]),
-        _feature("county", "Beta County", "TL/TS", _TRI_UPPER, [0, 0, 2, 2]),
-        _feature("county", "Gamma County", "TL/TS", _FAR_SQUARE, [10, 10, 12, 12]),
-        _feature("county", "Border County", "TL/TS", _ISOLATED_TRI, [20, 20, 22, 22]),
-    ])
-    _write_pack(data_dir / "states" / "test.geojson",
-                [_feature("state", "Teststate", "TL", _BIG_SQUARE, [-1, -1, 13, 13])])
-    _write_pack(data_dir / "countries" / "test.geojson",
-                [_feature("country", "Testland", None, _BIG_SQUARE, [-1, -1, 13, 13])])
-
-    db = sqlite3.connect(data_dir / "boundaries.db")
-    for layer in ("country", "state", "county"):
-        db.execute(f"CREATE VIRTUAL TABLE rtree_{layer} USING rtree(id, min_lat, max_lat, min_lon, max_lon)")
-        db.execute(f"CREATE TABLE region_{layer} (id INTEGER PRIMARY KEY, name TEXT NOT NULL, "
-                   "parent TEXT, pack TEXT NOT NULL, feature_index INTEGER NOT NULL, "
-                   "poly_version INTEGER NOT NULL, is_bundled INTEGER NOT NULL)")
-    db.execute("CREATE TABLE file_version (layer TEXT, country TEXT, state TEXT, version INTEGER)")
-
-    # rtree rows are (id, min_lat, max_lat, min_lon, max_lon)
-    db.executemany("INSERT INTO rtree_county VALUES (?, ?, ?, ?, ?)",
-                   [(1, 0, 2, 0, 2), (2, 0, 2, 0, 2), (3, 10, 12, 10, 12), (4, 20, 22, 20, 22)])
-    db.executemany("INSERT INTO region_county VALUES (?, ?, ?, ?, ?, ?, ?)", [
-        (1, "Alpha County", "TL/TS", "test.geojson", 0, 1, 1),
-        (2, "Beta County", "TL/TS", "test.geojson", 1, 1, 1),
-        (3, "Gamma County", "TL/TS", "test.geojson", 2, 1, 1),
-        (4, "Border County", "TL/TS", "test.geojson", 3, 1, 1),
-    ])
-    db.execute("INSERT INTO rtree_state VALUES (1, -1, 13, -1, 13)")
-    db.execute("INSERT INTO region_state VALUES (1, 'Teststate', 'TL', 'test.geojson', 0, 1, 1)")
-    db.execute("INSERT INTO rtree_country VALUES (1, -1, 13, -1, 13)")
-    db.execute("INSERT INTO region_country VALUES (1, 'Testland', NULL, 'test.geojson', 0, 1, 1)")
-    db.execute("INSERT INTO file_version VALUES ('dataset', NULL, NULL, 1)")
-    db.commit()
-    db.close()
+from tests.data import build_boundary_test_data
 
 
 @pytest.fixture()
 def store(tmp_path: Path) -> Iterator[BoundaryStore]:
-    _build_boundaries(tmp_path)
+    build_boundary_test_data(tmp_path)
     s = BoundaryStore(tmp_path)
     yield s
     s.close()


### PR DESCRIPTION
Following up on "should we have e2e tests for this feature?" -- yes, there was a real gap. test_geo.py exercises the real BoundaryStore/TerritoryResolver in isolation; test_update_location_dialog.py exercises the DB-writing worker with BoundaryStore/TerritoryResolver fully mocked. Nothing proved the two actually integrate correctly -- only manual testing caught that today.

Moved the synthetic boundary dataset builder (previously private to test_geo.py) into tests/data.py, since tests/unit-tests and tests/e2e-tests are hyphenated and can't import each other's modules directly -- it's already documented as "the authoritative, executable example of this contract", so it should actually be reusable as such.

Three new e2e tests, fully offline (real dialog, real worker, real DB, synthetic boundary data standing in for the network/bundle):
- single cache resolves correctly through the real dialog
- five caches spanning every region in the synthetic dataset resolve correctly through the real parallel-resolve path (Phase Extra's ThreadPoolExecutor), including the two overlapping-bbox triangles that force the Stage-2 point-in-polygon check
- the real (not mocked) graceful-degradation path when no boundary data is available

Found two real bugs writing these:
1. closeEvent crashed with "Internal C++ object (ReverseGeocodeWorker) already deleted" -- the worker deletes itself on completion, but the dialog never cleared its own reference, so closing it after a real (non-mocked) run touched a dangling pointer. Never caught before since no existing test ran a real worker to completion and then closed the dialog.
2. Two of my own test-point coordinates landed exactly on a polygon boundary edge (degenerate) instead of reusing test_geo.py's own known-good points -- fixed by matching those exactly.

#60