### PR TITLE
Reverse-geocoding fails on large databases: too many SQL variables

### DIFF
--- a/src/opensak/gui/dialogs/update_location_dialog.py
+++ b/src/opensak/gui/dialogs/update_location_dialog.py
@@ -150,25 +150,29 @@ class ReverseGeocodeWorker(QThread):
             self.cancelled.emit(result)
             return
 
-        # Phase 2 — bulk write in one transaction (single IN query, no per-row SELECT)
+        # Phase 2 — bulk write in one transaction, no per-row SELECT. The IN query
+        # is chunked to stay under SQLite's bound-parameter limit (large DBs).
         resolved_map = {row.gc_code: (row, loc) for row, loc in resolved}
+        gc_codes = list(resolved_map)
         try:
             with get_session() as session:
-                caches = (
-                    session.query(Cache)
-                    .filter(Cache.gc_code.in_(list(resolved_map)))
-                    .all()
-                )
-                for cache in caches:
-                    row, loc = resolved_map[cache.gc_code]
-                    cache.country          = loc.country
-                    cache.state            = loc.state
-                    cache.county           = loc.county
-                    cache.location_source  = "boundary"
-                    cache.location_basis   = row.basis
-                    cache.location_updated = now
-                    cache.location_dataset = dataset
-                    result.updated += 1
+                for i in range(0, len(gc_codes), 500):
+                    chunk = gc_codes[i:i + 500]
+                    caches = (
+                        session.query(Cache)
+                        .filter(Cache.gc_code.in_(chunk))
+                        .all()
+                    )
+                    for cache in caches:
+                        row, loc = resolved_map[cache.gc_code]
+                        cache.country          = loc.country
+                        cache.state            = loc.state
+                        cache.county           = loc.county
+                        cache.location_source  = "boundary"
+                        cache.location_basis   = row.basis
+                        cache.location_updated = now
+                        cache.location_dataset = dataset
+                        result.updated += 1
         except Exception as exc:
             result.errors += 1
             self.row_done.emit("", tr("update_loc_row_error", gc_code="batch", msg=str(exc)))

--- a/tests/unit-tests/test_update_location_dialog.py
+++ b/tests/unit-tests/test_update_location_dialog.py
@@ -146,6 +146,33 @@ class TestReverseGeocodeWorker:
                 assert c.country == "DK"
                 assert c.state == "ZL"
 
+    def test_run_chunks_large_bulk_write(self, db, geo_mocks, monkeypatch):
+        # Regression (#60): a large DB overflowed SQLite's bound-parameter limit
+        # because the bulk write bound every gc_code in one IN(...). The write is
+        # chunked so no single IN exceeds 500 codes.
+        with get_session() as s:
+            for i in range(3, 1103):
+                s.add(Cache(gc_code=f"GC{i}", name="x",
+                            cache_type="Traditional Cache",
+                            latitude=55.0, longitude=12.0))
+        rows = [_CacheRow(f"GC{i}", 55.0, 12.0) for i in range(1, 1103)]
+
+        sizes = []
+        real_in = type(Cache.gc_code).in_
+        def spy(self, other):
+            other = list(other)
+            sizes.append(len(other))
+            return real_in(self, other)
+        monkeypatch.setattr(type(Cache.gc_code), "in_", spy)
+
+        w = ReverseGeocodeWorker(rows)
+        done = []
+        w.all_done.connect(done.append)
+        w.run()
+
+        assert done[0].updated == 1102
+        assert sizes and max(sizes) <= 500
+
     def test_default_basis_is_posted(self):
         row = _CacheRow("GC1", 55.0, 12.0)
         assert row.basis == "posted"


### PR DESCRIPTION
Updating Country/State/County over a large database aborted at the write step with sqlite3.OperationalError: too many SQL variables. The resolve phase completed, but the bulk write loaded every matching cache in a single WHERE gc_code IN (...) query, binding one parameter per cache. On databases with tens of thousands of caches this exceeds SQLite's per-statement bound-parameter limit, so the whole update failed and nothing was written (the report had 71,729 parameters in one statement).

The write is now chunked in batches of 500 gc_codes, the same idiom the importer already uses for its batched IN queries, so it stays under the limit regardless of database size. Everything still runs inside the one transaction.

Added a regression test that seeds over 500 caches and asserts no single IN clause receives more than 500 codes; it fails on the previous single-query code and passes with the chunked write. Full dialog suite passes and mypy is clean on the changed files.

Closes #710
