### PR TITLE
Fix #609: database move fails on fresh install + forward-slash path d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.15.1] — 2026-07-16
+
+> Hotfix release. Addresses a bug in the welcome wizard and Settings →
+> Advanced's "move databases" flow reported shortly after 1.15.0 shipped.
+
+### Fixed
+
+- **Database move fails with "No such file or directory" on a fresh install
+  (#609)** — on a brand-new installation, the auto-created "Default"
+  database entry only exists as an in-memory/metadata record until the app
+  actually opens it; no physical `.db` file exists yet at that point. If
+  the user chose a separate database folder during the welcome wizard and
+  asked to move existing databases, this looked like an existing database
+  ("You have 1 existing database(s)") but the move itself then failed,
+  since there was no file to copy. Database entries without a physical
+  file on disk are now recognized as such — they're no longer counted in
+  the "existing databases" prompt, and moving them simply updates the
+  recorded path instead of failing.
+- **Database/install folder pickers showed forward slashes on Windows
+  (#609)** — the folder chosen via the "Browse…" button in the welcome
+  wizard and Settings → Advanced is now normalized to the platform's
+  native path separator for display, instead of showing Qt's internal
+  forward-slash path verbatim (e.g. `E:/Users/...` instead of
+  `E:\Users\...`).
+
+---
+
 ## [1.15.0] — 2026-07-14
 
 > First stable release of the 1.15.0 cycle. Replaces the run of

--- a/site/user-guide.html
+++ b/site/user-guide.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>OpenSAK User Guide — v1.15.0</title>
+<title>OpenSAK User Guide — v1.15.1</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Source+Serif+4:ital,wght@0,300;0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap');
 
@@ -473,7 +473,7 @@
 <nav>
   <div class="nav-header">
     <span class="nav-logo">OpenSAK</span>
-    <div class="nav-version">User Guide · v1.15.0</div>
+    <div class="nav-version">User Guide · v1.15.1</div>
   </div>
 
   <div class="nav-section-heading">Getting Started</div>
@@ -535,7 +535,7 @@
     <div class="hero-eyebrow">Complete User Guide</div>
     <h1>OpenSAK</h1>
     <p class="hero-sub">The open-source geocache management tool for Windows, Linux, and macOS.</p>
-    <div class="hero-meta">Version 1.15.0 &nbsp;·&nbsp; MIT Licence &nbsp;·&nbsp; <a href="https://github.com/OpenSAK-Org/opensak">github.com/OpenSAK-Org/opensak</a></div>
+    <div class="hero-meta">Version 1.15.1 &nbsp;·&nbsp; MIT Licence &nbsp;·&nbsp; <a href="https://github.com/OpenSAK-Org/opensak">github.com/OpenSAK-Org/opensak</a></div>
   </div>
 
   <figure class="screenshot" style="margin-top:-0.5rem;">
@@ -1443,7 +1443,7 @@ python run.py</code></pre>
         <tr><td>Bug reports &amp; feature requests</td><td><a href="https://github.com/OpenSAK-Org/opensak/issues">github.com/OpenSAK-Org/opensak/issues</a></td></tr>
         <tr><td>Community discussion</td><td><a href="https://www.facebook.com/groups/opensak">Facebook group: OpenSAK</a></td></tr>
         <tr><td>Releases &amp; downloads</td><td><a href="https://github.com/OpenSAK-Org/opensak/releases">github.com/OpenSAK-Org/opensak/releases</a></td></tr>
-        <tr><td>Changelog</td><td><a href="https://github.com/OpenSAK-Org/opensak/blob/v1.15.0/CHANGELOG.md">CHANGELOG.md on GitHub</a></td></tr>
+        <tr><td>Changelog</td><td><a href="https://github.com/OpenSAK-Org/opensak/blob/v1.15.1/CHANGELOG.md">CHANGELOG.md on GitHub</a></td></tr>
         <tr><td>Contributing</td><td><a href="https://github.com/OpenSAK-Org/opensak/blob/main/CONTRIBUTING.md">CONTRIBUTING.md on GitHub</a></td></tr>
         <tr><td>Support the project</td><td><a href="https://opencollective.com/opensak">opencollective.com/opensak</a></td></tr>
         <tr><td>Website</td><td><a href="https://opensak.com">opensak.com</a></td></tr>
@@ -1453,7 +1453,7 @@ python run.py</code></pre>
     <div class="callout tip"><div class="callout-icon">💡</div><div>OpenSAK is free and open-source software released under the MIT licence. Contributions of any kind — code, translations, documentation, or testing — are very welcome.</div></div>
 
     <p style="margin-top:2rem;color:var(--ink-light);font-size:0.85rem;font-style:italic;">
-      This guide was generated from the OpenSAK source code (v1.15.0). Last updated July 2026.
+      This guide was generated from the OpenSAK source code (v1.15.1). Last updated July 2026.
     </p>
   </section>
 

--- a/src/opensak/__init__.py
+++ b/src/opensak/__init__.py
@@ -1,5 +1,5 @@
 """OpenSAK — cross-platform geocache management tool."""
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"
 __author__ = "OpenSAK Contributors"
 __license__ = "MIT"

--- a/src/opensak/db/manager.py
+++ b/src/opensak/db/manager.py
@@ -413,6 +413,19 @@ class DatabaseManager:
                 continue  # allerede i destinationen — intet at gøre
 
             new_path = new_dir / old_path.name
+
+            # Issue #609: en "kendt" database har ikke nødvendigvis en
+            # fysisk .db-fil endnu — fx det auto-oprettede "Default"-metadata-
+            # objekt for en helt frisk installation, hvor SQLite-filen først
+            # bliver skabt når appen rent faktisk åbner den (init_db()),
+            # hvilket sker EFTER velkomst-wizarden. shutil.copy2() ville her
+            # fejle med "No such file or directory", selvom der reelt ikke
+            # er noget at flytte. Opdatér blot stien i metadata og fortsæt —
+            # ikke en fejl, bare intet arbejde at udføre.
+            if not old_path.exists():
+                db_info.path = new_path
+                updated_any = True
+                continue
             if new_path.exists() and new_path != old_path:
                 errors.append(
                     tr("db_err_move_target_exists", name=db_info.name, path=str(new_path))

--- a/src/opensak/gui/dialogs/settings_dialog.py
+++ b/src/opensak/gui/dialogs/settings_dialog.py
@@ -1047,7 +1047,9 @@ class SettingsDialog(QDialog):
         if new_db_dir != get_db_dir():
             from opensak.db.manager import get_db_manager
             manager = get_db_manager()
-            existing_count = len(manager.databases)
+            # Issue #609: tæl kun databaser der rent faktisk har en fysisk
+            # fil på disk — se samme rettelse i welcome_wizard.py.
+            existing_count = sum(1 for db in manager.databases if db.exists)
 
             if existing_count > 0:
                 move_box = QMessageBox(self)

--- a/src/opensak/gui/dialogs/welcome_wizard.py
+++ b/src/opensak/gui/dialogs/welcome_wizard.py
@@ -534,7 +534,11 @@ class WelcomeWizard(QDialog):
         from opensak.db.manager import get_db_manager
 
         manager = get_db_manager()
-        existing_count = len(manager.databases)
+        # Issue #609: tæl kun databaser der rent faktisk har en fysisk fil
+        # på disk endnu — ellers vises "You have 1 existing database(s)"
+        # for det auto-oprettede "Default"-metadata-objekt ved en helt
+        # frisk installation, selvom der intet er at flytte.
+        existing_count = sum(1 for db in manager.databases if db.exists)
         if existing_count == 0:
             return  # ingen kendte databaser at flytte
 

--- a/src/opensak/gui/dialogs/widgets.py
+++ b/src/opensak/gui/dialogs/widgets.py
@@ -44,7 +44,10 @@ class DirRow(QWidget):
             QFileDialog.Option.ShowDirsOnly,
         )
         if chosen:
-            self._edit.setText(chosen)
+            # Issue #609: QFileDialog returnerer altid stien med forward
+            # slashes, uanset platform — vis den native (backslash på
+            # Windows) i stedet for at sætte Qt-stien rå ind i feltet.
+            self._edit.setText(str(Path(chosen)))
 
     @property
     def path(self) -> Path:

--- a/tests/unit-tests/test_db_manager.py
+++ b/tests/unit-tests/test_db_manager.py
@@ -519,6 +519,26 @@ class TestMoveDatabasesTo:
         # The unrelated existing file at the destination must not be overwritten.
         assert (new_dir / old_path.name).read_text() == "unrelated existing file"
 
+    def test_entry_without_physical_file_is_updated_without_error(self, manager, tmp_path):
+        """
+        Issue #609: a fresh install's auto-created "Default" entry has no
+        physical .db file on disk yet (it's created lazily by init_db(),
+        which happens after the welcome wizard runs). Offering to move it
+        must not fail with FileNotFoundError — there is simply nothing to
+        copy, so just update the recorded path.
+        """
+        new_dir = tmp_path / "new_location"
+        old_path = manager.active.path
+        old_path.unlink(missing_ok=True)  # ensure the #609 scenario: no file yet
+        assert not old_path.exists()
+
+        with patch("opensak.db.database.dispose_engine"):
+            errors = manager.move_databases_to(new_dir, delete_originals=True)
+
+        assert errors == []
+        assert manager.active.path == new_dir / old_path.name
+        assert not (new_dir / old_path.name).exists()  # still nothing to copy
+
     def test_moves_multiple_databases(self, manager, tmp_path):
         new_dir = tmp_path / "new_location"
         with patch("opensak.db.database.init_db"):

--- a/tests/unit-tests/test_dialog_widgets.py
+++ b/tests/unit-tests/test_dialog_widgets.py
@@ -1,0 +1,56 @@
+# tests/unit-tests/test_dialog_widgets.py — delte dialog-widgets (DirRow).
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pytestqt")
+
+from opensak.gui.dialogs import widgets as w
+
+
+class TestDirRowBrowse:
+    def test_browse_normalizes_qt_forward_slashes(self, qtbot, tmp_path, monkeypatch):
+        """
+        Issue #609: QFileDialog.getExistingDirectory() always returns paths
+        using forward slashes, regardless of platform. The displayed path
+        must be normalized to the platform's native separator instead of
+        showing the raw Qt-style path to the user.
+        """
+        row = w.DirRow(tmp_path)
+        qtbot.addWidget(row)
+
+        chosen = str(tmp_path).replace("\\", "/") + "/subdir"
+        monkeypatch.setattr(
+            w.QFileDialog, "getExistingDirectory", lambda *a, **k: chosen
+        )
+
+        row._browse()
+
+        # Displayed text must go through Path() normalization rather than
+        # showing Qt's raw forward-slash path verbatim — on Windows this
+        # turns "E:/Users/.../subdir" into "E:\Users\...\subdir".
+        assert row._edit.text() == str(Path(chosen))
+
+    def test_browse_cancelled_leaves_text_unchanged(self, qtbot, tmp_path, monkeypatch):
+        row = w.DirRow(tmp_path)
+        qtbot.addWidget(row)
+        original = row._edit.text()
+
+        monkeypatch.setattr(w.QFileDialog, "getExistingDirectory", lambda *a, **k: "")
+
+        row._browse()
+
+        assert row._edit.text() == original
+
+    def test_path_property_reflects_edit_text(self, qtbot, tmp_path):
+        row = w.DirRow(tmp_path)
+        qtbot.addWidget(row)
+        assert row.path == tmp_path
+
+    def test_set_path_updates_display(self, qtbot, tmp_path):
+        row = w.DirRow(tmp_path)
+        qtbot.addWidget(row)
+        other = tmp_path / "elsewhere"
+        row.set_path(other)
+        assert row._edit.text() == str(other)

--- a/tests/unit-tests/test_welcome_wizard.py
+++ b/tests/unit-tests/test_welcome_wizard.py
@@ -90,8 +90,9 @@ class TestMoveSettingsFile:
 # ── _offer_move_databases ───────────────────────────────────────────────────
 
 class _FakeDbInfo:
-    def __init__(self, name):
+    def __init__(self, name, exists=True):
         self.name = name
+        self.exists = exists
 
 
 class _FakeManager:


### PR DESCRIPTION
…isplay

Two related bugs reported after v1.15.0 shipped, both in the "move databases to a new folder" flow used by the welcome wizard and by Settings -> Advanced:

1. On a brand-new installation, the auto-created "Default" database entry only exists as an in-memory metadata record until the app actually opens it via init_db(), which happens after the welcome wizard runs. If the user picked a separate database folder during the wizard and asked to move existing databases, move_databases_to() tried shutil.copy2() on a source file that didn't exist yet, failing with "No such file or directory".

   Fix: DatabaseInfo.exists now excludes file-less entries from the "existing databases" count, and a missing source file in move_databases_to() is treated as "nothing to copy" instead of an error.

2. DirRow._browse() stored QFileDialog's forward-slash path verbatim. Now normalized via str(Path(chosen)) for native display on Windows.

Reported-by: pjacklam
Fixes: #609