### PR TITLE
Reverse geocoding: collapse update-location and reverse-geocoding into one flag

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -109,5 +109,4 @@ if flags.my_new_flag:
 
 | Flag | Default | Description |
 |---|---|---|
-| `update-location` | `false` | Update County / State / Country via offline GeoNames lookup (Waypoint menu, right-click context menu, and auto-geocode on GPX import) |
-| `reverse-geocoding` | `false` | Offline boundary engine for County / State / Country (issue #60) — gates the phased work landing on `beta` |
+| `reverse-geocoding` | `false` | Offline boundary engine for County / State / Country (issue #60) — gates the Update Location menu action, its right-click context-menu entry, auto-geocode on GPX import, the boundary-packs download/update actions, and the related Settings section |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -194,7 +194,7 @@ The offline lookup uses the bundled [GeoNames](https://geonames.org/) database a
 
 For full details, see [Update Waypoint Locations](update-location.md).
 
-> **Note:** This feature requires the `update-location` feature flag to be enabled. It is on by default in developer builds and can be enabled with `--feature update-location=true`. See [Feature Flags](feature-flags.md).
+> **Note:** This feature requires the `reverse-geocoding` feature flag to be enabled. It can be enabled with `--feature reverse-geocoding=true`. See [Feature Flags](feature-flags.md).
 
 ---
 

--- a/docs/update-location.md
+++ b/docs/update-location.md
@@ -11,7 +11,7 @@ There are two ways to open the dialog, and both open the same window. The differ
 - **Waypoint menu → Update Waypoint Locations…** — opens with *Only waypoints with missing location data* selected by default.
 - **Right-click a waypoint → Update location data…** — opens with *Only this waypoint* selected by default.
 
-This option is only visible when the `update-location` feature flag is enabled. See [Feature Flags](feature-flags.md) for details.
+This option is only visible when the `reverse-geocoding` feature flag is enabled. See [Feature Flags](feature-flags.md) for details.
 
 ---
 

--- a/features.json
+++ b/features.json
@@ -1,4 +1,3 @@
 {
-  "update-location": false,
   "reverse-geocoding": false
 }

--- a/plans/reverse-geocoding.md
+++ b/plans/reverse-geocoding.md
@@ -21,7 +21,9 @@ This plan turns the architecture document into shippable work. It is ordered **b
 
 ## Feature flag
 
-The whole feature stays behind `flags.reverse_geocoding` (`utils/flags.py`, default `False` in release builds — see `features.json` / `--feature reverse-geocoding=true` to enable locally). This gates more than the GUI: `geo.store.ensure_baseline_seeded()`, called from `app.py` startup, only runs when the flag is on — without this a disabled feature would still silently download/copy boundary data on every user's first run. Any new runtime side effect added to this feature (network calls, file writes, background work) needs the same explicit check; being reachable only through an already-flag-gated menu entry is not sufficient; startup-level code runs regardless of what menu items exist.
+A single flag, `flags.reverse_geocoding` (`utils/flags.py`, default `False` in release builds — see `features.json` / `--feature reverse-geocoding=true` to enable locally), gates the entire feature: the Update Location menu action, its right-click context-menu entry, auto-geocode on GPX import, the boundary-packs download/update actions, and the Settings section. There used to be a second flag, `update-location`, gating the same GUI surface for historical reasons (predating the boundary engine) — collapsed into one flag so enabling the feature for a release is a single toggle, not two that have to be kept in sync.
+
+`geo.store.ensure_baseline_seeded()` is called from `ReverseGeocodeWorker.run()` (a `QThread`, not app startup — see Phase 5), and is only reachable through the flag-gated menu/dialog, so no separate explicit flag check is needed there. If a *new* runtime side effect (network call, file write, background work) is ever added somewhere NOT reachable exclusively through that gated entry point — e.g. something wired into `app.py` startup again — it needs its own explicit `if flags.reverse_geocoding:` check. Being reachable only through an already-gated menu entry is not sufficient for code that runs regardless of what menu items exist.
 
 ## Out of scope (follow-ups)
 

--- a/src/opensak/gui/cache_table.py
+++ b/src/opensak/gui/cache_table.py
@@ -1378,7 +1378,7 @@ class CacheTableView(QTableView):
             act_found.triggered.connect(lambda: self._toggle_found(cache, True))
 
         from opensak.utils import flags
-        if flags.update_location:
+        if flags.reverse_geocoding:
             menu.addSeparator()
 
             act_update_loc = menu.addAction(tr("ctx_update_location"))

--- a/src/opensak/gui/dialogs/import_dialog.py
+++ b/src/opensak/gui/dialogs/import_dialog.py
@@ -388,7 +388,7 @@ class ImportDialog(QDialog):
             self.import_completed.emit()
 
         from opensak.utils import flags
-        if flags.update_location and self._any_success:
+        if flags.reverse_geocoding and self._any_success:
             self._start_geocoding()
         else:
             self._browse_btn.setEnabled(True)

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -416,9 +416,9 @@ class SettingsDialog(QDialog):
 
         layout.addWidget(search_group)
 
-        # ── Location refinement (only shown when update-location flag is on) ──
+        # ── Location refinement (only shown when reverse-geocoding flag is on) ──
         from opensak.utils import flags
-        if flags.update_location:
+        if flags.reverse_geocoding:
             loc_ref_group = QGroupBox(tr("settings_group_nominatim"))
             loc_ref_layout = QVBoxLayout(loc_ref_group)
 

--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -354,7 +354,7 @@ class MainWindow(QMainWindow):
         wp_menu.addAction(act_clear_flags)
 
         from opensak.utils import flags
-        if flags.update_location:
+        if flags.reverse_geocoding:
             wp_menu.addSeparator()
 
             act_update_location = QAction(tr("action_update_location"), self)

--- a/src/opensak/utils/flags.py
+++ b/src/opensak/utils/flags.py
@@ -28,7 +28,6 @@ from pathlib import Path
 _FEATURES_FILE: Path = Path(__file__).parent.parent.parent.parent / "features.json"
 
 _RELEASE_DEFAULTS: dict[str, bool] = {
-    "update-location": False,
     "reverse-geocoding": False,
 }
 
@@ -70,5 +69,4 @@ _flags = _load()
 
 # ── Public flag attributes ────────────────────────────────────────────────────
 
-update_location: bool      = _flags["update-location"]
 reverse_geocoding: bool    = _flags["reverse-geocoding"]

--- a/tests/unit-tests/test_cache_table.py
+++ b/tests/unit-tests/test_cache_table.py
@@ -982,7 +982,7 @@ class TestView:
         monkeypatch.setattr(ct, "QMenu", _Menu)
         monkeypatch.setattr(ct.webbrowser, "open", lambda *a, **k: None)
         from opensak.utils import flags
-        monkeypatch.setattr(flags, "update_location", True, raising=False)
+        monkeypatch.setattr(flags, "reverse_geocoding", True, raising=False)
 
         c = _cache(gc_code="GCMENU", latitude=55.0, longitude=12.0)
         c.user_note = _note()  # corrected -> edit/clear branch

--- a/tests/unit-tests/test_doctor.py
+++ b/tests/unit-tests/test_doctor.py
@@ -253,7 +253,7 @@ class TestCheckFeatureFlags:
     def test_failure_branch(self, monkeypatch):
         # Drop a flag attribute so getattr() inside the check raises -> except branch.
         from opensak.utils import flags
-        monkeypatch.delattr(flags, "update_location", raising=False)
+        monkeypatch.delattr(flags, "reverse_geocoding", raising=False)
         _, ok, _ = check_feature_flags()
         assert ok is False
 

--- a/tests/unit-tests/test_flags.py
+++ b/tests/unit-tests/test_flags.py
@@ -9,7 +9,6 @@ import opensak.utils.flags as flags_module
 class TestLoad:
     def test_absent_file_returns_release_defaults(self, no_features_file):
         assert flags_module._flags == {
-            "update-location": False,
             "reverse-geocoding": False,
         }
 
@@ -23,7 +22,6 @@ class TestLoad:
         monkeypatch.setattr(flags_module, "_FEATURES_FILE", f)
         result = flags_module._load()
         assert result == {
-            "update-location": False,
             "reverse-geocoding": False,
         }
 
@@ -33,7 +31,7 @@ class TestLoad:
 
     def test_partial_file_keeps_unset_flags_as_defaults(self, patch_features_file):
         patch_features_file({})
-        assert flags_module._flags["update-location"] is False
+        assert flags_module._flags["reverse-geocoding"] is False
 
 
 # ── Module-level attribute ────────────────────────────────────────────────────

--- a/tests/unit-tests/test_import_dialog.py
+++ b/tests/unit-tests/test_import_dialog.py
@@ -270,7 +270,7 @@ class TestImportDialog:
 
     def test_on_all_done_emits_completed(self, dlg, monkeypatch):
         from opensak.utils import flags
-        monkeypatch.setattr(flags, "update_location", False, raising=False)
+        monkeypatch.setattr(flags, "reverse_geocoding", False, raising=False)
         dlg.add_files([Path("/a.gpx")])
         dlg._any_success = True
         fired = []
@@ -281,7 +281,7 @@ class TestImportDialog:
 
     def test_on_all_done_triggers_geocoding(self, dlg, monkeypatch):
         from opensak.utils import flags
-        monkeypatch.setattr(flags, "update_location", True, raising=False)
+        monkeypatch.setattr(flags, "reverse_geocoding", True, raising=False)
         called = []
         monkeypatch.setattr(dlg, "_start_geocoding", lambda: called.append(True))
         dlg._any_success = True


### PR DESCRIPTION
Caused real confusion just now: enabling only reverse-geocoding=true in features.json did nothing visible, because the Update Location menu action (and everything else in this feature) was still gated on the separate update-location flag, which defaults off.

update-location predates the boundary engine and has been fully redundant with reverse-geocoding since Phase 4 replaced the old GeoNames-based geocoder -- both flags gated the exact identical GUI surface (Update Location menu action, its context-menu entry, GPX auto-geocode, boundary-packs download/update actions, Settings section). No behavior ever differed between them; it was just two toggles that had to be kept in sync to release the feature, per your request to collapse this down to one flag for release.

Collapsed to reverse-geocoding alone: removed update-location from _RELEASE_DEFAULTS and the public flag attribute in utils/flags.py, updated all four call sites (mainwindow.py, cache_table.py, import_dialog.py, settings_dialog.py), features.json, and the tests/docs that referenced it (feature-flags.md's stale "Current flags" table also had the old GeoNames-era description for update-location, now fixed to describe what it actually gates).

#60