### PR TITLE
Enable offline reverse-geocoding by default

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,4 +1,4 @@
 {
-  "reverse-geocoding": false,
+  "reverse-geocoding": true,
   "map-popout": true
 }

--- a/src/opensak/utils/flags.py
+++ b/src/opensak/utils/flags.py
@@ -2,8 +2,8 @@
 src/opensak/utils/flags.py — Feature flags for in-development functionality.
 
 Flags are read from *features.json* at the project root.  That file is never
-included in PyInstaller bundles, so release builds always see all flags as
-False.  Developers edit features.json locally to turn features on.
+included in PyInstaller bundles, so release builds fall back to the built-in
+_RELEASE_DEFAULTS below.  Developers edit features.json locally to override them.
 
 CLI overrides (highest priority, useful for one-off testing):
 
@@ -28,7 +28,7 @@ from pathlib import Path
 _FEATURES_FILE: Path = Path(__file__).parent.parent.parent.parent / "features.json"
 
 _RELEASE_DEFAULTS: dict[str, bool] = {
-    "reverse-geocoding": False,
+    "reverse-geocoding": True,
     "map-popout": True,
 }
 

--- a/tests/unit-tests/test_flags.py
+++ b/tests/unit-tests/test_flags.py
@@ -9,7 +9,7 @@ import opensak.utils.flags as flags_module
 class TestLoad:
     def test_absent_file_returns_release_defaults(self, no_features_file):
         assert flags_module._flags == {
-            "reverse-geocoding": False,
+            "reverse-geocoding": True,
             "map-popout": True,
         }
 
@@ -23,7 +23,7 @@ class TestLoad:
         monkeypatch.setattr(flags_module, "_FEATURES_FILE", f)
         result = flags_module._load()
         assert result == {
-            "reverse-geocoding": False,
+            "reverse-geocoding": True,
             "map-popout": True,
         }
 
@@ -33,15 +33,15 @@ class TestLoad:
 
     def test_partial_file_keeps_unset_flags_as_defaults(self, patch_features_file):
         patch_features_file({})
-        assert flags_module._flags["reverse-geocoding"] is False
+        assert flags_module._flags["reverse-geocoding"] is True
 
 
 # ── Module-level attribute ────────────────────────────────────────────────────
 
 
 class TestReverseGeocoding:
-    def test_false_by_default_when_file_absent(self, no_features_file):
-        assert flags_module.reverse_geocoding is False
+    def test_true_by_default_when_file_absent(self, no_features_file):
+        assert flags_module.reverse_geocoding is True
 
     def test_true_when_enabled_in_file(self, patch_features_file):
         patch_features_file({"reverse-geocoding": True})


### PR DESCRIPTION
Offline reverse-geocoding (resolving Country/State/County from boundary polygons) has been behind the reverse-geocoding feature flag while it was built out. The engine, dataset seeding, GUI wiring and packaging are all in place, so this flips the flag on by default.

The default is changed in both places that carry it: the built-in _RELEASE_DEFAULTS in flags.py (what shipped release builds fall back to, since features.json is not bundled) and the tracked features.json used for local dev. It follows the same pattern map-popout already uses.

Enabling it is safe when the boundary dataset is absent: the worker checks store.available() first and shows an informative message instead of crashing. All existing gates on the flag are unchanged.

The flag-default tests in test_flags.py are updated to expect the new True default.

Part of #60.
