### PR TITLE
Reverse geocoding: fix crash on pack filenames with spaces

### DIFF
--- a/src/opensak/geo/packs.py
+++ b/src/opensak/geo/packs.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import sqlite3
 import tempfile
 import time
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -29,10 +31,19 @@ DOWNLOAD_TIMEOUT = 60
 # releases the GIL during the actual socket wait, so a higher worker count
 # than a CPU-bound pool (e.g. the resolver's min(4, cpu_count)) is fine here.
 BASELINE_FETCH_WORKERS = 16
+# http.client.HTTPException (e.g. InvalidURL) is not an OSError/URLError
+# subclass, so it isn't caught by a plain except (URLError, OSError) — a
+# malformed URL (bad characters in a filename) would otherwise crash the
+# whole download instead of degrading to "this one file failed".
+_FETCH_ERRORS = (URLError, OSError, http.client.HTTPException)
 
 
 def _asset_url(filename: str) -> str:
-    return f"{DATA_REPO_URL}/{filename}"
+    # Filenames should always be pre-sanitized by the generator (no spaces or
+    # other characters GitHub would rewrite on upload) — quote() defensively
+    # anyway so a stray character degrades to a 404, not an unhandled
+    # http.client.InvalidURL crashing the whole download.
+    return f"{DATA_REPO_URL}/{urllib.parse.quote(filename)}"
 
 
 def fetch_manifest(timeout: int = REQUEST_TIMEOUT) -> dict | None:
@@ -40,7 +51,7 @@ def fetch_manifest(timeout: int = REQUEST_TIMEOUT) -> dict | None:
     try:
         with urllib.request.urlopen(_asset_url(MANIFEST_FILENAME), timeout=timeout) as resp:
             return json.load(resp)  # type: ignore[no-any-return]
-    except (URLError, OSError, json.JSONDecodeError) as exc:
+    except (*_FETCH_ERRORS, json.JSONDecodeError) as exc:
         log.debug("manifest fetch failed: %s", exc)
         return None
 
@@ -54,7 +65,7 @@ def fetch_pack(filename: str, dest_dir: Path, timeout: int = DOWNLOAD_TIMEOUT) -
     try:
         with urllib.request.urlopen(_asset_url(filename), timeout=timeout) as resp:
             data = resp.read()
-    except (URLError, OSError) as exc:
+    except _FETCH_ERRORS as exc:
         log.debug("pack fetch failed (%s): %s", filename, exc)
         return False
     return _atomic_write(dest_dir, filename, data)
@@ -191,7 +202,7 @@ def _fetch_file_atomic(filename: str, dest_dir: Path) -> bool:
     try:
         with urllib.request.urlopen(_asset_url(filename), timeout=DOWNLOAD_TIMEOUT) as resp:
             data = resp.read()
-    except (URLError, OSError) as exc:
+    except _FETCH_ERRORS as exc:
         log.debug("file fetch failed (%s): %s", filename, exc)
         return False
     return _atomic_write(dest_dir, filename, data)

--- a/tests/unit-tests/test_gsak_to_opensak.py
+++ b/tests/unit-tests/test_gsak_to_opensak.py
@@ -146,6 +146,47 @@ def test_county_output_is_validity_repaired(tmp_path: Path) -> None:
     assert shape(fc["features"][0]["geometry"]).is_valid
 
 
+def test_sanitize_filename_part_strips_spaces_and_accents() -> None:
+    # GitHub Release assets silently rewrite spaces to dots on upload — a raw
+    # GSAK state name in the output filename would permanently diverge from
+    # the real asset name (found via Canada's "British Columbia", "Québec").
+    assert conv._sanitize_filename_part("British Columbia") == "British_Columbia"
+    assert conv._sanitize_filename_part("Québec") == "Quebec"
+    assert conv._sanitize_filename_part("Newfoundland and Labrador") == "Newfoundland_and_Labrador"
+    assert conv._sanitize_filename_part("Alberta") == "Alberta"
+
+
+def test_county_pack_filename_is_sanitized(tmp_path: Path) -> None:
+    bb_path = tmp_path / "bb.db3"
+    _write_bb_db3(bb_path)
+    _write_country_zip(tmp_path / "country_v1.zip", "1", "United States")
+    _write_county_zip(tmp_path / "counties" / "usa" / "california_v3.zip", "1", "Alpha County")
+    _write_county_zip(tmp_path / "counties" / "usa" / "texas_v5.zip", "2", "Beta County")
+
+    # Rename the "california" pack to something with a space, mirroring a
+    # real GSAK state name — bb.db3/Version rows drive the version lookup,
+    # the zip filename drives which file gets opened, so both need updating.
+    db = sqlite3.connect(bb_path)
+    db.execute("UPDATE bb_county SET State = 'New Brunswick' WHERE State = 'california'")
+    db.execute("UPDATE Version SET State = 'New Brunswick' WHERE State = 'california'")
+    db.commit()
+    db.close()
+    (tmp_path / "counties" / "usa" / "california_v3.zip").rename(
+        tmp_path / "counties" / "usa" / "New Brunswick_v3.zip"
+    )
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    _run(bb_path, tmp_path, out_dir)
+
+    packs = sorted(p.name for p in (out_dir / "counties").iterdir())
+    assert packs == ["usa_New_Brunswick.geojson", "usa_texas.geojson"]
+
+    manifest = json.loads((out_dir / "manifest.json").read_text())
+    assert "usa_New_Brunswick.geojson" in manifest["packs"]
+    assert " " not in "".join(manifest["packs"].keys())
+
+
 def _run(bb_path: Path, gsak_dir: Path, out_dir: Path) -> None:
     import sys
 

--- a/tests/unit-tests/test_packs.py
+++ b/tests/unit-tests/test_packs.py
@@ -118,6 +118,34 @@ class TestFetchPack:
         packs.fetch_pack("prt.geojson", tmp_path)
         assert "prt.geojson" in seen_urls[0]
 
+    def test_url_percent_encodes_special_characters(self, tmp_path: Path, monkeypatch):
+        # Defense in depth: filenames should always be pre-sanitized by the
+        # generator, but a raw space in a URL raises http.client.InvalidURL
+        # (not an OSError/URLError) if it isn't encoded first.
+        seen_urls: list[str] = []
+
+        def _fake(url, **_k):
+            seen_urls.append(url)
+            return _FakeResp(b"{}")
+
+        monkeypatch.setattr("urllib.request.urlopen", _fake)
+        packs.fetch_pack("can_British Columbia.geojson", tmp_path)
+        assert " " not in seen_urls[0]
+        assert "British%20Columbia" in seen_urls[0]
+
+    def test_invalid_url_error_returns_false_instead_of_crashing(self, tmp_path: Path, monkeypatch):
+        # http.client.InvalidURL is not an OSError/URLError subclass — this is
+        # exactly the exception that used to crash the whole QThread instead
+        # of degrading gracefully to "this one file failed".
+        import http.client
+
+        def _raise(*_a, **_k):
+            raise http.client.InvalidURL("URL can't contain control characters")
+
+        monkeypatch.setattr("urllib.request.urlopen", _raise)
+        result = packs.fetch_pack("bad name.geojson", tmp_path)
+        assert result is False
+
 
 # ── fetch_all ─────────────────────────────────────────────────────────────────
 

--- a/tools/boundaries/gsak_to_opensak.py
+++ b/tools/boundaries/gsak_to_opensak.py
@@ -28,7 +28,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sqlite3
+import unicodedata
 import zipfile
 from pathlib import Path
 
@@ -253,6 +255,15 @@ def _read_zip_entry(zf: zipfile.ZipFile, entry: str) -> str | None:
         return raw.decode("latin-1")  # GSAK files pre-2020 often use Latin-1
 
 
+def _sanitize_filename_part(name: str) -> str:
+    # GSAK state/pack names can contain spaces and accents (e.g. Canada's
+    # "British Columbia", "Québec") — GitHub Release assets silently rewrite
+    # such characters on upload (spaces become dots), which would otherwise
+    # make manifest.json permanently diverge from the real asset names.
+    ascii_only = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"[^A-Za-z0-9]+", "_", ascii_only).strip("_")
+
+
 # ── Version table ─────────────────────────────────────────────────────────────
 
 def _load_versions(bb: sqlite3.Connection) -> dict[tuple[str, str, str], int]:
@@ -411,10 +422,12 @@ def _convert_counties(
 
         # Counties from the same pack are flattened into a single release-asset
         # filename (cc_pack.geojson) — GitHub Release assets can't hold subdirectories,
-        # and packs.py fetches them by this exact flat name.
+        # and packs.py fetches them by this exact flat name. pack_name is sanitized
+        # here (not when locating the source zip above) since some GSAK state names
+        # contain spaces/accents (e.g. Canada's "British Columbia", "Québec").
         pack_features: list[dict[str, object]] = []
         pack_region_rows: list[tuple] = []
-        out_pack = f"{cc}_{pack_name}.geojson"
+        out_pack = f"{cc}_{_sanitize_filename_part(pack_name)}.geojson"
 
         with zipfile.ZipFile(zip_path) as zf:
             for row in by_cc_pack[(cc, pack_name)]:


### PR DESCRIPTION
Real crash hit while manually testing: "Download all boundary packs" aborted the whole app with http.client.InvalidURL. A Canadian province pack name with a space in it (can_British Columbia.geojson) produced a URL containing a raw space.

Two bugs, both fixed:

1. packs.py never percent-encoded filenames when building asset URLs, and InvalidURL is not an OSError/URLError subclass, so the existing except clauses never caught it -- the unhandled exception took down the QThread and the whole app with it (aborted process). Fixed: _asset_url now percent-encodes the filename, and all three network fetch functions also catch http.client.HTTPException as defense in depth.

2. The actual root cause: GitHub Release assets silently rewrite spaces to dots on upload. manifest.json (built from the raw GSAK state name) permanently diverged from the real uploaded asset name for every Canadian province with a space (British Columbia, New Brunswick, Newfoundland and Labrador, Nova Scotia, Prince Edward Island) or accent (Québec) -- 6 of Canada's 11 provinces were never actually downloadable regardless of the URL-encoding fix, since the filename itself didn't match what GitHub actually stored. Fixed by sanitizing pack_name (strip accents, replace non-alphanumerics with underscores) before building the output filename in gsak_to_opensak.py, so what manifest.json records always matches what actually gets published.

Verified: regenerated the real dataset, confirmed all 11 Canadian pack filenames are now clean (no spaces/accents), 0/22340 invalid geometries as before, manifest packs match the actual generated files exactly.

Still need to re-publish the corrected assets to the already-live release (data itself, not code) -- doing that as a separate step since it's a data operation, not a code change.

#60