### PR TITLE
Automated integrity check for the boundary dataset release

### DIFF
--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -5,7 +5,9 @@ name: Data integrity
 # and the resolver actually returns a result for known real-world coordinates.
 on:
   schedule:
-    - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC
+    # every 2 days, 06:00 UTC (cron has no exact "every N days" — day-of-month
+    # */2 drifts by a day across some month boundaries, close enough here)
+    - cron: '0 6 */2 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -1,0 +1,41 @@
+name: Data integrity
+
+# Verifies the published OpenSAK-Data boundary release (issue #60): checksums
+# match, boundaries.db is structurally sound, every GeoJSON pack is valid,
+# and the resolver actually returns a result for known real-world coordinates.
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Verify release data
+        run: python tools/boundaries/verify_release.py
+      - name: File an issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          open_count=$(gh issue list --label data-integrity --state open --json number --jq 'length')
+          if [ "$open_count" -eq 0 ]; then
+            gh issue create \
+              --label data-integrity \
+              --title "Data integrity check failed ($(date -u +%F))" \
+              --body "The scheduled data-integrity workflow failed. See the run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            echo "An open data-integrity issue already exists, skipping."
+          fi

--- a/docs/reverse-geocoding-data.md
+++ b/docs/reverse-geocoding-data.md
@@ -114,4 +114,4 @@ real-world coordinates. Run it against the published release
 (`python tools/boundaries/verify_release.py`) or against a local pre-publish
 directory before cutting a new release (`--data-dir <out-dir>`). A scheduled
 run (`.github/workflows/data-integrity.yml`) verifies the published release
-weekly and files a GitHub issue if it fails.
+every 2 days and files a GitHub issue if it fails.

--- a/docs/reverse-geocoding-data.md
+++ b/docs/reverse-geocoding-data.md
@@ -34,7 +34,8 @@ the tree.
 data/
 ├── boundaries.db        # SQLite: per-layer R-Trees + region metadata
 ├── manifest.json        # dataset version; "baseline" (world.geojson + state packs)
-│                         # and "packs" (county, on-demand) sections
+│                         # and "packs" (county, on-demand) sections; every entry
+│                         # also carries a sha256 + size for integrity checks
 ├── countries/
 │   └── world.geojson    # baseline — one country FeatureCollection
 ├── states/
@@ -102,3 +103,15 @@ boundary, any further rings are holes.
 but complete `data/` directory (three counties, one state, one country) in a
 temp dir via `_build_boundaries()`. It is the authoritative, executable example
 of this contract — copy its output into `data/` for a working hand-made dataset.
+
+## Verifying a release
+
+[`tools/boundaries/verify_release.py`](../tools/boundaries/verify_release.py)
+checks a boundary dataset end to end: every asset's `sha256`/`size` against
+the manifest, `boundaries.db`'s row counts against its GeoJSON packs, every
+pack's JSON/geometry validity, and a resolver smoke test against known
+real-world coordinates. Run it against the published release
+(`python tools/boundaries/verify_release.py`) or against a local pre-publish
+directory before cutting a new release (`--data-dir <out-dir>`). A scheduled
+run (`.github/workflows/data-integrity.yml`) verifies the published release
+weekly and files a GitHub issue if it fails.

--- a/plans/reverse-geocoding-data-migration.md
+++ b/plans/reverse-geocoding-data-migration.md
@@ -62,7 +62,7 @@ here as one migration story so the cut-over from `data/` is explicit.
    consuming the release; nothing previously verified that what's actually
    published stays intact. `tools/boundaries/verify_release.py` validates
    manifest checksums, `boundaries.db` structure, GeoJSON/geometry validity,
-   and a resolver smoke test — run on a weekly schedule
+   and a resolver smoke test — run every 2 days
    (`.github/workflows/data-integrity.yml`) against the live release, filing
    a GitHub issue on failure. See
    [`docs/reverse-geocoding-data.md`](../docs/reverse-geocoding-data.md#verifying-a-release).

--- a/plans/reverse-geocoding-data-migration.md
+++ b/plans/reverse-geocoding-data-migration.md
@@ -58,6 +58,18 @@ here as one migration story so the cut-over from `data/` is explicit.
    resolver via `OPENSAK_BOUNDARIES_DIR`. A real, unmocked end-to-end run was
    also done once, against the live release, to prove the mocks weren't lying.
 
+7. **Publisher-side integrity check. ✓ DONE.** Steps 1-6 cover the *client*
+   consuming the release; nothing previously verified that what's actually
+   published stays intact. `tools/boundaries/verify_release.py` validates
+   manifest checksums, `boundaries.db` structure, GeoJSON/geometry validity,
+   and a resolver smoke test — run on a weekly schedule
+   (`.github/workflows/data-integrity.yml`) against the live release, filing
+   a GitHub issue on failure. See
+   [`docs/reverse-geocoding-data.md`](../docs/reverse-geocoding-data.md#verifying-a-release).
+   Regenerating the dataset itself from a fresh source (e.g. pulling updated
+   polygons from OSM directly, instead of another manual `bb.db3` handoff)
+   is a separate, unbuilt follow-up.
+
 ## Acceptance
 
 - ✓ A fresh install resolves country/state offline from the bundled (or

--- a/tests/unit-tests/test_gsak_to_opensak.py
+++ b/tests/unit-tests/test_gsak_to_opensak.py
@@ -1,5 +1,6 @@
 # tests/unit-tests/test_gsak_to_opensak.py — GSAK boundary converter output contract.
 
+import hashlib
 import json
 import sqlite3
 import zipfile
@@ -85,6 +86,25 @@ def test_county_packs_are_flat_and_manifest_matches_real_versions(tmp_path: Path
     assert manifest["baseline"]["usa.geojson"]["version"] == "2"
     assert manifest["packs"]["usa_california.geojson"]["version"] == "3"
     assert manifest["packs"]["usa_texas.geojson"]["version"] == "5"
+
+    def _digest(path: Path) -> tuple[str, int]:
+        data = path.read_bytes()
+        return hashlib.sha256(data).hexdigest(), len(data)
+
+    db_sha, db_size = _digest(out_dir / "boundaries.db")
+    assert (manifest["boundaries_db"]["sha256"], manifest["boundaries_db"]["size"]) == (db_sha, db_size)
+
+    world_sha, world_size = _digest(out_dir / "countries" / "world.geojson")
+    assert manifest["baseline"]["world.geojson"]["sha256"] == world_sha
+    assert manifest["baseline"]["world.geojson"]["size"] == world_size
+
+    usa_sha, usa_size = _digest(out_dir / "states" / "usa.geojson")
+    assert manifest["baseline"]["usa.geojson"]["sha256"] == usa_sha
+    assert manifest["baseline"]["usa.geojson"]["size"] == usa_size
+
+    pack_sha, pack_size = _digest(out_dir / "counties" / "usa_california.geojson")
+    assert manifest["packs"]["usa_california.geojson"]["sha256"] == pack_sha
+    assert manifest["packs"]["usa_california.geojson"]["size"] == pack_size
 
 
 def test_simplify_preserves_shape_when_tolerance_is_zero() -> None:

--- a/tests/unit-tests/test_verify_release.py
+++ b/tests/unit-tests/test_verify_release.py
@@ -1,0 +1,220 @@
+# tests/unit-tests/test_verify_release.py — tools/boundaries/verify_release.py checks.
+
+import hashlib
+import json
+import sqlite3
+from io import BytesIO
+from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import unquote
+
+import pytest
+
+from tools.boundaries import verify_release as vr
+
+_SQUARE = [[[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]]
+# Self-intersecting "bowtie" ring — shapely reports it as an invalid geometry.
+_BOWTIE = [[[0, 0], [2, 2], [2, 0], [0, 2], [0, 0]]]
+
+_INSIDE = (1.0, 1.0, "Testland")
+
+
+class _FakeResp:
+    def __init__(self, payload: bytes) -> None:
+        self._data = BytesIO(payload)
+
+    def read(self) -> bytes:
+        return self._data.read()
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *_a: object) -> None:
+        return
+
+
+def _feature(layer: str, name: str, parent: str | None, coords: list = _SQUARE) -> dict:
+    return {
+        "type": "Feature",
+        "properties": {"layer": layer, "name": name, "parent": parent, "version": 1,
+                       "source": "test", "licence": "ODbL"},
+        "bbox": [0, 0, 2, 2],
+        "geometry": {"type": "Polygon", "coordinates": coords},
+    }
+
+
+def _write_fc(path: Path, features: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"type": "FeatureCollection", "features": features}), encoding="utf-8")
+
+
+def _digest(path: Path) -> dict:
+    data = path.read_bytes()
+    return {"sha256": hashlib.sha256(data).hexdigest(), "size": len(data)}
+
+
+def _build_release(root: Path, county_coords: list = _SQUARE) -> dict:
+    """A tiny, manifest-shaped release: one country/state/county, resolvable at (1, 1)."""
+    _write_fc(root / "countries" / "world.geojson", [_feature("country", "Testland", None)])
+    _write_fc(root / "states" / "usa.geojson", [_feature("state", "Teststate", "TL")])
+    _write_fc(root / "counties" / "usa_county.geojson",
+              [_feature("county", "Testcounty", "TL/TS", county_coords)])
+
+    db = sqlite3.connect(root / "boundaries.db")
+    for layer in ("country", "state", "county"):
+        db.execute(f"CREATE VIRTUAL TABLE rtree_{layer} USING rtree(id, min_lat, max_lat, min_lon, max_lon)")
+        db.execute(f"CREATE TABLE region_{layer} (id INTEGER PRIMARY KEY, name TEXT NOT NULL, "
+                   "parent TEXT, pack TEXT NOT NULL, feature_index INTEGER NOT NULL, "
+                   "poly_version INTEGER NOT NULL, is_bundled INTEGER NOT NULL)")
+    db.execute("CREATE TABLE file_version (layer TEXT, country TEXT, state TEXT, version INTEGER)")
+    db.execute("INSERT INTO rtree_country VALUES (1, 0, 2, 0, 2)")
+    db.execute("INSERT INTO region_country VALUES (1, 'Testland', NULL, 'world.geojson', 0, 1, 1)")
+    db.execute("INSERT INTO rtree_state VALUES (1, 0, 2, 0, 2)")
+    db.execute("INSERT INTO region_state VALUES (1, 'Teststate', 'TL', 'usa.geojson', 0, 1, 1)")
+    db.execute("INSERT INTO rtree_county VALUES (1, 0, 2, 0, 2)")
+    db.execute("INSERT INTO region_county VALUES (1, 'Testcounty', 'TL/TS', 'usa_county.geojson', 0, 1, 1)")
+    db.execute("INSERT INTO file_version VALUES ('dataset', NULL, NULL, 1)")
+    db.commit()
+    db.close()
+
+    manifest = {
+        "dataset_version": "1",
+        "boundaries_db": _digest(root / "boundaries.db"),
+        "baseline": {
+            "world.geojson": {"version": "1", **_digest(root / "countries" / "world.geojson")},
+            "usa.geojson": {"version": "1", **_digest(root / "states" / "usa.geojson")},
+        },
+        "packs": {
+            "usa_county.geojson": {"version": "1", **_digest(root / "counties" / "usa_county.geojson")},
+        },
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest
+
+
+@pytest.fixture(autouse=True)
+def _smoke_inside_fixture(monkeypatch):
+    # The real script checks real-world coordinates; point it at our synthetic
+    # square instead so tests don't depend on network-fetched production data.
+    monkeypatch.setattr(vr, "_SMOKE_COORDS", (_INSIDE,))
+
+
+# ── --data-dir (local) ──────────────────────────────────────────────────────
+
+class TestLocalDataDir:
+    def test_all_green(self, tmp_path: Path) -> None:
+        _build_release(tmp_path)
+        assert vr.verify(tmp_path) == []
+
+    def test_missing_manifest(self, tmp_path: Path) -> None:
+        errors = vr.verify(tmp_path)
+        assert len(errors) == 1
+        assert "manifest.json not found" in errors[0]
+
+    def test_missing_dataset_version(self, tmp_path: Path) -> None:
+        _build_release(tmp_path)
+        manifest_path = tmp_path / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        del manifest["dataset_version"]
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        errors = vr.verify(tmp_path)
+        assert any("dataset_version" in e for e in errors)
+
+    def test_checksum_mismatch_same_size(self, tmp_path: Path) -> None:
+        _build_release(tmp_path)
+        path = tmp_path / "states" / "usa.geojson"
+        # Same length, still valid JSON/UTF-8 — isolates the checksum check
+        # from the JSON/geometry checks, which have their own tests.
+        path.write_bytes(path.read_bytes().replace(b"Teststate", b"TESTSTATE"))
+        errors = vr.verify(tmp_path)
+        assert any("usa.geojson" in e and "sha256 mismatch" in e for e in errors)
+
+    def test_checksum_mismatch_size_changed(self, tmp_path: Path) -> None:
+        _build_release(tmp_path)
+        (tmp_path / "states" / "usa.geojson").write_bytes(b"tampered")
+        errors = vr.verify(tmp_path)
+        assert any("usa.geojson" in e and "size mismatch" in e for e in errors)
+
+    def test_missing_asset(self, tmp_path: Path) -> None:
+        _build_release(tmp_path)
+        (tmp_path / "counties" / "usa_county.geojson").unlink()
+        errors = vr.verify(tmp_path)
+        assert any("usa_county.geojson" in e and "not found" in e for e in errors)
+
+    def test_feature_index_out_of_bounds(self, tmp_path: Path) -> None:
+        _build_release(tmp_path)
+        db = sqlite3.connect(tmp_path / "boundaries.db")
+        db.execute("UPDATE region_county SET feature_index = 5")
+        db.commit()
+        db.close()
+        errors = vr.verify(tmp_path)
+        assert any("feature_index" in e and "out of bounds" in e for e in errors)
+
+    def test_row_count_mismatch(self, tmp_path: Path) -> None:
+        _build_release(tmp_path)
+        db = sqlite3.connect(tmp_path / "boundaries.db")
+        db.execute("INSERT INTO rtree_country VALUES (2, 10, 12, 10, 12)")
+        db.commit()
+        db.close()
+        errors = vr.verify(tmp_path)
+        assert any("rtree_country" in e and "region_country" in e for e in errors)
+
+    def test_invalid_geometry(self, tmp_path: Path) -> None:
+        _build_release(tmp_path, county_coords=_BOWTIE)
+        errors = vr.verify(tmp_path)
+        assert any("invalid geometry" in e for e in errors)
+
+    def test_resolver_returns_none_when_smoke_coords_miss(self, tmp_path: Path, monkeypatch) -> None:
+        _build_release(tmp_path)
+        monkeypatch.setattr(vr, "_SMOKE_COORDS", ((99.0, 99.0, "Nowhere"),))
+        errors = vr.verify(tmp_path)
+        assert len(errors) == 1
+        assert "resolver returned no country" in errors[0]
+
+
+# ── remote (network-mocked) ─────────────────────────────────────────────────
+
+def _fake_urlopen_factory(src_root: Path, manifest: dict):
+    def _fake(url, *_a, **_k):
+        name = unquote(url.rsplit("/", 1)[-1])
+        if name == "manifest.json":
+            return _FakeResp(json.dumps(manifest).encode())
+        for subdir in ("", "countries", "states", "counties"):
+            candidate = (src_root / subdir / name) if subdir else (src_root / name)
+            if candidate.is_file():
+                return _FakeResp(candidate.read_bytes())
+        raise URLError(f"no such asset: {name}")
+    return _fake
+
+
+class TestRemoteRelease:
+    def test_all_green_over_network(self, tmp_path: Path, monkeypatch) -> None:
+        manifest = _build_release(tmp_path)
+        monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen_factory(tmp_path, manifest))
+        assert vr.verify(None) == []
+
+    def test_manifest_fetch_failure(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda *_a, **_k: (_ for _ in ()).throw(URLError("down")),
+        )
+        errors = vr.verify(None)
+        assert len(errors) == 1
+        assert "failed to fetch manifest" in errors[0]
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+class TestMain:
+    def test_exits_nonzero_on_failure(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        monkeypatch.setattr("sys.argv", ["verify_release.py", "--data-dir", str(tmp_path)])
+        with pytest.raises(SystemExit) as exc:
+            vr.main()
+        assert exc.value.code == 1
+        assert "FAILED" in capsys.readouterr().out
+
+    def test_exits_zero_on_success(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        _build_release(tmp_path)
+        monkeypatch.setattr("sys.argv", ["verify_release.py", "--data-dir", str(tmp_path)])
+        vr.main()
+        assert "OK" in capsys.readouterr().out

--- a/tools/boundaries/gsak_to_opensak.py
+++ b/tools/boundaries/gsak_to_opensak.py
@@ -27,6 +27,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sqlite3
@@ -464,6 +465,11 @@ def _convert_counties(
     return pack_versions
 
 
+def _file_digest(path: Path) -> dict[str, object]:
+    data = path.read_bytes()
+    return {"sha256": hashlib.sha256(data).hexdigest(), "size": len(data)}
+
+
 def _write_manifest(
     out_dir: Path,
     dataset_version: int,
@@ -473,10 +479,21 @@ def _write_manifest(
     # "baseline" (world.geojson + state packs) is bundled in every install and
     # fetched wholesale on first run when not bundled (see geo/packs.py
     # fetch_baseline). "packs" (county-level) stays on-demand, per-country.
+    # sha256/size let verify_release.py detect a corrupted or truncated
+    # release asset without needing to reprocess the whole dataset.
     manifest = {
         "dataset_version": str(dataset_version),
-        "baseline": {name: {"version": str(v)} for name, v in sorted(baseline_versions.items())},
-        "packs": {name: {"version": str(v)} for name, v in sorted(pack_versions.items())},
+        "boundaries_db": _file_digest(out_dir / "boundaries.db"),
+        "baseline": {
+            name: {"version": str(v), **_file_digest(
+                out_dir / ("countries" if name == "world.geojson" else "states") / name
+            )}
+            for name, v in sorted(baseline_versions.items())
+        },
+        "packs": {
+            name: {"version": str(v), **_file_digest(out_dir / "counties" / name)}
+            for name, v in sorted(pack_versions.items())
+        },
     }
     (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 

--- a/tools/boundaries/verify_release.py
+++ b/tools/boundaries/verify_release.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# tools/boundaries/verify_release.py — validate a boundary dataset release.
+#
+# Checks a published OpenSAK-Data release (or a local pre-publish directory)
+# end to end: manifest well-formed, every asset's sha256/size matches,
+# boundaries.db opens with row counts consistent with its GeoJSON packs,
+# every pack is valid GeoJSON with valid geometries, and a resolver smoke
+# test against known real-world coordinates returns a result.
+#
+#   tools/boundaries/verify_release.py                # fetch + verify the published release
+#   tools/boundaries/verify_release.py --data-dir DIR  # verify a local pre-publish directory
+#
+# Exits non-zero and prints every issue found if anything is wrong.
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from shapely.geometry import shape as _shp_shape
+
+from opensak.geo import packs
+from opensak.geo.boundaries import TerritoryResolver
+from opensak.geo.store import BoundaryStore
+
+_LAYER_DIRS = {"country": "countries", "state": "states", "county": "counties"}
+
+# Fixed, well-inside-a-country coordinates. Only the *presence* of a country
+# result is asserted, never the exact name — state/county names are real
+# content that legitimately changes between releases.
+_SMOKE_COORDS: tuple[tuple[float, float, str], ...] = (
+    (38.7223, -9.1393, "Lisbon, Portugal"),
+    (38.9072, -77.0369, "Washington DC, USA"),
+)
+
+
+def _asset_entries(manifest: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
+    entries = [("boundaries.db", "", manifest.get("boundaries_db", {}))]
+    for name, info in manifest.get("baseline", {}).items():
+        subdir = "countries" if name == "world.geojson" else "states"
+        entries.append((name, subdir, info))
+    for name, info in manifest.get("packs", {}).items():
+        entries.append((name, "counties", info))
+    return entries
+
+
+def _download_all(manifest: dict[str, Any], dest_root: Path) -> list[str]:
+    errors = []
+    for name, subdir, _expected in _asset_entries(manifest):
+        dest_dir = dest_root / subdir if subdir else dest_root
+        if not packs.fetch_pack(name, dest_dir):
+            errors.append(f"{name}: failed to download")
+    return errors
+
+
+def _verify_checksums(manifest: dict[str, Any], root: Path) -> list[str]:
+    errors = []
+    for name, subdir, expected in _asset_entries(manifest):
+        sha = expected.get("sha256")
+        size = expected.get("size")
+        if sha is None or size is None:
+            errors.append(f"{name}: manifest missing sha256/size")
+            continue
+        path = (root / subdir / name) if subdir else (root / name)
+        if not path.is_file():
+            errors.append(f"{name}: not found at {path}")
+            continue
+        data = path.read_bytes()
+        if len(data) != size:
+            errors.append(f"{name}: size mismatch (expected {size}, got {len(data)})")
+            continue
+        actual_sha = hashlib.sha256(data).hexdigest()
+        if actual_sha != sha:
+            errors.append(f"{name}: sha256 mismatch (expected {sha}, got {actual_sha})")
+    return errors
+
+
+def _load_geojson(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    # A corrupted release asset can fail in several ways (bad encoding, bad
+    # JSON, truncated file) — none of them should crash the checker itself.
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, f"{path}: unreadable ({exc})"
+
+
+def _verify_boundaries_db(root: Path) -> list[str]:
+    db_path = root / "boundaries.db"
+    if not db_path.is_file():
+        return [f"boundaries.db not found at {db_path}"]
+
+    errors: list[str] = []
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    except sqlite3.DatabaseError as exc:
+        return [f"{db_path}: not a valid SQLite database ({exc})"]
+    try:
+        pack_feature_counts: dict[str, int] = {}
+        for layer, dirname in _LAYER_DIRS.items():
+            rtree_table, region_table = f"rtree_{layer}", f"region_{layer}"
+            if rtree_table not in tables or region_table not in tables:
+                errors.append(f"{layer}: missing table {rtree_table} or {region_table}")
+                continue
+
+            rtree_count = conn.execute(f"SELECT COUNT(*) FROM {rtree_table}").fetchone()[0]
+            region_rows = conn.execute(
+                f"SELECT id, pack, feature_index FROM {region_table}"
+            ).fetchall()
+            if rtree_count != len(region_rows):
+                errors.append(
+                    f"{layer}: {rtree_table} has {rtree_count} row(s) but "
+                    f"{region_table} has {len(region_rows)}"
+                )
+
+            for row in region_rows:
+                pack_path = root / dirname / row["pack"]
+                count = pack_feature_counts.get(str(pack_path))
+                if count is None:
+                    if not pack_path.is_file():
+                        errors.append(f"{layer} region {row['id']}: pack file missing: {pack_path}")
+                        continue
+                    fc, load_error = _load_geojson(pack_path)
+                    if load_error:
+                        errors.append(load_error)
+                        continue
+                    assert fc is not None
+                    count = len(fc.get("features", []))
+                    pack_feature_counts[str(pack_path)] = count
+                if not (0 <= row["feature_index"] < count):
+                    errors.append(
+                        f"{layer} region {row['id']}: feature_index {row['feature_index']} "
+                        f"out of bounds for {row['pack']} ({count} features)"
+                    )
+    finally:
+        conn.close()
+    return errors
+
+
+def _verify_pack_geometries(root: Path) -> list[str]:
+    errors = []
+    for dirname in _LAYER_DIRS.values():
+        d = root / dirname
+        if not d.is_dir():
+            continue
+        for path in sorted(d.glob("*.geojson")):
+            fc, load_error = _load_geojson(path)
+            if load_error:
+                errors.append(load_error)
+                continue
+            assert fc is not None
+            for i, feature in enumerate(fc.get("features", [])):
+                geom = feature.get("geometry")
+                if geom is None:
+                    continue
+                try:
+                    shp = _shp_shape(geom)
+                except Exception as exc:  # noqa: BLE001 — any shapely/geometry error is a data defect
+                    errors.append(f"{path} feature {i}: unparsable geometry ({exc})")
+                    continue
+                if not shp.is_valid:
+                    errors.append(f"{path} feature {i}: invalid geometry")
+    return errors
+
+
+def _verify_resolver(root: Path) -> list[str]:
+    store = BoundaryStore(root)
+    if not store.available():
+        return ["boundaries.db not available for resolver smoke test"]
+    resolver = TerritoryResolver(store)
+    errors = []
+    for lat, lon, label in _SMOKE_COORDS:
+        location = resolver.resolve(lat, lon)
+        if not location.country:
+            errors.append(f"resolver returned no country for {label} ({lat}, {lon})")
+    store.close()
+    return errors
+
+
+def _run_checks(manifest: dict[str, Any], root: Path) -> list[str]:
+    errors: list[str] = []
+    if not manifest.get("dataset_version"):
+        errors.append("manifest missing dataset_version")
+    errors += _verify_checksums(manifest, root)
+    errors += _verify_boundaries_db(root)
+    errors += _verify_pack_geometries(root)
+    if not errors:  # skip the (slower) resolver smoke test if the data is already known-bad
+        errors += _verify_resolver(root)
+    return errors
+
+
+def verify(data_dir: Path | None) -> list[str]:
+    if data_dir is not None:
+        manifest_path = data_dir / "manifest.json"
+        if not manifest_path.is_file():
+            return [f"manifest.json not found at {manifest_path}"]
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        return _run_checks(manifest, data_dir)
+
+    manifest = packs.fetch_manifest()
+    if manifest is None:
+        return ["failed to fetch manifest.json from OpenSAK-Data"]
+    with tempfile.TemporaryDirectory(prefix="opensak-verify-") as tmp:
+        root = Path(tmp)
+        errors = _download_all(manifest, root)
+        errors += _run_checks(manifest, root)
+        return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify a published (or local pre-publish) OpenSAK-Data boundary release."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Validate a local pre-publish directory instead of downloading the published release",
+    )
+    args = parser.parse_args()
+
+    errors = verify(args.data_dir)
+    if errors:
+        print(f"FAILED — {len(errors)} issue(s) found:")
+        for error in errors:
+            print(f"  - {error}")
+        raise SystemExit(1)
+    print("OK — release data verified.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a publisher-side integrity check for the OpenSAK-Data boundary release, the piece that was missing from #60: the app already refreshes its local copy on a schedule, but nothing verified that what's actually published stays intact.

manifest.json now carries a sha256 and size for every asset (boundaries.db, baseline packs, county packs), computed by gsak_to_opensak.py at generation time. tools/boundaries/verify_release.py checks a release end to end: every asset's checksum against the manifest, boundaries.db's row counts against its GeoJSON packs, every pack's JSON/geometry validity, and a resolver smoke test against known real-world coordinates. It works against the published release or a local pre-publish directory (--data-dir), so it can also be run before cutting a new release. A new scheduled workflow, data-integrity.yml, runs it weekly and files a data-integrity issue on failure (deduped against any already-open one).

Ran it against the current live release as a real end-to-end check. It correctly reports the 241 assets as missing sha256/size (expected, since they predate this manifest format) and, more importantly, found a real live bug: boundaries.db still stores the unsanitized, space-containing pack filenames for 6 Canadian provinces (British Columbia, New Brunswick, Newfoundland and Labrador, Nova Scotia, Prince Edward Island, Québec), while manifest.json has the correctly sanitized underscore versions. Since they don't match, the app's on-demand county fetch 404s silently for those provinces today. That mismatch predates this PR and isn't fixed here — it needs a new dataset regeneration and republish, which is a separate, riskier action I didn't want to bundle into this change. Happy to open a follow-up issue for it if you want to track it separately.

Automating the other half of #60 (regenerating the dataset itself from a fresh source, e.g. pulling updated polygons from OSM directly instead of another manual bb.db3 handoff) is a bigger feature and stays out of scope here.

Relates to #60.