### PR TITLE
issue 683: fixing toolbar context menu translation

### DIFF
--- a/src/opensak/gui/mainwindow.py
+++ b/src/opensak/gui/mainwindow.py
@@ -567,7 +567,7 @@ class MainWindow(QMainWindow):
         menubar.addAction(count_action)
 
     def _setup_toolbar(self) -> None:
-        tb = QToolBar("Værktøjslinje")
+        tb = QToolBar(tr("toolbar_context_menu"))
         tb.setObjectName("main_toolbar")
         tb.setMovable(False)
         tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)

--- a/src/opensak/lang/cs.py
+++ b/src/opensak/lang/cs.py
@@ -126,6 +126,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "Žádný",
     "toolbar_filter_combo_active":   "Aktivní (neuloženo)",
     "toolbar_refresh":              "Obnovit",
+    "toolbar_context_menu":         "Panel nástrojů",
 
     # ── Status bar ────────────────────────────────────────────────────────────
     "status_filter_reset":          "Filtr zrušen",
@@ -200,7 +201,7 @@ STRINGS: dict[str, str] = {
     "gsak_prescan_title":           "Některé osobní poznámky obsahují obrázky",
     "gsak_prescan_body":            "{notes} vašich osobních poznámek obsahuje {images} obrázek/obrázky, které GSAK stáhl do vašeho starého počítače. Ty nelze automaticky zkopírovat, takže OpenSAK místo nich zobrazí zástupný text jako [image: filename.jpg]. Samotný text poznámky bude importován normálně.\n\nPokračovat v importu?",
     "gsak_prescan_continue":        "Pokračovat v importu",
-    
+
     # ── Filter dialog ─────────────────────────────────────────────────────────
     "filter_dialog_title":          "Nastavit filtr",
     "filter_tab_dates":             "Data",

--- a/src/opensak/lang/da.py
+++ b/src/opensak/lang/da.py
@@ -126,6 +126,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "Ingen",
     "toolbar_filter_combo_active":   "Aktivt (ikke gemt)",
     "toolbar_refresh":              "Opdater",
+    "toolbar_context_menu":         "Værktøjslinje",
 
     # ── Statusbar ─────────────────────────────────────────────────────────────
     "status_filter_reset":          "Filter nulstillet",

--- a/src/opensak/lang/de.py
+++ b/src/opensak/lang/de.py
@@ -126,6 +126,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "Kein",
     "toolbar_filter_combo_active":   "Aktiv (nicht gespeichert)",
     "toolbar_refresh":              "Aktualisieren",
+    "toolbar_context_menu":         "Werkzeugleiste",
 
     # ── Status bar ────────────────────────────────────────────────────────────
     "status_filter_reset":          "Filter gelöscht",

--- a/src/opensak/lang/en.py
+++ b/src/opensak/lang/en.py
@@ -126,6 +126,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "None",
     "toolbar_filter_combo_active":   "Active (unsaved)",
     "toolbar_refresh":              "Refresh",
+    "toolbar_context_menu":         "Toolbar",
 
     # ── Status bar ────────────────────────────────────────────────────────────
     "status_filter_reset":          "Filter cleared",

--- a/src/opensak/lang/fr.py
+++ b/src/opensak/lang/fr.py
@@ -126,6 +126,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "Aucun",
     "toolbar_filter_combo_active":   "Actif (non enregistré)",
     "toolbar_refresh":              "Rafraîchir",
+    "toolbar_context_menu":         "Barre d’outils",
 
     # ── Status bar ────────────────────────────────────────────────────────────
     "status_filter_reset":          "Filtre effacé",

--- a/src/opensak/lang/nl.py
+++ b/src/opensak/lang/nl.py
@@ -129,6 +129,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "Geen",
     "toolbar_filter_combo_active":   "Actief (niet opgeslagen)",
     "toolbar_refresh":              "Vernieuwen",
+    "toolbar_context_menu":         "Werkbalk",
 
     # ── Status bar ────────────────────────────────────────────────────────────
     "status_filter_reset":          "Filter gewist",

--- a/src/opensak/lang/pt.py
+++ b/src/opensak/lang/pt.py
@@ -126,6 +126,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "Nenhum",
     "toolbar_filter_combo_active":   "Ativo (não guardado)",
     "toolbar_refresh":              "Atualizar",
+    "toolbar_context_menu":         "Barra de ferramentas",
 
     # ── Status bar ────────────────────────────────────────────────────────────
     "status_filter_reset":          "Limpar filtro",

--- a/src/opensak/lang/se.py
+++ b/src/opensak/lang/se.py
@@ -126,6 +126,7 @@ STRINGS: dict[str, str] = {
     "toolbar_filter_combo_none":     "Inget",
     "toolbar_filter_combo_active":   "Aktivt (ej sparat)",
     "toolbar_refresh":              "Uppdatera",
+    "toolbar_context_menu":         "Verktygsfält",
 
     # ── Status bar ────────────────────────────────────────────────────────────
     "status_filter_reset":          "Filter rensat",
@@ -666,7 +667,7 @@ STRINGS: dict[str, str] = {
     "detail_no_logs":               "(Inga loggar)",
 
     # ── Toolbar extras ────────────────────────────────────────────────────────
-    
+
     # ── Cache table columns ───────────────────────────────────────────────────
     "col_gc_code":      "GC Kod",
     "col_name":         "Namn",
@@ -992,7 +993,7 @@ STRINGS: dict[str, str] = {
     "trip_btn_preview_map_tooltip":            "Öppna valda cacher på en interaktiv karta",
     "trip_map_preview_title":                  "Ruttplanerare — Förhandsvisning",
     "trip_map_preview_info":                   "{count} cacher visas — ruttplaneraren hålls öppen",
-    
+
     # Trip planner — save to database
     "trip_btn_save_db":                        "🗄️  Spara till databas…",
     "trip_btn_save_db_tooltip":                "Spara den valda rutten till en ny eller en existerande OpenSAK databas",


### PR DESCRIPTION
This is a bugfix for issue 683 (https://github.com/OpenSAK-Org/OpenSAK/issues/683) where the context menu to show/hide the toolbar was not translated.

**Changes I made:**

- removed the hard coded QToolBar name and using "tr("key")" instead
- added the required translation entries to all language files
- used the previously hard coded danish text in the danish language file
- translated those two languages I speak fluently (english and german)
- translated the other languages using ChatGPT (what is the "best practice" here? should I have left the Danish or English translation in those files, so the other translators can translate it themselves? or was my approach correct)?

**Testing**

- pytest -v tests/   shows all test as passed
- python run.py    brought up the application, I could still import a GSAK database and the context menu was shown in the english translation

**Environment**

python --version = 3.14.6
os=Windows 11 Pro 25H2 64-bit German